### PR TITLE
Remove redundant virtual keyword for overriding member functions

### DIFF
--- a/include/aikido/constraint/InverseKinematicsSampleable.hpp
+++ b/include/aikido/constraint/InverseKinematicsSampleable.hpp
@@ -39,7 +39,7 @@ public:
   virtual ~InverseKinematicsSampleable() = default;
 
   // Documentation inherited.
-  virtual statespace::StateSpacePtr getStateSpace() const override;
+  statespace::StateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   std::unique_ptr<SampleGenerator> createSampleGenerator() const override;

--- a/include/aikido/planner/ompl/CRRT.hpp
+++ b/include/aikido/planner/ompl/CRRT.hpp
@@ -52,7 +52,7 @@ public:
 
   /// Clear all internal datastructures. Planner settings are not affected.
   /// Subsequent calls to solve() will ignore all previous work.
-  virtual void clear(void) override;
+  void clear(void) override;
 
   /// Set the goal bias. In the process of randomly selecting states in the
   /// state space to attempt to go towards, the algorithm may in fact choose the


### PR DESCRIPTION
Searched them using regexp: `^ *virtual .*override`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/personalrobotics/aikido/141)
<!-- Reviewable:end -->
