### PR TITLE
Fixed TinyXML linking errors

### DIFF
--- a/aikido/CMakeLists.txt
+++ b/aikido/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8.11)
 project(aikido)
 
+list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/cmake") 
+list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
+
 set(INCLUDE_INSTALL_DIR include)
 set(LIBRARY_INSTALL_DIR lib)
 set(CONFIG_INSTALL_DIR "${LIBRARY_INSTALL_DIR}/${PROJECT_NAME}/cmake")
@@ -8,6 +11,7 @@ set(CONFIG_INSTALL_DIR "${LIBRARY_INSTALL_DIR}/${PROJECT_NAME}/cmake")
 find_package(Boost REQUIRED COMPONENTS filesystem)
 find_package(DART REQUIRED COMPONENTS core)
 find_package(OMPL REQUIRED)
+find_package(TinyXML2 REQUIRED)
 
 if("${OMPL_VERSION}" VERSION_LESS "1.0.0")
   message(SEND_ERROR
@@ -22,9 +26,8 @@ include_directories(
 include_directories(SYSTEM
   ${Boost_INCLUDE_DIRS}
   ${DART_INCLUDE_DIRS}
+  ${TinyXML2_INCLUDE_DIRS}
 )
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 # Build
 add_library(${PROJECT_NAME} SHARED
@@ -45,6 +48,7 @@ target_link_libraries(${PROJECT_NAME}
   ${DART_LIBRARIES}
   ${OMPL_LIBRARIES}
   ${Boost_LIBRARIES}
+  ${TinyXML2_LIBRARIES}
 )
 
 # Install targets, headers, and a package.xml file (to satisfy REP-136).

--- a/aikido/cmake/FindTinyXML2.cmake
+++ b/aikido/cmake/FindTinyXML2.cmake
@@ -1,0 +1,15 @@
+# Copyright (c) 2014 Andrew Kelley
+# This file is MIT licensed.
+# See http://opensource.org/licenses/MIT
+
+# TinyXML2_FOUND
+# TinyXML2_INCLUDE_DIRS
+# TinyXML2_LIBRARIES
+
+find_path(TinyXML2_INCLUDE_DIRS NAMES tinyxml2.h)
+find_library(TinyXML2_LIBRARIES NAMES tinyxml2)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TinyXML2 DEFAULT_MSG TinyXML2_LIBRARIES TinyXML2_INCLUDE_DIRS)
+
+mark_as_advanced(TinyXML2_INCLUDE_DIRS TinyXML2_LIBRARIES)


### PR DESCRIPTION
@lgw903 and @Shushman both ran into missing symbols related to my use of TinyXML 2 in `CatkinResourceRetriever`. This pull request adds the necessary `find_package` to `CMakeLists.txt` to fix this.

This fixes #19.
