### PR TITLE
Improvements needed for planning with OMPL for HERB

### DIFF
--- a/aikido/include/aikido/constraint/CyclicSampleable.hpp
+++ b/aikido/include/aikido/constraint/CyclicSampleable.hpp
@@ -15,6 +15,7 @@ namespace constraint {
 class CyclicSampleable : public Sampleable
 {
 public:
+
 	/// Constructor.
 	/// \param _sampleable Sampleable whose samples are to be iterated.
   explicit CyclicSampleable(

--- a/aikido/include/aikido/constraint/CyclicSampleable.hpp
+++ b/aikido/include/aikido/constraint/CyclicSampleable.hpp
@@ -15,7 +15,6 @@ namespace constraint {
 class CyclicSampleable : public Sampleable
 {
 public:
-
 	/// Constructor.
 	/// \param _sampleable Sampleable whose samples are to be iterated.
   explicit CyclicSampleable(

--- a/aikido/include/aikido/constraint/NonColliding.hpp
+++ b/aikido/include/aikido/constraint/NonColliding.hpp
@@ -19,14 +19,29 @@ class NonColliding : public Testable
 {
 public:
   /// Constructs an empty constraint that uses \c _collisionDetector to test
-  /// for collision. You should call \c addPairWiseCheck and \c addSelfCheck
-  /// to register collision checks before calling \c isSatisfied.
+  /// for collision with default \c CollisionOptions. The default behavior is
+  /// terminate on first collision and use
+  /// a \c dart::collision::BodyNodeCollisionFilter. You should call \c
+  /// addPairWiseCheck and \c addSelfCheck to register collision checks before
+  /// calling \c isSatisfied.
   ///
   /// \param _statespace state space on which the constraint operates
   /// \param _collisionDetector collision detector used to test for collision
   NonColliding(
       statespace::dart::MetaSkeletonStateSpacePtr _statespace,
       std::shared_ptr<dart::collision::CollisionDetector> _collisionDetector);
+
+  /// Constructs an empty constraint that uses \c _collisionDetector to test
+  /// for collision. You should call \c addPairWiseCheck and \c addSelfCheck
+  /// to register collision checks before calling \c isSatisfied.
+  ///
+  /// \param _statespace state space on which the constraint operates
+  /// \param _collisionDetector collision detector used to test for collision
+  /// \param _collisionOptions options passed to \c _collisionDetector
+  NonColliding(
+      statespace::dart::MetaSkeletonStateSpacePtr _statespace,
+      std::shared_ptr<dart::collision::CollisionDetector> _collisionDetector,
+      dart::collision::Option _collisionOptions);
 
   // Documentation inherited.
   statespace::StateSpacePtr getStateSpace() const override;

--- a/aikido/include/aikido/planner/ompl/GeometricStateSpace.hpp
+++ b/aikido/include/aikido/planner/ompl/GeometricStateSpace.hpp
@@ -115,6 +115,9 @@ public:
   /// \param _state The state to free.
   void freeState(::ompl::base::State *_state) const override;
 
+  /// Return the Aikido StateSpace that this OMPL StateSpace wraps
+  statespace::StateSpacePtr getAikidoStateSpace() const;
+
 private:
   statespace::StateSpacePtr mStateSpace;
   statespace::InterpolatorPtr mInterpolator;

--- a/aikido/include/aikido/planner/ompl/Planner.hpp
+++ b/aikido/include/aikido/planner/ompl/Planner.hpp
@@ -40,6 +40,8 @@ namespace ompl {
 /// valid bounds defined on the StateSpace
 /// \param _maxPlanTime The maximum time to allow the planner to search for a
 /// solution
+/// \param _maxDistanceBtwValidityChecks The maximum distance (under dmetric) between
+/// validity checking two successive points on a tree extension
 template <class PlannerType>
 trajectory::TrajectoryPtr planOMPL(
     const statespace::StateSpace::State *_start,
@@ -50,7 +52,8 @@ trajectory::TrajectoryPtr planOMPL(
     constraint::SampleablePtr _sampler,
     constraint::TestablePtr _validityConstraint,
     constraint::TestablePtr _boundsConstraint,
-    constraint::ProjectablePtr _boundsProjector, double _maxPlanTime);
+    constraint::ProjectablePtr _boundsProjector, 
+    double _maxPlanTime, double _maxDistanceBtwValidityChecks);
 
 /// Use the template OMPL Planner type to plan a trajectory that moves from the
 /// start to a goal region.
@@ -75,6 +78,8 @@ trajectory::TrajectoryPtr planOMPL(
 /// valid bounds defined on the StateSpace
 /// \param _maxPlanTime The maximum time to allow the planner to search for a
 /// solution
+/// \param _maxDistanceBtwValidityChecks The maximum distance (under dmetric) between
+/// validity checking two successive points on a tree extension
 template <class PlannerType>
 trajectory::TrajectoryPtr planOMPL(
     const statespace::StateSpace::State *_start,
@@ -87,7 +92,7 @@ trajectory::TrajectoryPtr planOMPL(
     constraint::TestablePtr _validityConstraint,
     constraint::TestablePtr _boundsConstraint,
     constraint::ProjectablePtr _boundsProjector,
-    double _maxPlanTime);
+    double _maxPlanTime, double _maxDistanceBtwValidityChecks);
 
 /// Generate an OMPL SpaceInformation from aikido components
 /// \param _statespace The StateSpace that the SpaceInformation operates on
@@ -106,6 +111,8 @@ trajectory::TrajectoryPtr planOMPL(
 /// satsified for a state to be considered valid.
 /// \param _boundsProjector A Projectable that projects a state back within
 /// valid bounds defined on the StateSpace
+/// \param _maxDistanceBtwValidityChecks The maximum distance (under dmetric) between
+/// validity checking two successive points on a tree extension
 ::ompl::base::SpaceInformationPtr getSpaceInformation(
     statespace::StateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
@@ -113,7 +120,8 @@ trajectory::TrajectoryPtr planOMPL(
     constraint::SampleablePtr _sampler,
     constraint::TestablePtr _validityConstraint,
     constraint::TestablePtr _boundsConstraint,
-    constraint::ProjectablePtr _boundsProjector);
+    constraint::ProjectablePtr _boundsProjector,
+    double _maxDistanceBtwValidityChecks);
 
 /// Use the template OMPL Planner type to plan in a custom OMPL Space
 /// Information and problem definition and return an aikido Trajector

--- a/aikido/include/aikido/planner/ompl/Planner.hpp
+++ b/aikido/include/aikido/planner/ompl/Planner.hpp
@@ -19,7 +19,7 @@ namespace planner {
 namespace ompl {
 
 /// Use the template OMPL Planner type to plan a trajectory that moves from the
-/// start to the goal point.
+/// start to the goal point. Returns nullptr on planning failure.
 /// \param _start The start state
 /// \param _goal The goal state
 /// \param _statespace The StateSpace that the planner must plan within
@@ -56,7 +56,7 @@ trajectory::InterpolatedPtr planOMPL(
     double _maxPlanTime, double _maxDistanceBtwValidityChecks);
 
 /// Use the template OMPL Planner type to plan a trajectory that moves from the
-/// start to a goal region.
+/// start to a goal region. Returns nullptr on planning failure.
 /// \param _start The start state
 /// \param _goalTestable A Testable constraint that can determine if a given state is a goal state
 /// \param _goalSamplers A Sampleable capable of sampling states that satisfy _goalTestable
@@ -125,6 +125,7 @@ trajectory::InterpolatedPtr planOMPL(
 
 /// Use the template OMPL Planner type to plan in a custom OMPL Space
 /// Information and problem definition and return an aikido Trajector
+/// Returns nullptr on planning failure.
 /// \param _si The SpaceInformation used by the planner
 /// \param _pdef The ProblemDefintion. This contains start and goal conditions for the planner.
 /// \param _sspace The aikido StateSpace to plan against. Used for constructing the return trajectory.

--- a/aikido/include/aikido/planner/ompl/Planner.hpp
+++ b/aikido/include/aikido/planner/ompl/Planner.hpp
@@ -7,7 +7,7 @@
 #include "../../constraint/Testable.hpp"
 #include "../../constraint/Sampleable.hpp"
 #include "../../constraint/Projectable.hpp"
-#include "../../trajectory/Trajectory.hpp"
+#include "../../trajectory/Interpolated.hpp"
 
 #include <ompl/base/Planner.h>
 #include <ompl/base/ProblemDefinition.h>
@@ -43,7 +43,7 @@ namespace ompl {
 /// \param _maxDistanceBtwValidityChecks The maximum distance (under dmetric) between
 /// validity checking two successive points on a tree extension
 template <class PlannerType>
-trajectory::TrajectoryPtr planOMPL(
+trajectory::InterpolatedPtr planOMPL(
     const statespace::StateSpace::State *_start,
     const statespace::StateSpace::State *_goal,
     statespace::StateSpacePtr _stateSpace,
@@ -81,7 +81,7 @@ trajectory::TrajectoryPtr planOMPL(
 /// \param _maxDistanceBtwValidityChecks The maximum distance (under dmetric) between
 /// validity checking two successive points on a tree extension
 template <class PlannerType>
-trajectory::TrajectoryPtr planOMPL(
+trajectory::InterpolatedPtr planOMPL(
     const statespace::StateSpace::State *_start,
     constraint::TestablePtr _goalTestable,
     constraint::SampleablePtr _goalSampler,
@@ -131,7 +131,7 @@ trajectory::TrajectoryPtr planOMPL(
 /// \param _interpolator An aikido interpolator that can be used with the _stateSpace.
 /// \param _maxPlanTime The maximum time to allow the planner to search for a
 /// solution
-trajectory::TrajectoryPtr planOMPL(const ::ompl::base::PlannerPtr &_planner,
+trajectory::InterpolatedPtr planOMPL(const ::ompl::base::PlannerPtr &_planner,
                              const ::ompl::base::ProblemDefinitionPtr &_pdef,
                              statespace::StateSpacePtr _sspace,
                              statespace::InterpolatorPtr _interpolator,

--- a/aikido/include/aikido/planner/ompl/dart.hpp
+++ b/aikido/include/aikido/planner/ompl/dart.hpp
@@ -16,10 +16,13 @@ namespace ompl {
 /// should be done before marking a state as valid. This constraint should
 /// include collision checks. It does not need to include joint limits or
 /// boundary checks. These will be added by the function.
+/// \param _maxDistanceBtwValidityChecks The maximum distance (under dmetric) between
+/// validity checking two successive points on a tree extension
 /// \param _rng A random number generator to be used by state samplers
 ::ompl::base::SpaceInformationPtr createSpaceInformation(
     statespace::dart::MetaSkeletonStateSpacePtr _stateSpace,
     constraint::TestablePtr _validityConstraint,
+    double _maxDistanceBtwValidityChecks,
     std::unique_ptr<util::RNG> _rng);
 }
 }

--- a/aikido/include/aikido/planner/ompl/detail/Planner-impl.hpp
+++ b/aikido/include/aikido/planner/ompl/detail/Planner-impl.hpp
@@ -10,7 +10,7 @@ namespace ompl {
 
 //=============================================================================
 template <class PlannerType>
-trajectory::TrajectoryPtr planOMPL(
+trajectory::InterpolatedPtr planOMPL(
     const statespace::StateSpace::State *_start,
     const statespace::StateSpace::State *_goal,
     statespace::StateSpacePtr _stateSpace,
@@ -48,7 +48,7 @@ trajectory::TrajectoryPtr planOMPL(
 
 //=============================================================================
 template <class PlannerType>
-trajectory::TrajectoryPtr planOMPL(
+trajectory::InterpolatedPtr planOMPL(
     const statespace::StateSpace::State *_start,
     constraint::TestablePtr _goalTestable,
     constraint::SampleablePtr _goalSampler,

--- a/aikido/include/aikido/planner/ompl/detail/Planner-impl.hpp
+++ b/aikido/include/aikido/planner/ompl/detail/Planner-impl.hpp
@@ -19,13 +19,14 @@ trajectory::TrajectoryPtr planOMPL(
     constraint::SampleablePtr _sampler,
     constraint::TestablePtr _validityConstraint,
     constraint::TestablePtr _boundsConstraint,
-    constraint::ProjectablePtr _boundsProjector, double _maxPlanTime)
+    constraint::ProjectablePtr _boundsProjector, 
+    double _maxPlanTime, double _maxDistanceBtwValidityChecks)
 {
   // Create a SpaceInformation.  This function will ensure state space matching
   auto si = getSpaceInformation(
       _stateSpace, _interpolator, std::move(_dmetric), std::move(_sampler),
       std::move(_validityConstraint), std::move(_boundsConstraint),
-      std::move(_boundsProjector));
+      std::move(_boundsProjector), _maxDistanceBtwValidityChecks);
 
   // Start and states
   auto pdef = boost::make_shared<::ompl::base::ProblemDefinition>(si);
@@ -58,7 +59,7 @@ trajectory::TrajectoryPtr planOMPL(
     constraint::TestablePtr _validityConstraint,
     constraint::TestablePtr _boundsConstraint,
     constraint::ProjectablePtr _boundsProjector,
-    double _maxPlanTime)
+    double _maxPlanTime, double _maxDistanceBtwValidityChecks)
 {
   if (_goalTestable == nullptr) {
     throw std::invalid_argument("Testable goal is nullptr.");
@@ -79,7 +80,7 @@ trajectory::TrajectoryPtr planOMPL(
   auto si = getSpaceInformation(
       _stateSpace, _interpolator, std::move(_dmetric), std::move(_sampler),
       std::move(_validityConstraint), std::move(_boundsConstraint),
-      std::move(_boundsProjector));
+      std::move(_boundsProjector), _maxDistanceBtwValidityChecks);
 
   // Set the start and goal
   auto pdef = boost::make_shared<::ompl::base::ProblemDefinition>(si);

--- a/aikido/src/constraint/NonColliding.cpp
+++ b/aikido/src/constraint/NonColliding.cpp
@@ -1,5 +1,7 @@
 #include <aikido/constraint/NonColliding.hpp>
-#include <dart/collision/Result.h>
+#include <dart/dart.h>
+
+using dart::collision::BodyNodeCollisionFilter;
 
 namespace aikido {
 namespace constraint {
@@ -8,9 +10,22 @@ namespace constraint {
 NonColliding::NonColliding(
     statespace::dart::MetaSkeletonStateSpacePtr _statespace,
     std::shared_ptr<dart::collision::CollisionDetector> _collisionDetector)
+: NonColliding(
+    std::move(_statespace),
+    std::move(_collisionDetector),
+    dart::collision::Option(
+      false, true, 1, std::make_shared<BodyNodeCollisionFilter>()))
+{
+}
+
+//=============================================================================
+NonColliding::NonColliding(
+    statespace::dart::MetaSkeletonStateSpacePtr _statespace,
+    std::shared_ptr<dart::collision::CollisionDetector> _collisionDetector,
+    dart::collision::Option _collisionOptions)
 : statespace(std::move(_statespace))
 , collisionDetector(std::move(_collisionDetector))
-, collisionOptions{false, true}
+, collisionOptions(std::move(_collisionOptions))
 {
   if (!statespace)
     throw std::invalid_argument("_statespace is nullptr.");

--- a/aikido/src/planner/ompl/GeometricStateSpace.cpp
+++ b/aikido/src/planner/ompl/GeometricStateSpace.cpp
@@ -98,6 +98,9 @@ double GeometricStateSpace::getMeasure() const
 void GeometricStateSpace::enforceBounds(::ompl::base::State *_state) const
 {
   auto state = static_cast<const StateType *>(_state);
+  if (state == nullptr || state->mState == nullptr)
+    throw std::invalid_argument("enforceBounds called with null state");
+
   auto temporaryState = mStateSpace->createState();
   mBoundsProjection->project(state->mState, temporaryState);
   mStateSpace->copyState(temporaryState, state->mState);
@@ -118,7 +121,11 @@ void GeometricStateSpace::copyState(
     ::ompl::base::State *_destination, const ::ompl::base::State *_source) const
 {
   auto dst = static_cast<StateType *>(_destination);
+  if (dst == nullptr || dst->mState == nullptr)
+    throw std::invalid_argument("copyState called with null destination");
   auto sst = static_cast<const StateType *>(_source);
+  if (sst == nullptr || sst->mState == nullptr)
+    throw std::invalid_argument("copyState called with null source state");
   mStateSpace->copyState(sst->mState, dst->mState);
 }
 
@@ -129,6 +136,11 @@ double GeometricStateSpace::distance(
 {
   auto state1 = static_cast<const StateType *>(_state1);
   auto state2 = static_cast<const StateType *>(_state2);
+
+  if (state1 == nullptr || state1->mState == nullptr)
+    throw std::invalid_argument("distance called with null state1");
+  if (state2 == nullptr || state2->mState == nullptr)
+    throw std::invalid_argument("distance called with null state2");
 
   return mDistance->distance(state1->mState, state2->mState);
 }
@@ -149,8 +161,14 @@ void GeometricStateSpace::interpolate(const ::ompl::base::State *_from,
                                             ::ompl::base::State *_state) const
 {
   auto from = static_cast<const StateType *>(_from);
+  if (from == nullptr || from->mState == nullptr)
+    throw std::invalid_argument("interpolate called with null from state");
   auto to = static_cast<const StateType *>(_to);
+  if (to == nullptr || to->mState == nullptr)
+    throw std::invalid_argument("interpolate called with null to state");
   auto state = static_cast<StateType *>(_state);
+  if (state == nullptr || state->mState == nullptr)
+    throw std::invalid_argument("interpolate called with null out state");
   mInterpolator->interpolate(from->mState, to->mState, _t, state->mState);
 }
 

--- a/aikido/src/planner/ompl/GeometricStateSpace.cpp
+++ b/aikido/src/planner/ompl/GeometricStateSpace.cpp
@@ -183,10 +183,16 @@ GeometricStateSpace::allocDefaultStateSampler() const
 void GeometricStateSpace::freeState(::ompl::base::State *_state) const
 {
   auto st = static_cast<StateType *>(_state);
-  mStateSpace->freeState(st->mState);
+  if(st->mState != nullptr){
+      mStateSpace->freeState(st->mState);
+  }
   delete st;
 }
 
+//=============================================================================
+statespace::StateSpacePtr GeometricStateSpace::getAikidoStateSpace() const {
+  return mStateSpace;
+}
 }
 }
 }

--- a/aikido/src/planner/ompl/GeometricStateSpace.cpp
+++ b/aikido/src/planner/ompl/GeometricStateSpace.cpp
@@ -182,11 +182,13 @@ GeometricStateSpace::allocDefaultStateSampler() const
 //=============================================================================
 void GeometricStateSpace::freeState(::ompl::base::State *_state) const
 {
-  auto st = static_cast<StateType *>(_state);
-  if(st->mState != nullptr){
+  if (_state != nullptr) {
+    auto st = static_cast<StateType *>(_state);
+    if (st->mState != nullptr) {
       mStateSpace->freeState(st->mState);
+    }
+    delete st;
   }
-  delete st;
 }
 
 //=============================================================================

--- a/aikido/src/planner/ompl/GeometricStateSpace.cpp
+++ b/aikido/src/planner/ompl/GeometricStateSpace.cpp
@@ -108,6 +108,8 @@ bool GeometricStateSpace::satisfiesBounds(
     const ::ompl::base::State *_state) const
 {
   auto state = static_cast<const StateType *>(_state);
+  if( state == nullptr || state->mState == nullptr )
+      return false;
   return mBoundsConstraint->isSatisfied(state->mState);
 }
 

--- a/aikido/src/planner/ompl/GoalRegion.cpp
+++ b/aikido/src/planner/ompl/GoalRegion.cpp
@@ -73,6 +73,8 @@ double GoalRegion::distanceGoal(const ::ompl::base::State* _state) const
 bool GoalRegion::isSatisfied(const ::ompl::base::State* _state) const
 {
   auto state = static_cast<const GeometricStateSpace::StateType*>(_state);
+  if (state == nullptr || state->mState == nullptr)
+      return false;
   return mTestable->isSatisfied(state->mState);
 }
 

--- a/aikido/src/planner/ompl/GoalRegion.cpp
+++ b/aikido/src/planner/ompl/GoalRegion.cpp
@@ -40,7 +40,14 @@ void GoalRegion::sampleGoal(::ompl::base::State* _state) const
     valid = mSampleGenerator->sample(state->mState);
   }
   if (!valid) {
-    throw std::runtime_error("Failed to sample a valid goal");
+    auto stateSpace =
+        boost::dynamic_pointer_cast<GeometricStateSpace>(si_->getStateSpace());
+    if (!stateSpace) {
+      throw std::runtime_error(
+          "GoalRegion can only sample states from the GeometricStateSpace");
+    }
+    stateSpace->getAikidoStateSpace()->freeState(state->mState);
+    state->mState = nullptr;
   }
 }
 

--- a/aikido/src/planner/ompl/Planner.cpp
+++ b/aikido/src/planner/ompl/Planner.cpp
@@ -114,7 +114,7 @@ namespace ompl {
 }
 
 //=============================================================================
-trajectory::TrajectoryPtr planOMPL(
+trajectory::InterpolatedPtr planOMPL(
   const ::ompl::base::PlannerPtr &_planner,
   const ::ompl::base::ProblemDefinitionPtr &_pdef,
   statespace::StateSpacePtr _sspace,

--- a/aikido/src/planner/ompl/Planner.cpp
+++ b/aikido/src/planner/ompl/Planner.cpp
@@ -124,10 +124,11 @@ trajectory::InterpolatedPtr planOMPL(
   _planner->setProblemDefinition(_pdef);
   _planner->setup();
   auto solved = _planner->solve(_maxPlanTime);
-  auto returnTraj = std::make_shared<trajectory::Interpolated>(
-      std::move(_sspace), std::move(_interpolator));
 
   if (solved) {
+    auto returnTraj = std::make_shared<trajectory::Interpolated>(
+        std::move(_sspace), std::move(_interpolator));
+
     // Get the path
     auto path =
         boost::dynamic_pointer_cast<::ompl::geometric::PathGeometric>(
@@ -145,8 +146,10 @@ trajectory::InterpolatedPtr planOMPL(
       // Arbitrary timing
       returnTraj->addWaypoint(idx, st->mState);
     }
+
+    return returnTraj;
   }
-  return returnTraj;
+  return nullptr;
 }
 
 }

--- a/aikido/src/planner/ompl/StateSampler.cpp
+++ b/aikido/src/planner/ompl/StateSampler.cpp
@@ -31,7 +31,14 @@ void StateSampler::sampleUniform(::ompl::base::State *_state) {
   }
 
   if (!valid) {
-    throw std::runtime_error("Failed to generate valid sample.");
+    auto stateSpace =
+        dynamic_cast<const GeometricStateSpace*>(space_);
+    if (!stateSpace) {
+      throw std::runtime_error(
+          "StateSampler can only sample states from the GeometricStateSpace");
+    }
+    stateSpace->getAikidoStateSpace()->freeState(state->mState);
+    state->mState = nullptr;
   }
 }
 

--- a/aikido/src/planner/ompl/StateValidityChecker.cpp
+++ b/aikido/src/planner/ompl/StateValidityChecker.cpp
@@ -25,6 +25,8 @@ StateValidityChecker::StateValidityChecker(
 bool StateValidityChecker::isValid(const ::ompl::base::State *_state) const
 {
   auto st = static_cast<const GeometricStateSpace::StateType *>(_state);
+  if(st == nullptr || st->mState == nullptr)
+      return false;
   return mConstraint->isSatisfied(st->mState);
 }
 

--- a/aikido/src/planner/ompl/dart.cpp
+++ b/aikido/src/planner/ompl/dart.cpp
@@ -11,6 +11,7 @@ namespace ompl {
 ::ompl::base::SpaceInformationPtr createSpaceInformation(
     statespace::dart::MetaSkeletonStateSpacePtr _stateSpace,
     constraint::TestablePtr _validityConstraint,
+    double _maxDistanceBtwValidityChecks,
     std::unique_ptr<util::RNG> _rng)
 {
 
@@ -34,7 +35,8 @@ namespace ompl {
                              std::move(dmetric), std::move(sampler),
                              std::move(_validityConstraint),
                              std::move(boundsConstraint),
-                             std::move(boundsProjection));
+                             std::move(boundsProjection),
+                             _maxDistanceBtwValidityChecks);
 }
 }
 }

--- a/aikido/src/planner/parabolic/ParabolicTimer.cpp
+++ b/aikido/src/planner/parabolic/ParabolicTimer.cpp
@@ -111,9 +111,13 @@ std::unique_ptr<trajectory::Spline> computeParabolicTiming(
   {
     if (_maxVelocity[i] <= 0.)
       throw std::invalid_argument("Velocity limits must be positive.");
+    if (!std::isfinite(_maxVelocity[i]))
+      throw std::invalid_argument("Velocity limits must be finite.");
 
     if (_maxAcceleration[i] <= 0.)
       throw std::invalid_argument("Acceleration limits must be positive.");
+    if (!std::isfinite(_maxAcceleration[i]))
+      throw std::invalid_argument("Acceleration limits must be finite.");
   }
 
   // Convert the Interpolated to the internal data structure by

--- a/aikido/tests/planner/ompl/test_GeometricStateSpace.cpp
+++ b/aikido/tests/planner/ompl/test_GeometricStateSpace.cpp
@@ -300,3 +300,17 @@ TEST_F(GeometricStateSpaceTest, CopyAlloc)
   gSpace->freeState(s1);
   gSpace->freeState(s2);
 }
+
+TEST_F(GeometricStateSpaceTest, GetAikidoStateSpace) {
+  constructStateSpace();
+  EXPECT_EQ(stateSpace, gSpace->getAikidoStateSpace());
+}
+
+TEST_F(GeometricStateSpaceTest, DeallocNullAikidoState) {
+  constructStateSpace();
+  auto state =
+      gSpace->allocState()->as<GeometricStateSpace::StateType>();
+  stateSpace->freeState(state->mState);
+  state->mState = nullptr;
+  gSpace->freeState(state);
+}

--- a/aikido/tests/planner/ompl/test_GeometricStateSpace.cpp
+++ b/aikido/tests/planner/ompl/test_GeometricStateSpace.cpp
@@ -168,6 +168,7 @@ TEST_F(GeometricStateSpaceTest, SatisfiesBoundsFalse)
 
   gSpace->freeState(state);
 }
+
 TEST_F(GeometricStateSpaceTest, SatisfiesBoundsTrue)
 {
   constructStateSpace();
@@ -178,6 +179,21 @@ TEST_F(GeometricStateSpaceTest, SatisfiesBoundsTrue)
   EXPECT_TRUE(gSpace->satisfiesBounds(state));
 
   gSpace->freeState(state);
+}
+
+TEST_F(GeometricStateSpaceTest, SatisfiesBoundsFalseNullOmplState)
+{
+  constructStateSpace();
+  EXPECT_FALSE(nullptr);
+}
+
+TEST_F(GeometricStateSpaceTest, SatisfiesBoundsFalseNullAikidoState)
+{
+  constructStateSpace();
+  auto state = gSpace->allocState()->as<GeometricStateSpace::StateType>();
+  stateSpace->freeState(state->mState);
+  state->mState = nullptr;
+  EXPECT_FALSE(gSpace->satisfiesBounds(state));
 }
 
 TEST_F(GeometricStateSpaceTest, CopyState)

--- a/aikido/tests/planner/ompl/test_GeometricStateSpace.cpp
+++ b/aikido/tests/planner/ompl/test_GeometricStateSpace.cpp
@@ -314,3 +314,8 @@ TEST_F(GeometricStateSpaceTest, DeallocNullAikidoState) {
   state->mState = nullptr;
   gSpace->freeState(state);
 }
+
+TEST_F(GeometricStateSpaceTest, DallocNullState) {
+    constructStateSpace();
+    gSpace->freeState(nullptr);
+}

--- a/aikido/tests/planner/ompl/test_GeometricStateSpace.cpp
+++ b/aikido/tests/planner/ompl/test_GeometricStateSpace.cpp
@@ -157,6 +157,20 @@ TEST_F(GeometricStateSpaceTest, EnforceBoundsNoProjection)
   gSpace->freeState(state);
 }
 
+TEST_F(GeometricStateSpaceTest, EnforceBoundsNullState) {
+  constructStateSpace();
+  EXPECT_THROW(gSpace->enforceBounds(nullptr), std::invalid_argument);
+}
+
+TEST_F(GeometricStateSpaceTest, EnforceBoundsNullAikidoState) {
+  constructStateSpace();
+  auto state = gSpace->allocState()->as<GeometricStateSpace::StateType>();
+  stateSpace->freeState(state->mState);
+  state->mState = nullptr;
+  EXPECT_THROW(gSpace->enforceBounds(state), std::invalid_argument);
+  gSpace->freeState(state);
+}
+
 TEST_F(GeometricStateSpaceTest, SatisfiesBoundsFalse) 
 {
   constructStateSpace();
@@ -212,6 +226,36 @@ TEST_F(GeometricStateSpaceTest, CopyState)
   gSpace->freeState(copyState);
 }
 
+TEST_F(GeometricStateSpaceTest, CopyStateThrowsOnNullSource)
+{
+  constructStateSpace();
+  auto s1 = gSpace->allocState()->as<GeometricStateSpace::StateType>();
+  EXPECT_THROW(gSpace->copyState(s1, nullptr), std::invalid_argument);
+
+  auto s2 = gSpace->allocState()->as<GeometricStateSpace::StateType>();
+  stateSpace->freeState(s2->mState);
+  s2->mState = nullptr;
+  EXPECT_THROW(gSpace->copyState(s1, s2), std::invalid_argument);
+
+  gSpace->freeState(s1);
+  gSpace->freeState(s2);
+}
+
+TEST_F(GeometricStateSpaceTest, CopyStateThrowsOnNullDestination)
+{
+  constructStateSpace();
+  auto s1 = gSpace->allocState()->as<GeometricStateSpace::StateType>();
+  EXPECT_THROW(gSpace->copyState(nullptr, s1), std::invalid_argument);
+
+  auto s2 = gSpace->allocState()->as<GeometricStateSpace::StateType>();
+  stateSpace->freeState(s2->mState);
+  s2->mState = nullptr;
+  EXPECT_THROW(gSpace->copyState(s2, s1), std::invalid_argument);
+
+  gSpace->freeState(s1);
+  gSpace->freeState(s2);
+}
+
 TEST_F(GeometricStateSpaceTest, Distance)
 {
   constructStateSpace();
@@ -224,6 +268,24 @@ TEST_F(GeometricStateSpaceTest, Distance)
   setTranslationalState(v2, stateSpace, s2);
 
   EXPECT_DOUBLE_EQ((v1 - v2).norm(), gSpace->distance(s1, s2));
+
+  gSpace->freeState(s1);
+  gSpace->freeState(s2);
+}
+
+TEST_F(GeometricStateSpaceTest, DistanceThrowsOnNullState)
+{
+  constructStateSpace();
+  auto s1 = gSpace->allocState()->as<GeometricStateSpace::StateType>();
+  auto s2 = gSpace->allocState()->as<GeometricStateSpace::StateType>();
+
+  EXPECT_THROW(gSpace->distance(s1, nullptr), std::invalid_argument);
+  EXPECT_THROW(gSpace->distance(nullptr, s1), std::invalid_argument);
+  
+  stateSpace->freeState(s1->mState);
+  s1->mState = nullptr;
+  EXPECT_THROW(gSpace->distance(s1, s2), std::invalid_argument);
+  EXPECT_THROW(gSpace->distance(s2, s1), std::invalid_argument);  
 
   gSpace->freeState(s1);
   gSpace->freeState(s2);
@@ -292,6 +354,23 @@ TEST_F(GeometricStateSpaceTest, Interpolate)
   gSpace->freeState(s1);
   gSpace->freeState(s2);
   gSpace->freeState(s3);
+}
+
+TEST_F(GeometricStateSpaceTest, InterpolateThrowsOnNullState) 
+{
+  constructStateSpace();
+  auto s1 = gSpace->allocState()->as<GeometricStateSpace::StateType>();
+  auto s2 = gSpace->allocState()->as<GeometricStateSpace::StateType>();
+  auto s3 = gSpace->allocState()->as<GeometricStateSpace::StateType>();
+  EXPECT_THROW(gSpace->interpolate(nullptr, s2, 0, s3), std::invalid_argument);
+  EXPECT_THROW(gSpace->interpolate(s1, nullptr, 0, s3), std::invalid_argument);
+  EXPECT_THROW(gSpace->interpolate(s1, s2, 0, nullptr), std::invalid_argument);
+
+  stateSpace->freeState(s1->mState);
+  s1->mState = nullptr;
+  EXPECT_THROW(gSpace->interpolate(s1, s2, 0, s3), std::invalid_argument);
+  EXPECT_THROW(gSpace->interpolate(s2, s1, 0, s3), std::invalid_argument);
+  EXPECT_THROW(gSpace->interpolate(s2, s3, 0, s1), std::invalid_argument);
 }
 
 TEST_F(GeometricStateSpaceTest, AllocStateSampler)

--- a/aikido/tests/planner/ompl/test_GoalRegion.cpp
+++ b/aikido/tests/planner/ompl/test_GoalRegion.cpp
@@ -183,6 +183,20 @@ TEST_F(GoalRegionTest, GoalSatisfied)
   si->freeState(state);
 }
 
+TEST_F(GoalRegionTest, GoalSatisfiedFailsOnNullState)
+{
+  auto testable = std::make_shared<PassingConstraint>(stateSpace);
+  auto generator = dart::common::make_unique<EmptySampleGenerator>(stateSpace);
+  GoalRegion gr(si, std::move(testable), std::move(generator));
+  EXPECT_FALSE(gr.isSatisfied(nullptr));
+
+  auto state = si->allocState()->as<GeometricStateSpace::StateType>();
+  stateSpace->freeState(state->mState);
+  state->mState = nullptr;
+  EXPECT_FALSE(gr.isSatisfied(state));
+  si->freeState(state);
+}
+
 TEST_F(GoalRegionTest, GoalNotSatisfied)
 {
   auto testable = std::make_shared<FailingConstraint>(stateSpace);

--- a/aikido/tests/planner/ompl/test_GoalRegion.cpp
+++ b/aikido/tests/planner/ompl/test_GoalRegion.cpp
@@ -17,8 +17,13 @@ public:
     gSpace = std::make_shared<GeometricStateSpace>(
         stateSpace, interpolator, dmetric, sampler, boundsConstraint,
         boundsProjection);
+    si = aikido::planner::ompl::getSpaceInformation(
+      stateSpace, interpolator, dmetric, sampler, collConstraint,
+      boundsConstraint, boundsProjection, 0.1);
+
   }
   std::shared_ptr<GeometricStateSpace> gSpace;
+  boost::shared_ptr<::ompl::base::SpaceInformation> si;
 };
 
 TEST_F(GoalRegionTest, ThrowsOnNullSpaceInformation)
@@ -31,9 +36,6 @@ TEST_F(GoalRegionTest, ThrowsOnNullSpaceInformation)
 
 TEST_F(GoalRegionTest, ThrowsOnNullTestable)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto generator = dart::common::make_unique<EmptySampleGenerator>(stateSpace);
   EXPECT_THROW(GoalRegion(si, nullptr, std::move(generator)),
                std::invalid_argument);
@@ -41,9 +43,6 @@ TEST_F(GoalRegionTest, ThrowsOnNullTestable)
 
 TEST_F(GoalRegionTest, ThrowsOnNullGenerator)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto testable = std::make_shared<PassingConstraint>(stateSpace);
   EXPECT_THROW(GoalRegion(si, std::move(testable), nullptr),
                std::invalid_argument);
@@ -51,9 +50,6 @@ TEST_F(GoalRegionTest, ThrowsOnNullGenerator)
 
 TEST_F(GoalRegionTest, ThrowsOnTestableGeneratorMismatch)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto so3 = std::make_shared<aikido::statespace::SO3>();
   auto testable = std::make_shared<PassingConstraint>(so3);
   auto generator = dart::common::make_unique<EmptySampleGenerator>(stateSpace);
@@ -63,9 +59,6 @@ TEST_F(GoalRegionTest, ThrowsOnTestableGeneratorMismatch)
 
 TEST_F(GoalRegionTest, DifferentSample)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto testable = std::make_shared<PassingConstraint>(stateSpace);
   GoalRegion gr(si, std::move(testable),
                 std::move(sampler->createSampleGenerator()));
@@ -84,9 +77,6 @@ TEST_F(GoalRegionTest, DifferentSample)
 
 TEST_F(GoalRegionTest, ValidSample)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto testable = std::make_shared<PassingConstraint>(stateSpace);
   GoalRegion gr(si, std::move(testable),
                 std::move(sampler->createSampleGenerator()));
@@ -101,9 +91,6 @@ TEST_F(GoalRegionTest, ValidSample)
 
 TEST_F(GoalRegionTest, CantSample)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto testable = std::make_shared<PassingConstraint>(stateSpace);
   auto generator = dart::common::make_unique<EmptySampleGenerator>(stateSpace);
   GoalRegion gr(si, std::move(testable), std::move(generator));
@@ -117,10 +104,10 @@ TEST_F(GoalRegionTest, CantSample)
 TEST_F(GoalRegionTest, CantSampleBadStateSpace)
 {
   auto so2 = boost::make_shared<::ompl::base::SO2StateSpace>();
-  auto si = boost::make_shared<::ompl::base::SpaceInformation>(so2);
+  auto sinew = boost::make_shared<::ompl::base::SpaceInformation>(so2);
   auto testable = std::make_shared<PassingConstraint>(stateSpace);
   auto generator = dart::common::make_unique<EmptySampleGenerator>(stateSpace);
-  GoalRegion gr(si, std::move(testable), std::move(generator));
+  GoalRegion gr(sinew, std::move(testable), std::move(generator));
 
   GeometricStateSpace::StateType state(stateSpace->createState());
   EXPECT_THROW(gr.sampleGoal(&state), std::runtime_error);
@@ -128,9 +115,6 @@ TEST_F(GoalRegionTest, CantSampleBadStateSpace)
 
 TEST_F(GoalRegionTest, FailedSample)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto testable = std::make_shared<PassingConstraint>(stateSpace);
   auto generator = dart::common::make_unique<FailedSampleGenerator>(stateSpace);
   GoalRegion gr(si, std::move(testable), std::move(generator));
@@ -143,9 +127,6 @@ TEST_F(GoalRegionTest, FailedSample)
 
 TEST_F(GoalRegionTest, NumSamples)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto testable = std::make_shared<PassingConstraint>(stateSpace);
   auto generator = dart::common::make_unique<FailedSampleGenerator>(stateSpace);
   GoalRegion gr(si, std::move(testable), std::move(generator));
@@ -154,9 +135,6 @@ TEST_F(GoalRegionTest, NumSamples)
 
 TEST_F(GoalRegionTest, CouldSampleTrue)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto testable = std::make_shared<PassingConstraint>(stateSpace);
   auto generator = dart::common::make_unique<FailedSampleGenerator>(stateSpace);
   GoalRegion gr(si, std::move(testable), std::move(generator));
@@ -165,9 +143,6 @@ TEST_F(GoalRegionTest, CouldSampleTrue)
 
 TEST_F(GoalRegionTest, CouldSampleFalse)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto testable = std::make_shared<PassingConstraint>(stateSpace);
   auto generator = dart::common::make_unique<EmptySampleGenerator>(stateSpace);
   GoalRegion gr(si, std::move(testable), std::move(generator));
@@ -176,9 +151,6 @@ TEST_F(GoalRegionTest, CouldSampleFalse)
 
 TEST_F(GoalRegionTest, ZeroDistance)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto testable = std::make_shared<PassingConstraint>(stateSpace);
   auto generator = dart::common::make_unique<EmptySampleGenerator>(stateSpace);
   GoalRegion gr(si, std::move(testable), std::move(generator));
@@ -190,9 +162,6 @@ TEST_F(GoalRegionTest, ZeroDistance)
 
 TEST_F(GoalRegionTest, InfiniteDistance)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto testable = std::make_shared<FailingConstraint>(stateSpace);
   auto generator = dart::common::make_unique<EmptySampleGenerator>(stateSpace);
   GoalRegion gr(si, std::move(testable), std::move(generator));
@@ -205,9 +174,6 @@ TEST_F(GoalRegionTest, InfiniteDistance)
 
 TEST_F(GoalRegionTest, GoalSatisfied)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto testable = std::make_shared<PassingConstraint>(stateSpace);
   auto generator = dart::common::make_unique<EmptySampleGenerator>(stateSpace);
   GoalRegion gr(si, std::move(testable), std::move(generator));
@@ -219,9 +185,6 @@ TEST_F(GoalRegionTest, GoalSatisfied)
 
 TEST_F(GoalRegionTest, GoalNotSatisfied)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto testable = std::make_shared<FailingConstraint>(stateSpace);
   auto generator = dart::common::make_unique<EmptySampleGenerator>(stateSpace);
   GoalRegion gr(si, std::move(testable), std::move(generator));

--- a/aikido/tests/planner/ompl/test_MotionValidator.cpp
+++ b/aikido/tests/planner/ompl/test_MotionValidator.cpp
@@ -22,7 +22,7 @@ public:
         std::make_shared<MetaSkeletonStateSpace>(robot);
 
     auto mockTestable = std::make_shared<PassingConstraint>(stateSpace);
-    si = aikido::planner::ompl::createSpaceInformation(stateSpace, mockTestable, make_rng());
+    si = aikido::planner::ompl::createSpaceInformation(stateSpace, mockTestable, 0.1, make_rng());
 
     auto mockCollisionConstraint =
         std::make_shared<MockTranslationalRobotConstraint>(

--- a/aikido/tests/planner/ompl/test_OMPLPlanner.cpp
+++ b/aikido/tests/planner/ompl/test_OMPLPlanner.cpp
@@ -5,6 +5,7 @@
 #include <aikido/constraint/CartesianProductSampleable.hpp>
 #include <aikido/constraint/CartesianProductTestable.hpp>
 #include <aikido/constraint/JointStateSpaceHelpers.hpp>
+#include <aikido/planner/ompl/MotionValidator.hpp>
 #include <ompl/geometric/planners/rrt/RRTConnect.h>
 
 using StateSpace = aikido::statespace::dart::MetaSkeletonStateSpace;
@@ -30,7 +31,7 @@ TEST_F(PlannerTest, PlanToConfiguration)
   auto traj = aikido::planner::ompl::planOMPL<ompl::geometric::RRTConnect>(
       startState, goalState, stateSpace, interpolator, std::move(dmetric),
       std::move(sampler), std::move(collConstraint),
-      std::move(boundsConstraint), std::move(boundsProjection), 5.0);
+      std::move(boundsConstraint), std::move(boundsProjection), 5.0, 0.1);
 
   // Check the first waypoint
   auto s0 = stateSpace->createState();
@@ -74,7 +75,7 @@ TEST_F(PlannerTest, PlanToGoalRegion)
   auto traj = aikido::planner::ompl::planOMPL<ompl::geometric::RRTConnect>(
       startState, goalTestable, goalSampleable, stateSpace, interpolator,
       std::move(dmetric), std::move(sampler), std::move(collConstraint),
-      std::move(boundsConstraint), std::move(boundsProjection), 5.0);
+      std::move(boundsConstraint), std::move(boundsProjection), 5.0, 0.1);
 
   // Check the first waypoint
   auto s0 = stateSpace->createState();
@@ -105,7 +106,7 @@ TEST_F(PlannerTest, PlanThrowsOnNullGoalTestable)
                    startState, nullptr, std::move(goalSampleable), stateSpace,
                    interpolator, std::move(dmetric), std::move(sampler),
                    std::move(collConstraint), std::move(boundsConstraint),
-                   std::move(boundsProjection), 5.0),
+                   std::move(boundsProjection), 5.0, 0.1),
                std::invalid_argument);
 }
 
@@ -132,7 +133,7 @@ TEST_F(PlannerTest, PlanThrowsOnGoalTestableMismatch)
           startState, goalTestable, std::move(goalSampleable), stateSpace,
           interpolator, std::move(dmetric), std::move(sampler),
           std::move(collConstraint), std::move(boundsConstraint),
-          std::move(boundsProjection), 5.0),
+          std::move(boundsProjection), 5.0, 0.1),
       std::invalid_argument);
 }
 
@@ -153,7 +154,7 @@ TEST_F(PlannerTest, PlanThrowsOnNullGoalSampler)
       aikido::planner::ompl::planOMPL<ompl::geometric::RRTConnect>(
           startState, goalTestable, nullptr, stateSpace, interpolator,
           std::move(dmetric), std::move(sampler), std::move(collConstraint),
-          std::move(boundsConstraint), std::move(boundsProjection), 5.0),
+          std::move(boundsConstraint), std::move(boundsProjection), 5.0, 0.1),
       std::invalid_argument);
 }
 
@@ -180,7 +181,7 @@ TEST_F(PlannerTest, PlanThrowsOnGoalSamplerMismatch)
           startState, goalTestable, std::move(goalSampleable), stateSpace,
           interpolator, std::move(dmetric), std::move(sampler),
           std::move(collConstraint), std::move(boundsConstraint),
-          std::move(boundsProjection), 5.0),
+          std::move(boundsProjection), 5.0, 0.1),
       std::invalid_argument);
 }
 
@@ -189,7 +190,7 @@ TEST_F(PlannerTest, GetSpaceInformationThrowsOnNullStateSpace)
   EXPECT_THROW(getSpaceInformation(
                    nullptr, std::move(interpolator), std::move(dmetric),
                    std::move(sampler), std::move(collConstraint),
-                   std::move(boundsConstraint), std::move(boundsProjection)),
+                   std::move(boundsConstraint), std::move(boundsProjection), 0.1),
                std::invalid_argument);
 }
 
@@ -198,7 +199,7 @@ TEST_F(PlannerTest, GetSpaceInformationThrowsOnNullInterpolator)
   EXPECT_THROW(getSpaceInformation(
                    std::move(stateSpace), nullptr, std::move(dmetric),
                    std::move(sampler), std::move(collConstraint),
-                   std::move(boundsConstraint), std::move(boundsProjection)),
+                   std::move(boundsConstraint), std::move(boundsProjection), 0.1),
                std::invalid_argument);
 }
 
@@ -212,7 +213,7 @@ TEST_F(PlannerTest, GetSpaceInformationThrowsOnInterpolatorMismatch)
       getSpaceInformation(
           std::move(stateSpace), std::move(binterpolator), std::move(dmetric),
           std::move(sampler), std::move(collConstraint),
-          std::move(boundsConstraint), std::move(boundsProjection)),
+          std::move(boundsConstraint), std::move(boundsProjection), 0.1),
       std::invalid_argument);
 }
 
@@ -221,7 +222,7 @@ TEST_F(PlannerTest, GetSpaceInformationThrowsOnNullDistanceMetric)
   EXPECT_THROW(getSpaceInformation(
                    std::move(stateSpace), std::move(interpolator), nullptr,
                    std::move(sampler), std::move(collConstraint),
-                   std::move(boundsConstraint), std::move(boundsProjection)),
+                   std::move(boundsConstraint), std::move(boundsProjection), 0.1),
                std::invalid_argument);
 }
 
@@ -233,7 +234,7 @@ TEST_F(PlannerTest, GetSpaceInformationThrowsOnDistanceMetricMismatch)
   EXPECT_THROW(getSpaceInformation(
                    std::move(stateSpace), std::move(interpolator),
                    std::move(dm), std::move(sampler), std::move(collConstraint),
-                   std::move(boundsConstraint), std::move(boundsProjection)),
+                   std::move(boundsConstraint), std::move(boundsProjection), 0.1),
                std::invalid_argument);
 }
 
