### PR TITLE
Check OMPL version

### DIFF
--- a/aikido/CMakeLists.txt
+++ b/aikido/CMakeLists.txt
@@ -9,6 +9,11 @@ find_package(Boost REQUIRED COMPONENTS filesystem)
 find_package(DART REQUIRED COMPONENTS core)
 find_package(OMPL REQUIRED)
 
+if("${OMPL_VERSION}" VERSION_LESS "1.0.0")
+  message(SEND_ERROR
+    "Aikido requires OMPL 1.0.0 or greater; found ${OMPL_VERSION}.")
+endif()
+
 # Compilation setup
 include_directories(
   include

--- a/aikido/package.xml
+++ b/aikido/package.xml
@@ -11,7 +11,7 @@
   <depend>boost</depend>
   <depend>dart</depend>
   <depend>eigen</depend>
-  <depend>ompl</depend>
+  <depend version_gte="1.0.0">ompl</depend>
   <depend>python</depend>
   <!-- This is required by REP-136. -->
   <exec_depend>catkin</exec_depend>


### PR DESCRIPTION
As @jslee02 discovered in #12, we apparently require OMPL 1.0.0 or above. I added a version check to our `CMakeLists.txt` file so this fails gracefully.
