### PR TITLE
Renaming `r3` to `AIKIDO`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.8)
-project(r3)
+project(aikido)
 
 set(INCLUDE_INSTALL_DIR include)
 set(LIBRARY_INSTALL_DIR lib)

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# r3 - Robot Representation Resources
+# AIKIDO - AI for KIDO
 
-> :warning: **Warning:** R3 is under heavy development. These instructions are
+> :warning: **Warning:** AIKIDO is under heavy development. These instructions are
 > primarily for reference by the developers.
 
-R3 is a C++ library, complete with Python bindings, for solving robotic motion
+AIKIDO is a C++ library, complete with Python bindings, for solving robotic motion
 planning and decision making problems. This library is tightly integrated with
 [DART](http://dartsim.github.io/) for kinematic/dynamics calculations and
-[OMPL](http://ompl.kavrakilab.org/) for motion planning. R3 optionally
-integrates with [ROS](http://ros.org/), through the suite of `r3_ros` packages,
+[OMPL](http://ompl.kavrakilab.org/) for motion planning. AIKIDO optionally
+integrates with [ROS](http://ros.org/), through the suite of `aikido_ros` packages,
 for execution on a real robot.
 
 ### Dependencies
-R3 depends on [CMake](http://www.cmake.org/), [Boost](http://www.boost.org/),
+AIKIDO depends on [CMake](http://www.cmake.org/), [Boost](http://www.boost.org/),
 [DART](http://dartsim.github.io/) (version 5.0 or above),
 [OMPL](http://ompl.kavrakilab.org/), and the Python development headers
-(`python-dev` on Debian systems). DART and R3 both make heavy use of C++11 and
+(`python-dev` on Debian systems). DART and AIKIDO both make heavy use of C++11 and
 require a modern compiler.
 
 ### Installation (Standalone)
-Once the dependencies are installed, you can build R3 using CMake:
+Once the dependencies are installed, you can build AIKIDO using CMake:
 ```shell
 $ mkdir build
 $ cd build
@@ -28,9 +28,9 @@ $ sudo make install
 ```
 
 ### Installation (Catkin)
-It is also possible to build R3 as a
+It is also possible to build AIKIDO as a
 [third-party package](http://www.ros.org/reps/rep-0136.html) inside a
-[Catkin workspace](http://wiki.ros.org/catkin/workspaces). To do so, clone R3
+[Catkin workspace](http://wiki.ros.org/catkin/workspaces). To do so, clone AIKIDO
 into your Catkin workspace and use the `catkin build` command like normal.
 
 If you are using the older `catkin_make` command, then
@@ -40,10 +40,10 @@ dramatically increase your build time, so we *strongly recommend* that you use
 package](http://catkin-tools.readthedocs.org/en/latest/), if possible.
 
 ### License
-R3 is licensed under a BSD license. See [LICENSE](./LICENSE) for more information.
+AIKIDO is licensed under a BSD license. See [LICENSE](./LICENSE) for more information.
 
 ### Authors
-R3 was developed by Michael Koval ([**@mkoval**](https://github.com/mkoval))
+AIKIDO was developed by Michael Koval ([**@mkoval**](https://github.com/mkoval))
 and Pras Velagapudi ([**@psigen**](https://github.com/psigen)) in the
 [Personal Robotics Lab](https://personalrobotics.ri.cmu.edu/) in the
 [Robotics Institute](http://ri.cmu.edu/) at

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,4 +1,4 @@
-# R3 Style Guide #
+# AIKIDO Style Guide #
 
 The code in this library should generally follow the rules of the Google C++ and Python Style Guides:
 
@@ -16,6 +16,6 @@ Use streams.  They are OK.
 Use exceptions.  DART does not use exceptions though, so expect that this would need to be changed for any code that is moved upstream to DART.
 
 ### Boost ###
-While Boost is a great set of libraries, we would like R3 to be portable with minimal external dependencies.  As such, please only use supported C++11 features and the following Boost libraries:
+While Boost is a great set of libraries, we would like AIKIDO to be portable with minimal external dependencies.  As such, please only use supported C++11 features and the following Boost libraries:
 
 * `Boost.Python`

--- a/cmake/aikidoConfig.cmake.in
+++ b/cmake/aikidoConfig.cmake.in
@@ -1,11 +1,11 @@
-set(r3_VERSION x.y.z)
+set(AIKIDO_VERSION x.y.z)
 
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/r3Targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/AIKIDOTargets.cmake")
 
-set_and_check(r3_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
-set(r3_LIBRARY r3)
+set_and_check(AIKIDO_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+set(AIKIDO_LIBRARY aikido)
 
 # Transitive dependencies.
 find_package(Boost REQUIRED)
@@ -13,14 +13,14 @@ find_package(DART REQUIRED COMPONENTS core)
 find_package(OMPL REQUIRED)
 
 # Both direct and transitive dependencies.
-set(r3_INCLUDE_DIRS
-  ${r3_INCLUDE_DIR}
+set(AIKIDO_INCLUDE_DIRS
+  ${AIKIDO_INCLUDE_DIR}
   ${Boost_INCLUDE_DIRS}
   ${DART_INCLUDE_DIRS}
   ${OMPL_INCLUDE_DIRS}
 )
-set(r3_LIBRARIES
-  ${r3_LIBRARY}
+set(AIKIDO_LIBRARIES
+  ${AIKIDO_LIBRARY}
   ${Boost_LIBRARIES}
   ${DART_LIBRARIES}
   ${OMPL_LIBRARIES}

--- a/include/aikido/ompl/DARTGeometricStateSpace.h
+++ b/include/aikido/ompl/DARTGeometricStateSpace.h
@@ -1,5 +1,5 @@
-#ifndef R3_OMPL_DARTGEOMETRICSTATESPACE_H_
-#define R3_OMPL_DARTGEOMETRICSTATESPACE_H_
+#ifndef AIKIDO_OMPL_DARTGEOMETRICSTATESPACE_H_
+#define AIKIDO_OMPL_DARTGEOMETRICSTATESPACE_H_
 #include <vector>
 #include <unordered_set>
 #include <Eigen/Dense>
@@ -12,12 +12,12 @@ namespace dart {
 
 namespace collision {
     class CollisionDetector;
-} // namespace dart::collision
+} // namespace collision
 
 } // namespace dart
 
 
-namespace r3 {
+namespace aikido {
 namespace ompl {
 
 class DARTGeometricStateSpace : public ::ompl::base::CompoundStateSpace {
@@ -49,7 +49,7 @@ private:
 
 typedef boost::shared_ptr<DARTGeometricStateSpace> DARTGeometricStateSpacePtr;
 
-} // namespace r3::ompl
-} // namespace r3
+} // namespace ompl
+} // namespace aikido
 
-#endif
+#endif // AIKIDO_OMPL_DARTGEOMETRICSTATESPACE_H_

--- a/include/aikido/ompl/DARTGeometricStateValidityChecker.h
+++ b/include/aikido/ompl/DARTGeometricStateValidityChecker.h
@@ -1,8 +1,8 @@
-#ifndef R3_OMPL_DARTGEOMETRICSTATEVALIDITYCHECKER_H_
-#define R3_OMPL_DARTGEOMETRICSTATEVALIDITYCHECKER_H_
+#ifndef AIKIDO_OMPL_DARTGEOMETRICSTATEVALIDITYCHECKER_H_
+#define AIKIDO_OMPL_DARTGEOMETRICSTATEVALIDITYCHECKER_H_
 #include <ompl/base/StateValidityChecker.h>
 
-namespace r3 {
+namespace aikido {
 namespace ompl {
 
 class DARTGeometricStateSpace;
@@ -21,7 +21,7 @@ private:
     DARTGeometricStateSpace *state_space_;
 };
 
-} // namespace r3::ompl
-} // namespace r3
+} // namespace ompl
+} // namespace aikido
 
-#endif
+#endif // AIKIDO_OMPL_DARTGEOMETRICSTATEVALIDITYCHECKER_H_

--- a/include/aikido/ompl/plan.h
+++ b/include/aikido/ompl/plan.h
@@ -1,5 +1,5 @@
-#ifndef R3_OMPL_PLAN_H_
-#define R3_OMPL_PLAN_H_
+#ifndef AIKIDO_OMPL_PLAN_H_
+#define AIKIDO_OMPL_PLAN_H_
 #include <memory>
 #include <vector>
 #include <Eigen/Dense>
@@ -14,7 +14,7 @@ class World;
 } // namespace simulation
 } // namespace dart
 
-namespace r3 {
+namespace aikido {
 namespace ompl {
 
 ::Eigen::MatrixXd Plan(
@@ -27,6 +27,6 @@ namespace ompl {
 );
 
 } // namespace ompl
-} // namespace r3
+} // namespace aikido
 
-#endif
+#endif // AIKIDO_OMPL_PLAN_H_

--- a/include/aikido/path/BlendTrajectory.h
+++ b/include/aikido/path/BlendTrajectory.h
@@ -1,8 +1,8 @@
-#ifndef R3_PATH_BLENDTRAJECTORY_H_
-#define R3_PATH_BLENDTRAJECTORY_H_
-#include <r3/path/Spline.h>
+#ifndef AIKIDO_PATH_BLENDTRAJECTORY_H_
+#define AIKIDO_PATH_BLENDTRAJECTORY_H_
+#include "Spline.h"
 
-namespace r3 {
+namespace aikido {
 namespace path {
 
 class BlendTrajectory : public virtual Trajectory {
@@ -31,6 +31,6 @@ private:
 };
 
 } // namespace path
-} // namespace r3
+} // namespace aikido
 
-#endif // ifndef R3_PATH_BLENDTRAJECTORY_H_
+#endif // AIKIDO_PATH_BLENDTRAJECTORY_H_

--- a/include/aikido/path/CartesianTrajectory.h
+++ b/include/aikido/path/CartesianTrajectory.h
@@ -1,8 +1,8 @@
-#ifndef R3_PATH_CARTESIANTRAJECTORY_H_
-#define R3_PATH_CARTESIANTRAJECTORY_H_
+#ifndef AIKIDO_PATH_CARTESIANTRAJECTORY_H_
+#define AIKIDO_PATH_CARTESIANTRAJECTORY_H_
 #include <memory>
 
-namespace r3 {
+namespace aikido {
 namespace path {
 
 template <int _Dim>
@@ -33,6 +33,6 @@ using SE3TrajectoryPtr = std::shared_ptr<SE3Trajectory>;
 using ConstSE3TrajectoryPtr = std::shared_ptr<const SE3Trajectory>;
 
 } // namespace path
-} // namespace r3
+} // namespace aikido
 
-#endif // ifndef R3_PATH_TRAJECTORY_H_
+#endif // AIKIDO_PATH_TRAJECTORY_H_

--- a/include/aikido/path/CartesianTwistTrajectory.h
+++ b/include/aikido/path/CartesianTwistTrajectory.h
@@ -1,10 +1,10 @@
-#ifndef R3_PATH_TWISTTRAJECTORY_H_
-#define R3_PATH_TWISTTRAJECTORY_H_
+#ifndef AIKIDO_PATH_TWISTTRAJECTORY_H_
+#define AIKIDO_PATH_TWISTTRAJECTORY_H_
 
-#include <r3/path/Trajectory.h>
-#include <r3/path/CartesianTrajectory.h>
+#include "Trajectory.h"
+#include "CartesianTrajectory.h"
 
-namespace r3 {
+namespace aikido {
 namespace path {
 
 class SE3TwistTrajectory : public virtual SE3Trajectory
@@ -23,6 +23,6 @@ private:
 };
 
 } // namespace path
-} // namespace r3
+} // namespace aikido
 
-#endif // ifndef R3_PATH_TWISTTRAJECTORY_H_
+#endif // AIKIDO_PATH_TWISTTRAJECTORY_H_

--- a/include/aikido/path/ShiftTrajectory.h
+++ b/include/aikido/path/ShiftTrajectory.h
@@ -1,8 +1,8 @@
-#ifndef R3_PATH_SHIFTTRAJECTORY_H_
-#define R3_PATH_SHIFTTRAJECTORY_H_
-#include <r3/path/Spline.h>
+#ifndef AIKIDO_PATH_SHIFTTRAJECTORY_H_
+#define AIKIDO_PATH_SHIFTTRAJECTORY_H_
+#include "Spline.h"
 
-namespace r3 {
+namespace aikido {
 namespace path {
 
 class ShiftTrajectory : public virtual Trajectory {
@@ -23,6 +23,6 @@ private:
 };
 
 } // namespace path
-} // namespace r3
+} // namespace aikido
 
-#endif // ifndef R3_PATH_SHIFTTRAJECTORY_H_
+#endif // AIKIDO_PATH_SHIFTTRAJECTORY_H_

--- a/include/aikido/path/Spline.h
+++ b/include/aikido/path/Spline.h
@@ -1,5 +1,5 @@
-#ifndef R3_PATH_SPLINE_H_
-#define R3_PATH_SPLINE_H_
+#ifndef AIKIDO_PATH_SPLINE_H_
+#define AIKIDO_PATH_SPLINE_H_
 
 #include <cstddef>
 #include <vector>
@@ -9,7 +9,7 @@
 #include <Eigen/Sparse>
 #include <Eigen/StdVector>
 
-namespace r3 {
+namespace aikido {
 namespace path {
 
 template <
@@ -165,11 +165,11 @@ public:
 };
 
 } // namespace path
-} // namespace r3
+} // namespace aikido
 
 #include "detail/Spline-impl.h"
 
-#include <r3/path/Trajectory.h>
-#include <r3/path/SplineTrajectory.h>
+#include "Trajectory.h"
+#include "SplineTrajectory.h"
 
-#endif // ifndef R3_PATH_SPLINE_H_
+#endif // AIKIDO_PATH_SPLINE_H_

--- a/include/aikido/path/SplineTrajectory.h
+++ b/include/aikido/path/SplineTrajectory.h
@@ -1,9 +1,9 @@
-#ifndef R3_PATH_SPLINETRAJECTORY_H_
-#define R3_PATH_SPLINETRAJECTORY_H_
-#include <r3/path/Spline.h>
-#include <r3/path/Trajectory.h>
+#ifndef AIKIDO_PATH_SPLINETRAJECTORY_H_
+#define AIKIDO_PATH_SPLINETRAJECTORY_H_
+#include "Spline.h"
+#include "Trajectory.h"
 
-namespace r3 {
+namespace aikido {
 namespace path {
 
 
@@ -12,7 +12,7 @@ class SplineTrajectory : public virtual Trajectory {
 public:
   using Spline = SplineND<
     Scalar, Index, _NumCoefficients, Eigen::Dynamic, Eigen::Dynamic>;
-  using SplineProblem = r3::path::SplineProblem<
+  using SplineProblem = aikido::path::SplineProblem<
     Scalar, Index, _NumCoefficients, Eigen::Dynamic, Eigen::Dynamic>;
 
   SplineTrajectory() = default;
@@ -65,8 +65,8 @@ using ConstQuinticSplineTrajectoryPtr
 
 
 } // namespace path
-} // namespace r3
+} // namespace aikido
 
 #include "detail/SplineTrajectory-impl.h"
 
-#endif // ifndef R3_PATH_SPLINETRAJECTORY_H_
+#endif // ifndef AIKIDO_PATH_SPLINETRAJECTORY_H_

--- a/include/aikido/path/Trajectory.h
+++ b/include/aikido/path/Trajectory.h
@@ -1,8 +1,8 @@
-#ifndef R3_PATH_TRAJECTORY_H_
-#define R3_PATH_TRAJECTORY_H_
+#ifndef AIKIDO_PATH_TRAJECTORY_H_
+#define AIKIDO_PATH_TRAJECTORY_H_
 #include <boost/shared_ptr.hpp>
 
-namespace r3 {
+namespace aikido {
 namespace path {
 
 
@@ -30,6 +30,6 @@ using ConstTrajectoryPtr = boost::shared_ptr<const Trajectory>;
 
 
 } // namespace path
-} // namespace r3
+} // namespace aikido
 
-#endif // ifndef R3_PATH_TRAJECTORY_H_
+#endif // ifndef AIKIDO_PATH_TRAJECTORY_H_

--- a/include/aikido/path/detail/Spline-impl.h
+++ b/include/aikido/path/detail/Spline-impl.h
@@ -3,7 +3,7 @@
 #include <stdexcept>
 #include <algorithm>
 
-namespace r3 {
+namespace aikido {
 namespace path {
 
 template <
@@ -390,4 +390,4 @@ Scalar SplineProblem<Scalar, Index, _NumCoefficients, _NumOutputs, _NumKnots>
 }
 
 } // namespace path
-} // namespace r3
+} // namespace aikido

--- a/include/aikido/path/detail/SplineTrajectory-impl.h
+++ b/include/aikido/path/detail/SplineTrajectory-impl.h
@@ -1,4 +1,4 @@
-namespace r3 {
+namespace aikido {
 namespace path {
 
 template <Trajectory::Index _NumCoefficients>
@@ -51,4 +51,4 @@ auto SplineTrajectory<_NumCoefficients>
 }
 
 } // namespace path
-} // namespace r3
+} // namespace aikido

--- a/include/aikido/tsr/TSR.hpp
+++ b/include/aikido/tsr/TSR.hpp
@@ -1,12 +1,12 @@
-#ifndef R3_TSR_TSR_H_
-#define R3_TSR_TSR_H_
+#ifndef AIKIDO_TSR_TSR_H_
+#define AIKIDO_TSR_TSR_H_
 
 #include "../util/RNG.hpp"
 
 #include <Eigen/Dense>
 #include <random>
 
-namespace r3 {
+namespace aikido {
 namespace tsr {
 
 class TSR
@@ -32,7 +32,7 @@ public:
   ///
   /// \param[in] rng Random number generator from which to sample
   /// \return a transform within the bounds of this TSR.
-  const Eigen::Isometry3d sample(r3::util::RNG& rng);
+  const Eigen::Isometry3d sample(aikido::util::RNG& rng);
 
   /// Transformation from origin frame into "wiggle" frame.
   Eigen::Isometry3d mT0_w;
@@ -45,6 +45,6 @@ public:
 };
 
 } // namespace tsr
-} // namespace r3
+} // namespace aikido
 
-#endif // R3_TSR_TSR_H_
+#endif // AIKIDO_TSR_TSR_H_

--- a/include/aikido/util/CatkinResourceRetriever.h
+++ b/include/aikido/util/CatkinResourceRetriever.h
@@ -1,11 +1,11 @@
-#ifndef R3_UTIL_CATKINRESOURCERETRIEVER_H_
-#define R3_UTIL_CATKINRESOURCERETRIEVER_H_
+#ifndef AIKIDO_UTIL_CATKINRESOURCERETRIEVER_H_
+#define AIKIDO_UTIL_CATKINRESOURCERETRIEVER_H_
 #include <string>
 #include <unordered_map>
 #include <vector>
 #include <dart/common/ResourceRetriever.h>
 
-namespace r3 {
+namespace aikido {
 namespace util {
 
 class CatkinResourceRetriever : public virtual dart::common::ResourceRetriever {
@@ -34,6 +34,6 @@ private:
 };
 
 } // namespace util
-} // namespace r3
+} // namespace aikido
 
-#endif // ifndef R3_UTIL_CATKINRESOURCERETRIEVER_H_
+#endif // ifndef AIKIDO_UTIL_CATKINRESOURCERETRIEVER_H_

--- a/include/aikido/util/RNG.hpp
+++ b/include/aikido/util/RNG.hpp
@@ -1,11 +1,11 @@
-#ifndef R3_UTIL_RNG_H_
-#define R3_UTIL_RNG_H_
+#ifndef AIKIDO_UTIL_RNG_H_
+#define AIKIDO_UTIL_RNG_H_
 
 #include <ctime>
 #include <memory>
 #include <stdint.h>
 
-namespace r3 {
+namespace aikido {
 namespace util {
 
 class RNG
@@ -67,6 +67,6 @@ private:
 };
 
 } // util
-} // r3
+} // aikido
 
-#endif // R3_UTIL_RNG_H_
+#endif // AIKIDO_UTIL_RNG_H_

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>r3</name>
+  <name>aikido</name>
   <version>0.0.1</version>
   <description>description</description>
   <maintainer email="mkoval@cs.cmu.edu">Michael Koval</maintainer>

--- a/src/ompl/DARTGeometricStateSpace.cpp
+++ b/src/ompl/DARTGeometricStateSpace.cpp
@@ -4,14 +4,14 @@
 #include <dart/dynamics/dynamics.h>
 #include <ompl/base/spaces/RealVectorStateSpace.h>
 #include <ompl/base/spaces/SO2StateSpace.h>
-#include <r3/ompl/DARTGeometricStateSpace.h>
+#include <aikido/ompl/DARTGeometricStateSpace.h>
 
 using ::dart::collision::CollisionDetector;
 using ::dart::dynamics::DegreeOfFreedom;
 using ::dart::dynamics::DegreeOfFreedomPtr;
 using ::dart::dynamics::Skeleton;
 using ::dart::dynamics::SkeletonPtr;
-using ::r3::ompl::DARTGeometricStateSpace;
+using ::aikido::ompl::DARTGeometricStateSpace;
 
 typedef ::ompl::base::SO2StateSpace::StateType SO2State;
 typedef ::ompl::base::RealVectorStateSpace::StateType RealVectorState;

--- a/src/ompl/DARTGeometricStateValidityChecker.cpp
+++ b/src/ompl/DARTGeometricStateValidityChecker.cpp
@@ -1,8 +1,8 @@
-#include <r3/ompl/DARTGeometricStateSpace.h>
-#include <r3/ompl/DARTGeometricStateValidityChecker.h>
+#include <aikido/ompl/DARTGeometricStateSpace.h>
+#include <aikido/ompl/DARTGeometricStateValidityChecker.h>
 #include <ompl/base/SpaceInformation.h>
 
-using r3::ompl::DARTGeometricStateValidityChecker;
+using aikido::ompl::DARTGeometricStateValidityChecker;
 
 DARTGeometricStateValidityChecker::DARTGeometricStateValidityChecker(
         ::ompl::base::SpaceInformation *space_info)

--- a/src/ompl/plan.cpp
+++ b/src/ompl/plan.cpp
@@ -7,9 +7,9 @@
 #include <ompl/control/PathControl.h>
 #include <ompl/geometric/PathGeometric.h>
 #include <ompl/geometric/SimpleSetup.h>
-#include <r3/ompl/plan.h>
-#include <r3/ompl/DARTGeometricStateSpace.h>
-#include <r3/ompl/DARTGeometricStateValidityChecker.h>
+#include <aikido/ompl/plan.h>
+#include <aikido/ompl/DARTGeometricStateSpace.h>
+#include <aikido/ompl/DARTGeometricStateValidityChecker.h>
 
 using ::dart::collision::CollisionDetector;
 using ::dart::dynamics::DegreeOfFreedomPtr;
@@ -18,7 +18,7 @@ using ::dart::simulation::World;
 
 typedef ::std::shared_ptr<CollisionDetector> CollisionDetectorPtr;
 
-Eigen::MatrixXd r3::ompl::Plan(
+Eigen::MatrixXd aikido::ompl::Plan(
     CollisionDetectorPtr const &collision_detector,
     std::vector<DegreeOfFreedomPtr> const &dofs,
     Eigen::VectorXd const &dof_weights,
@@ -38,8 +38,8 @@ Eigen::MatrixXd r3::ompl::Plan(
     using ::ompl::control::PathControl;
     using ::ompl::geometric::PathGeometric;
     using ::ompl::geometric::SimpleSetup;
-    using ::r3::ompl::DARTGeometricStateSpace;
-    using ::r3::ompl::DARTGeometricStateValidityChecker;
+    using ::aikido::ompl::DARTGeometricStateSpace;
+    using ::aikido::ompl::DARTGeometricStateValidityChecker;
 
     size_t const num_dofs = dofs.size();
     if (!collision_detector) {

--- a/src/ompl/test.cpp
+++ b/src/ompl/test.cpp
@@ -8,8 +8,8 @@
 #include <ompl/control/PathControl.h>
 #include <ompl/geometric/PathGeometric.h>
 #include <ompl/geometric/SimpleSetup.h>
-#include <r3/ompl/DARTGeometricStateSpace.h>
-#include <r3/ompl/DARTGeometricStateValidityChecker.h>
+#include <aikido/ompl/DARTGeometricStateSpace.h>
+#include <aikido/ompl/DARTGeometricStateValidityChecker.h>
 
 using ::dart::dynamics::DegreeOfFreedom;
 using ::dart::dynamics::Skeleton;
@@ -45,8 +45,8 @@ Eigen::MatrixXd Plan(
     using ::ompl::control::PathControl;
     using ::ompl::geometric::PathGeometric;
     using ::ompl::geometric::SimpleSetup;
-    using ::r3::ompl::DARTGeometricStateSpace;
-    using ::r3::ompl::DARTGeometricStateValidityChecker;
+    using ::aikido::ompl::DARTGeometricStateSpace;
+    using ::aikido::ompl::DARTGeometricStateValidityChecker;
 
     BOOST_ASSERT(world);
     BOOST_ASSERT(dofs.size() == dof_weights.size());

--- a/src/path/BlendTrajectory.cpp
+++ b/src/path/BlendTrajectory.cpp
@@ -1,6 +1,6 @@
-#include <r3/path/BlendTrajectory.h>
+#include <aikido/path/BlendTrajectory.h>
 
-namespace r3 {
+namespace aikido {
 namespace path {
 
 BlendTrajectory::BlendTrajectory(
@@ -58,4 +58,4 @@ Eigen::VectorXd BlendTrajectory::evaluate(Scalar _t, Index _derivative) const
 }
 
 } // namespace path
-} // namespace r3
+} // namespace aikido

--- a/src/path/CartesianTwistTrajectory.cpp
+++ b/src/path/CartesianTwistTrajectory.cpp
@@ -1,7 +1,7 @@
 #include <dart/math/Geometry.h>
-#include <r3/path/CartesianTwistTrajectory.h>
+#include <aikido/path/CartesianTwistTrajectory.h>
 
-namespace r3 {
+namespace aikido {
 namespace path {
 
 SE3TwistTrajectory::SE3TwistTrajectory(const TrajectoryPtr& _twistTrajectory)
@@ -33,4 +33,4 @@ auto SE3TwistTrajectory::evaluate(Scalar _t) const -> Output
 }
 
 } // namespace path
-} // namespace r3
+} // namespace aikido

--- a/src/path/HauserSmoother.cpp
+++ b/src/path/HauserSmoother.cpp
@@ -1,10 +1,10 @@
 #include <boost/format.hpp>
-#include <r3/path/GeometricPath.h>
-#include <r3/path/SplineTrajectory.h>
+#include <aikido/path/GeometricPath.h>
+#include <aikido/path/SplineTrajectory.h>
 #include "external/hauser_parabolic_smoother/DynamicPath.h"
 
-using r3::path::GeometricPath;
-using r3::path::TrajectoryPtr;
+using aikido::path::GeometricPath;
+using aikido::path::TrajectoryPtr;
 
 static ParabolicRamp::Vector toHauserVector(Eigen::VectorXd const &u)
 {

--- a/src/path/KunzBlender.cpp
+++ b/src/path/KunzBlender.cpp
@@ -1,4 +1,4 @@
-#include <r3/path/GeometricPath.h>
+#include <aikido/path/GeometricPath.h>
 #include <dart/planning/Path.h>
 
 void KunzBlender(GeometricPath const &path)

--- a/src/path/ShiftTrajectory.cpp
+++ b/src/path/ShiftTrajectory.cpp
@@ -1,6 +1,6 @@
-#include <r3/path/ShiftTrajectory.h>
+#include <aikido/path/ShiftTrajectory.h>
 
-namespace r3 {
+namespace aikido {
 namespace path {
 
 ShiftTrajectory::ShiftTrajectory(const ConstTrajectoryPtr& _traj, Scalar _offset)
@@ -32,4 +32,4 @@ Eigen::VectorXd ShiftTrajectory::evaluate(Scalar _t, Index _derivative) const
 }
 
 } // namespace path
-} // namespace r3
+} // namespace aikido

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -3,7 +3,7 @@
 
 void python_OMPL();
 
-BOOST_PYTHON_MODULE(R3_MODULE_NAME)
+BOOST_PYTHON_MODULE(AIKIDO_MODULE_NAME)
 {
     SetupEigenConverters();
 

--- a/src/python/python_OMPL.cpp
+++ b/src/python/python_OMPL.cpp
@@ -1,12 +1,12 @@
 #include <boost/python.hpp>
 #include <dart/dynamics/dynamics.h>
 #include <dart/simulation/World.h>
-#include <r3/ompl/plan.h>
+#include <aikido/ompl/plan.h>
 
 void python_OMPL()
 {
     using namespace ::boost::python;
-    using ::r3::ompl::Plan;
+    using ::aikido::ompl::Plan;
 
     def("ompl_plan", &Plan);
 }

--- a/src/tsr/TSR.cpp
+++ b/src/tsr/TSR.cpp
@@ -1,12 +1,12 @@
-#include <r3/tsr/TSR.hpp>
+#include <aikido/tsr/TSR.hpp>
 
 #include <stdexcept>
 #include <math.h>
 #include <vector>
 
-using r3::util::RNG;
+using aikido::util::RNG;
 
-namespace r3 {
+namespace aikido {
 namespace tsr {
 
 //=============================================================================
@@ -73,4 +73,4 @@ const Eigen::Isometry3d TSR::sample(RNG& rng)
 }
 
 } // namespace tsr
-} // namespace r3
+} // namespace aikido

--- a/src/util/CatkinResourceRetriever.cpp
+++ b/src/util/CatkinResourceRetriever.cpp
@@ -6,13 +6,13 @@
 #include <dart/common/Console.h>
 #include <dart/common/Uri.h>
 #include <dart/common/LocalResourceRetriever.h>
-#include <r3/util/CatkinResourceRetriever.h>
+#include <aikido/util/CatkinResourceRetriever.h>
 
 static const std::string CATKIN_MARKER(".catkin");
 
 using dart::common::Uri;
 
-namespace r3 {
+namespace aikido {
 namespace util {
 
 CatkinResourceRetriever::CatkinResourceRetriever()
@@ -195,4 +195,4 @@ Uri CatkinResourceRetriever::resolvePackageUri(const Uri& _uri) const
 }
 
 } // namespace util
-} // namespace r3
+} // namespace aikido

--- a/tests/test_SplineTrajectory.cpp
+++ b/tests/test_SplineTrajectory.cpp
@@ -1,8 +1,8 @@
 #include <boost/assert.hpp>
-#include <r3/path/SplineTrajectory.h>
+#include <aikido/path/SplineTrajectory.h>
 
-using r3::path::Spline;
-using r3::path::SplineTrajectory;
+using aikido::path::Spline;
+using aikido::path::SplineTrajectory;
 using Knot = Spline::Knot;
 
 


### PR DESCRIPTION
With the renaming of `DART` to `KIDO`, we are renaming the `r3` library to:
`AIKIDO`: `AI` for `KIDO`.

This PR completes the basic renaming/refactoring of all classes.