@@ -242,7 +243,7 @@ TEST_F(PlannerTest, GetSpaceInformationThrowsOnNullSampler)
   EXPECT_THROW(getSpaceInformation(
                    std::move(stateSpace), std::move(interpolator),
                    std::move(dmetric), nullptr, std::move(collConstraint),
-                   std::move(boundsConstraint), std::move(boundsProjection)),
+                   std::move(boundsConstraint), std::move(boundsProjection), 0.1),
                std::invalid_argument);
 }
 
@@ -254,7 +255,7 @@ TEST_F(PlannerTest, GetSpaceInformationThrowsOnSamplerMismatch)
   EXPECT_THROW(getSpaceInformation(
                    std::move(stateSpace), std::move(interpolator),
                    std::move(dmetric), std::move(ds), std::move(collConstraint),
-                   std::move(boundsConstraint), std::move(boundsProjection)),
+                   std::move(boundsConstraint), std::move(boundsProjection), 0.1),
                std::invalid_argument);
 }
 
@@ -263,7 +264,7 @@ TEST_F(PlannerTest, GetSpaceInformationThrowsOnNullValidityConstraint)
   EXPECT_THROW(getSpaceInformation(
                    std::move(stateSpace), std::move(interpolator),
                    std::move(dmetric), std::move(sampler), nullptr,
-                   std::move(boundsConstraint), std::move(boundsProjection)),
+                   std::move(boundsConstraint), std::move(boundsProjection), 0.1),
                std::invalid_argument);
 }
 
