### PR TITLE
fix missing argument to VanDerCorput constructor

### DIFF
--- a/src/planner/ompl/MotionValidator.cpp
+++ b/src/planner/ompl/MotionValidator.cpp
@@ -26,7 +26,7 @@ bool MotionValidator::checkMotion(const ::ompl::base::State* _s1,
                                   const ::ompl::base::State* _s2) const
 {
   double dist = si_->distance(_s1, _s2);
-  aikido::util::VanDerCorput vdc{1, true,  // include endpoints
+  aikido::util::VanDerCorput vdc{1, true, true,  // include endpoints
                                  mSequenceResolution / dist};
 
   auto stateSpace = si_->getStateSpace();


### PR DESCRIPTION
This compilation error wasn't caught by Travis CI, so I suspect a silent exclusion of the planner_ompl module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/personalrobotics/aikido/133)
<!-- Reviewable:end -->
