### PR TITLE
Refactored SplineTrajectory

### DIFF
--- a/include/r3/path/CartesianTrajectory.h
+++ b/include/r3/path/CartesianTrajectory.h
@@ -9,7 +9,7 @@ template <int _Dim>
 class CartesianTrajectory
 {
 public:
-  using Index = ptrdiff_t;
+  using Index = int;
   using Scalar = double;
   using Output = Eigen::Transform<Scalar, _Dim, Eigen::Isometry>;
 

--- a/include/r3/path/Spline.h
+++ b/include/r3/path/Spline.h
@@ -54,7 +54,11 @@ public:
   SplineND& operator =(SplineND&& _other) = default;
   SplineND& operator =(const SplineND& _other) = default;
 
+  void setTime(Index _index, Scalar _t);
+  void setTimes(TimeVector &&_t);
+  void setTimes(const TimeVector &_t);
   const TimeVector &getTimes() const;
+
   const SolutionMatrices &getCoefficients() const;
 
   Index getNumKnots() const;

--- a/include/r3/path/SplineTrajectory.h
+++ b/include/r3/path/SplineTrajectory.h
@@ -1,14 +1,19 @@
 #ifndef R3_PATH_SPLINETRAJECTORY_H_
 #define R3_PATH_SPLINETRAJECTORY_H_
+#include <r3/path/Spline.h>
 #include <r3/path/Trajectory.h>
 
 namespace r3 {
 namespace path {
 
-template <class _Spline>
+
+template <Trajectory::Index _NumCoefficients = Eigen::Dynamic>
 class SplineTrajectory : public virtual Trajectory {
 public:
-  using Spline = _Spline;
+  using Spline = SplineND<
+    Scalar, Index, _NumCoefficients, Eigen::Dynamic, Eigen::Dynamic>;
+  using SplineProblem = SplineProblem<
+    Scalar, Index, _NumCoefficients, Eigen::Dynamic, Eigen::Dynamic>;
 
   SplineTrajectory() = default;
   explicit SplineTrajectory(const Spline& _spline);
@@ -21,7 +26,9 @@ public:
   SplineTrajectory& operator =(SplineTrajectory&& _other) = default;
   SplineTrajectory& operator =(const SplineTrajectory& _other) = default;
 
-  const Spline &getSpline() const;
+  Spline& getSpline();
+
+  const Spline& getSpline() const;
 
   Index getNumOutputs() const override;
 
@@ -29,11 +36,33 @@ public:
 
   Scalar getDuration() const override;
 
-  Eigen::VectorXd evaluate(Scalar _t, Index _derivative) const override;
+  Vector evaluate(Scalar _t, Index _derivative) const override;
 
 private:
   Spline mSpline;
 };
+
+
+using LinearSplineTrajectory = SplineTrajectory<2>;
+using LinearSplineTrajectoryPtr
+  = boost::shared_ptr<LinearSplineTrajectory>;
+using ConstLinearSplineTrajectoryPtr
+  = boost::shared_ptr<const LinearSplineTrajectory>;
+
+
+using CubicSplineTrajectory = SplineTrajectory<4>;
+using CubicSplineTrajectoryPtr
+  = boost::shared_ptr<CubicSplineTrajectory>;
+using ConstCubicSplineTrajectoryPtr
+  = boost::shared_ptr<const CubicSplineTrajectory>;
+
+
+using QuinticSplineTrajectory = SplineTrajectory<6>;
+using QuinticSplineTrajectoryPtr
+  = boost::shared_ptr<QuinticSplineTrajectory>;
+using ConstQuinticSplineTrajectoryPtr
+  = boost::shared_ptr<const QuinticSplineTrajectory>;
+
 
 } // namespace path
 } // namespace r3

--- a/include/r3/path/Trajectory.h
+++ b/include/r3/path/Trajectory.h
@@ -5,11 +5,13 @@
 namespace r3 {
 namespace path {
 
+
 class Trajectory
 {
 public:
+  using Index = int;
   using Scalar = double;
-  using Index = ptrdiff_t;
+  using Vector = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
 
   virtual ~Trajectory() = default;
 
@@ -19,11 +21,13 @@ public:
 
   virtual Scalar getDuration() const = 0;
 
-  virtual Eigen::VectorXd evaluate(Scalar _t, Index _derivative) const = 0;
+  virtual Vector evaluate(Scalar _t, Index _derivative) const = 0;
 };
+
 
 using TrajectoryPtr = boost::shared_ptr<Trajectory>;
 using ConstTrajectoryPtr = boost::shared_ptr<const Trajectory>;
+
 
 } // namespace path
 } // namespace r3

--- a/include/r3/path/detail/Spline-impl.h
+++ b/include/r3/path/detail/Spline-impl.h
@@ -22,6 +22,33 @@ SplineND<Scalar, Index, _NumCoefficients, _NumOutputs, _NumKnots>
 template <
   class Scalar, class Index,
   Index _NumCoefficients, Index _NumOutputs, Index _NumKnots>
+void SplineND<Scalar, Index, _NumCoefficients, _NumOutputs, _NumKnots>
+  ::setTime(Index _index, Scalar _t)
+{
+  mTimes[_index] = _t;
+}
+
+template <
+  class Scalar, class Index,
+  Index _NumCoefficients, Index _NumOutputs, Index _NumKnots>
+void SplineND<Scalar, Index, _NumCoefficients, _NumOutputs, _NumKnots>
+  ::setTimes(TimeVector &&_t)
+{
+  mTimes = _t;
+}
+
+template <
+  class Scalar, class Index,
+  Index _NumCoefficients, Index _NumOutputs, Index _NumKnots>
+void SplineND<Scalar, Index, _NumCoefficients, _NumOutputs, _NumKnots>
+  ::setTimes(const TimeVector &_t)
+{
+  mTimes = _t;
+}
+
+template <
+  class Scalar, class Index,
+  Index _NumCoefficients, Index _NumOutputs, Index _NumKnots>
 auto SplineND<Scalar, Index, _NumCoefficients, _NumOutputs, _NumKnots>
   ::getTimes() const -> const TimeVector &
 {

--- a/include/r3/path/detail/SplineTrajectory-impl.h
+++ b/include/r3/path/detail/SplineTrajectory-impl.h
@@ -1,45 +1,51 @@
 namespace r3 {
 namespace path {
 
-template <class _Spline>
-SplineTrajectory<_Spline>::SplineTrajectory(const Spline& _spline)
+template <Trajectory::Index _NumCoefficients>
+SplineTrajectory<_NumCoefficients>::SplineTrajectory(const Spline& _spline)
   : mSpline(_spline)
 {
 }
 
-template <class _Spline>
-SplineTrajectory<_Spline>::SplineTrajectory(Spline&& _spline)
+template <Trajectory::Index _NumCoefficients>
+SplineTrajectory<_NumCoefficients>::SplineTrajectory(Spline&& _spline)
   : mSpline(_spline)
 {
 }
 
-template <class _Spline>
-auto SplineTrajectory<_Spline>::getSpline() const -> const Spline &
+template <Trajectory::Index _NumCoefficients>
+auto SplineTrajectory<_NumCoefficients>::getSpline() -> Spline &
 {
   return mSpline;
 }
 
-template <class _Spline>
-auto SplineTrajectory<_Spline>::getNumOutputs() const -> Index
+template <Trajectory::Index _NumCoefficients>
+auto SplineTrajectory<_NumCoefficients>::getSpline() const -> const Spline &
+{
+  return mSpline;
+}
+
+template <Trajectory::Index _NumCoefficients>
+auto SplineTrajectory<_NumCoefficients>::getNumOutputs() const -> Index
 {
   return mSpline.getNumOutputs();
 }
 
-template <class _Spline>
-auto SplineTrajectory<_Spline>::getNumDerivatives() const -> Index
+template <Trajectory::Index _NumCoefficients>
+auto SplineTrajectory<_NumCoefficients>::getNumDerivatives() const -> Index
 {
   return mSpline.getNumDerivatives();
 }
 
-template <class _Spline>
-auto SplineTrajectory<_Spline>::getDuration() const -> Scalar
+template <Trajectory::Index _NumCoefficients>
+auto SplineTrajectory<_NumCoefficients>::getDuration() const -> Scalar
 {
   return mSpline.getDuration();
 }
 
-template <class _Spline>
-Eigen::VectorXd SplineTrajectory<_Spline>
-  ::evaluate(Scalar _t, Index _derivative) const
+template <Trajectory::Index _NumCoefficients>
+auto SplineTrajectory<_NumCoefficients>
+  ::evaluate(Scalar _t, Index _derivative) const -> Vector
 {
   return mSpline.evaluate(_t, _derivative);
 }


### PR DESCRIPTION
This pull request refactors `SplineTrajectory` to take degree as a template parameter, instead of a `SplineND` type. This allows us to define types for specific order trajectories (e.g. `Linear`, `Cubic`, `Quintic`).