@@ -275,7 +276,7 @@ TEST_F(PlannerTest, GetSpaceInformationThrowsOnValidityConstraintMismatch)
   EXPECT_THROW(getSpaceInformation(
                    std::move(stateSpace), std::move(interpolator),
                    std::move(dmetric), std::move(sampler), std::move(dv),
-                   std::move(boundsConstraint), std::move(boundsProjection)),
+                   std::move(boundsConstraint), std::move(boundsProjection), 0.1),
                std::invalid_argument);
 }
 
@@ -285,7 +286,7 @@ TEST_F(PlannerTest, GetSpaceInformationThrowsOnNullBoundsConstraint)
       getSpaceInformation(std::move(stateSpace), std::move(interpolator),
                           std::move(dmetric), std::move(sampler),
                           std::move(collConstraint), nullptr,
-                          std::move(boundsProjection)),
+                          std::move(boundsProjection), 0.1),
       std::invalid_argument);
 }
 
@@ -298,7 +299,7 @@ TEST_F(PlannerTest, GetSpaceInformationThrowsOnBoundsConstraintMismatch)
       getSpaceInformation(std::move(stateSpace), std::move(interpolator),
                           std::move(dmetric), std::move(sampler),
                           std::move(collConstraint), std::move(ds),
-                          std::move(boundsProjection)),
+                          std::move(boundsProjection), 0.1),
       std::invalid_argument);
 }
 
