### PR TITLE
Fixed build badge for Travis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# AIKIDO - AI for KIDO [![Build Status](https://travis-ci.com/personalrobotics/aikido.svg?token=1MmAniN9fkMcwpRUTdFq&branch=master)](https://travis-ci.com/personalrobotics/aikido)
+![Build Status](https://api.travis-ci.org/personalrobotics/aikido.svg)
+# AIKIDO - AI for KIDO
 
 > :warning: **Warning:** AIKIDO is under heavy development. These instructions are
 > primarily for reference by the developers.


### PR DESCRIPTION
This updates the Travis build badge to use `travis-ci.org` instead of `travis-ci.com`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/personalrobotics/aikido/78)
<!-- Reviewable:end -->
