### PR TITLE
Add missing STL headers

### DIFF
--- a/src/util/VanDerCorput.cpp
+++ b/src/util/VanDerCorput.cpp
@@ -1,5 +1,8 @@
 #include <aikido/util/VanDerCorput.hpp>
+
+#include <algorithm>
 #include <cmath>
+#include <stdexcept>
 
 using namespace aikido::util;
 using std::pair;


### PR DESCRIPTION
This PR includes the missing headers `<algorithm>` and `<stdexcept>` to `VanDerCorput.cpp` for `std::max()` and `std::out_of_range`, respectively.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/personalrobotics/aikido/138)
<!-- Reviewable:end -->