@@ -308,7 +309,7 @@ TEST_F(PlannerTest, GetSpaceInformationThrowsOnNullBoundsProjector)
       getSpaceInformation(std::move(stateSpace), std::move(interpolator),
                           std::move(dmetric), std::move(sampler),
                           std::move(collConstraint),
-                          std::move(boundsConstraint), nullptr),
+                          std::move(boundsConstraint), nullptr, 0.1),
       std::invalid_argument);
 }
 
@@ -321,7 +322,20 @@ TEST_F(PlannerTest, GetSpaceInformationThrowsOnBoundsProjectorMismatch)
       getSpaceInformation(std::move(stateSpace), std::move(interpolator),
                           std::move(dmetric), std::move(sampler),
                           std::move(collConstraint),
-                          std::move(boundsConstraint), std::move(ds)),
+                          std::move(boundsConstraint), std::move(ds), 0.1),
+      std::invalid_argument);
+}
+
+TEST_F(PlannerTest, GetSpaceInformationThrowsOnNegativeDistanceBetweenChecks)
+{
+  auto ss = std::make_shared<StateSpace>(robot);
+  auto ds = aikido::constraint::createProjectableBounds(ss);
+
+  EXPECT_THROW(
+      getSpaceInformation(std::move(stateSpace), std::move(interpolator),
+                          std::move(dmetric), std::move(sampler),
+                          std::move(collConstraint),
+                          std::move(boundsConstraint), std::move(boundsProjection), -0.1),
       std::invalid_argument);
 }
 
