### PR TITLE
Add custom target for displaying the headers in IDEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 include_directories("include")
 
+# This custom target doesn't affect on building aikido projects but is only for
+# displaying the header files in IDEs.
+FILE(GLOB_RECURSE aikido_headers "include/*.hpp")
+add_custom_target(headers SOURCES ${aikido_headers})
+
 add_subdirectory("src")
 
 enable_testing()


### PR DESCRIPTION
Some IDEs including Qt Creator doesn't show the headers when they are not in a build target. This PR adds a dummy custom target that contains the headers for displaying them in IDEs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/personalrobotics/aikido/121)
<!-- Reviewable:end -->
