### PR TITLE
Fix capitalization aikidoConfig.cmake.in

### DIFF
--- a/aikido/cmake/aikidoConfig.cmake.in
+++ b/aikido/cmake/aikidoConfig.cmake.in
@@ -2,10 +2,10 @@ set(AIKIDO_VERSION x.y.z)
 
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/AIKIDOTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/aikidoTargets.cmake")
 
-set_and_check(AIKIDO_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
-set(AIKIDO_LIBRARY aikido)
+set_and_check(aikido_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+set(aikido_LIBRARY aikido)
 
 # Transitive dependencies.
 find_package(Boost REQUIRED)
@@ -13,14 +13,14 @@ find_package(DART REQUIRED COMPONENTS core)
 find_package(OMPL REQUIRED)
 
 # Both direct and transitive dependencies.
-set(AIKIDO_INCLUDE_DIRS
-  ${AIKIDO_INCLUDE_DIR}
+set(aikido_INCLUDE_DIRS
+  ${aikido_INCLUDE_DIR}
   ${Boost_INCLUDE_DIRS}
   ${DART_INCLUDE_DIRS}
   ${OMPL_INCLUDE_DIRS}
 )
-set(AIKIDO_LIBRARIES
-  ${AIKIDO_LIBRARY}
+set(aikido_LIBRARIES
+  ${aikido_LIBRARY}
   ${Boost_LIBRARIES}
   ${DART_LIBRARIES}
   ${OMPL_LIBRARIES}


### PR DESCRIPTION
This fixes inconsistent capitalization between `CMakeLists.txt` and the auto-generated `aikidoTargets.cmake` file. As far as I can tell, this is necessary to build any project that depends on Aikido.