@@ -330,7 +344,7 @@ TEST_F(PlannerTest, GetSpaceInformationNotNull)
   auto si = getSpaceInformation(
       std::move(stateSpace), std::move(interpolator), std::move(dmetric),
       std::move(sampler), std::move(collConstraint),
-      std::move(boundsConstraint), std::move(boundsProjection));
+      std::move(boundsConstraint), std::move(boundsProjection), 0.1);
   EXPECT_FALSE(si == nullptr);
 }
 
@@ -339,7 +353,7 @@ TEST_F(PlannerTest, GetSpaceInformationCreatesGeometricStateSpace)
   auto si = getSpaceInformation(
       std::move(stateSpace), std::move(interpolator), std::move(dmetric),
       std::move(sampler), std::move(collConstraint),
-      std::move(boundsConstraint), std::move(boundsProjection));
+      std::move(boundsConstraint), std::move(boundsProjection), 0.1);
 
   auto ss = boost::dynamic_pointer_cast<aikido::planner::ompl::GeometricStateSpace>(
       si->getStateSpace());
@@ -351,10 +365,21 @@ TEST_F(PlannerTest, GetSpaceInformationCreatesValidityChecker)
   auto si = getSpaceInformation(
       std::move(stateSpace), std::move(interpolator), std::move(dmetric),
       std::move(sampler), std::move(collConstraint),
-      std::move(boundsConstraint), std::move(boundsProjection));
+      std::move(boundsConstraint), std::move(boundsProjection), 0.1);
 
   auto vc = boost::dynamic_pointer_cast<aikido::planner::ompl::StateValidityChecker>(
       si->getStateValidityChecker());
   EXPECT_FALSE(vc == nullptr);
 }
 
+TEST_F(PlannerTest, GetSpaceInformationCreatesMotionValidator)
+{
+  auto si = getSpaceInformation(
+      std::move(stateSpace), std::move(interpolator), std::move(dmetric),
+      std::move(sampler), std::move(collConstraint),
+      std::move(boundsConstraint), std::move(boundsProjection), 0.1);
+
+  auto mvalidator = boost::dynamic_pointer_cast<aikido::planner::ompl::MotionValidator>(
+      si->getMotionValidator());
+  EXPECT_FALSE(mvalidator == nullptr);
+}

--- a/aikido/tests/planner/ompl/test_StateSampler.cpp
+++ b/aikido/tests/planner/ompl/test_StateSampler.cpp
@@ -1,5 +1,7 @@
 #include "OMPLTestHelpers.hpp"
 #include <aikido/planner/ompl/StateSampler.hpp>
+#include <boost/make_shared.hpp>
+#include <ompl/base/spaces/SO2StateSpace.h>
 
 using aikido::planner::ompl::GeometricStateSpace;
 using aikido::planner::ompl::StateSampler;
@@ -37,7 +39,8 @@ TEST_F(StateSamplerTest, SampleUniformGeneratorCantSample)
   auto s1 = gSpace->allocState()->as<GeometricStateSpace::StateType>();
 
   // Ensure we get two different states if we sample twice
-  EXPECT_THROW(ssampler.sampleUniform(s1), std::runtime_error);
+  ssampler.sampleUniform(s1);
+  EXPECT_EQ(nullptr, s1->mState);
 
   gSpace->freeState(s1);
 }
@@ -50,7 +53,8 @@ TEST_F(StateSamplerTest, SampleUniformGeneratorFailsSample)
   auto s1 = gSpace->allocState()->as<GeometricStateSpace::StateType>();
 
   // Ensure we get two different states if we sample twice
-  EXPECT_THROW(ssampler.sampleUniform(s1), std::runtime_error);
+  ssampler.sampleUniform(s1);
+  EXPECT_EQ(nullptr, s1->mState);
   gSpace->freeState(s1);
 }
 
@@ -94,4 +98,15 @@ TEST_F(StateSamplerTest, SampleGaussianAlwaysThrows)
 
   gSpace->freeState(s1);
   gSpace->freeState(s2);
+}
+
+TEST_F(StateSamplerTest, BadStateSpaceThrows)
+{
+  auto so2 = boost::make_shared<::ompl::base::SO2StateSpace>();
+  auto generator = dart::common::make_unique<EmptySampleGenerator>(stateSpace);
+  StateSampler ssampler(so2.get(), std::move(generator));
+
+  auto s1 = gSpace->allocState()->as<GeometricStateSpace::StateType>();
+  EXPECT_THROW(ssampler.sampleUniform(s1), std::runtime_error);
+  gSpace->freeState(s1);
 }

--- a/aikido/tests/planner/ompl/test_ValidityChecker.cpp
+++ b/aikido/tests/planner/ompl/test_ValidityChecker.cpp
@@ -59,3 +59,27 @@ TEST_F(StateValidityCheckerTest, InvalidState)
   EXPECT_FALSE(vchecker.isValid(state));
   si->freeState(state);
 }
+
+TEST_F(StateValidityCheckerTest, NullAikidoState)
+{
+  auto si = aikido::planner::ompl::getSpaceInformation(
+      stateSpace, interpolator, dmetric, sampler, collConstraint,
+      boundsConstraint, boundsProjection);
+  auto constraint = std::make_shared<PassingConstraint>(stateSpace);
+  StateValidityChecker vchecker(si, constraint);
+  auto state = si->allocState()->as<GeometricStateSpace::StateType>();
+  stateSpace->freeState(state->mState);
+  state->mState = nullptr;
+  EXPECT_FALSE(vchecker.isValid(state));
+  si->freeState(state);
+}
+
+TEST_F(StateValidityCheckerTest, NullOmplState)
+{
+  auto si = aikido::planner::ompl::getSpaceInformation(
+      stateSpace, interpolator, dmetric, sampler, collConstraint,
+      boundsConstraint, boundsProjection);
+  auto constraint = std::make_shared<PassingConstraint>(stateSpace);
+  StateValidityChecker vchecker(si, constraint);
+  EXPECT_FALSE(vchecker.isValid(nullptr));
+}

--- a/aikido/tests/planner/ompl/test_ValidityChecker.cpp
+++ b/aikido/tests/planner/ompl/test_ValidityChecker.cpp
@@ -16,8 +16,12 @@ public:
     gSpace = std::make_shared<GeometricStateSpace>(
         stateSpace, interpolator, dmetric, sampler, boundsConstraint,
         boundsProjection);
+    si = aikido::planner::ompl::getSpaceInformation(
+      stateSpace, interpolator, dmetric, sampler, collConstraint,
+      boundsConstraint, boundsProjection, 0.1);
   }
   std::shared_ptr<GeometricStateSpace> gSpace;
+  boost::shared_ptr<::ompl::base::SpaceInformation> si;
 };
 
 TEST_F(StateValidityCheckerTest, ThrowsOnNullSpaceInformation)
@@ -30,17 +34,11 @@ TEST_F(StateValidityCheckerTest, ThrowsOnNullSpaceInformation)
 
 TEST_F(StateValidityCheckerTest, ThrowsOnNullConstraint)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   EXPECT_THROW(StateValidityChecker(si, nullptr), std::invalid_argument);
 }
 
 TEST_F(StateValidityCheckerTest, ValidState)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto constraint = std::make_shared<PassingConstraint>(stateSpace);
   StateValidityChecker vchecker(si, constraint);
   auto state = si->allocState();
@@ -50,9 +48,6 @@ TEST_F(StateValidityCheckerTest, ValidState)
 
 TEST_F(StateValidityCheckerTest, InvalidState)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto constraint = std::make_shared<FailingConstraint>(stateSpace);
   StateValidityChecker vchecker(si, constraint);
   auto state = si->allocState();
@@ -62,9 +57,6 @@ TEST_F(StateValidityCheckerTest, InvalidState)
 
 TEST_F(StateValidityCheckerTest, NullAikidoState)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto constraint = std::make_shared<PassingConstraint>(stateSpace);
   StateValidityChecker vchecker(si, constraint);
   auto state = si->allocState()->as<GeometricStateSpace::StateType>();
@@ -76,9 +68,6 @@ TEST_F(StateValidityCheckerTest, NullAikidoState)
 
 TEST_F(StateValidityCheckerTest, NullOmplState)
 {
-  auto si = aikido::planner::ompl::getSpaceInformation(
-      stateSpace, interpolator, dmetric, sampler, collConstraint,
-      boundsConstraint, boundsProjection);
   auto constraint = std::make_shared<PassingConstraint>(stateSpace);
   StateValidityChecker vchecker(si, constraint);
   EXPECT_FALSE(vchecker.isValid(nullptr));


### PR DESCRIPTION
This PR contains a set of improvements/bug fixes that were necessary to use the aikido framework and OMPL planners with HERB:

* Aikido state now set to a nullptr when a valid sample fails to be generated.  This includes regular state and goal sampling
* GeometricStateSpace, StateSampler, StateValidityChecker and GoalRegion updated to properly handle these states.
* Additional logic to ```aikido::constraint::NonColliding``` to pass collision options that ignore collisions between physically adjacent links by default.  Also added a constructor that exposes the option of passing custom ```CollisionOptions``` to the constraint.
* Added checks for infinite velocity or acceleration limits to ```ParabolicTimer```
* Update OMPL planner functions to use the custom ```MotionValidator``` by default
* Update OMPL planner functions to return ```Interpolated``` type paths instead of generic ```Trajectory``` type
* Return ```nullptr``` instead of an empty path when a solution cannot be found

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/personalrobotics/aikido/90)
<!-- Reviewable:end -->
