### PR TITLE
Fix test_KinematicSimulationTrajectoryExecutor

### DIFF
--- a/tests/control/test_KinematicSimulationTrajectoryExecutor.cpp
+++ b/tests/control/test_KinematicSimulationTrajectoryExecutor.cpp
@@ -155,13 +155,22 @@ TEST_F(KinematicSimulationTrajectoryExecutorTest, execute_TrajectoryIsAlreadyRun
 
   auto future = executor.execute(mTraj);
   
-  // Executor cannot not immediately execute the next one.
-  EXPECT_THROW(executor.execute(mTraj), std::runtime_error);
+  // Executor possibly not able to immediately execute the next one.
+  try
+  {
+    executor.execute(mTraj);
+  }
+  catch (const std::runtime_error& e)
+  {
+    EXPECT_EQ(std::string(e.what()), "Another trajectory in execution.");
+
+    // It couldn't finished the trajectory execution yet.
+    EXPECT_NE(mSkeleton->getDof(0)->getPosition(), 1.0);
+  };
 
   future.wait();
   EXPECT_DOUBLE_EQ(mSkeleton->getDof(0)->getPosition(), 1.0);
 }
-
 
 TEST_F(KinematicSimulationTrajectoryExecutorTest, execute_TrajectoryFinished_DoesNotThrow)
 {

--- a/tests/control/test_KinematicSimulationTrajectoryExecutor.cpp
+++ b/tests/control/test_KinematicSimulationTrajectoryExecutor.cpp
@@ -163,9 +163,6 @@ TEST_F(KinematicSimulationTrajectoryExecutorTest, execute_TrajectoryIsAlreadyRun
   catch (const std::runtime_error& e)
   {
     EXPECT_EQ(std::string(e.what()), "Another trajectory in execution.");
-
-    // It could not have finished the trajectory execution yet.
-    EXPECT_NE(mSkeleton->getDof(0)->getPosition(), 1.0);
   };
 
   future.wait();

--- a/tests/control/test_KinematicSimulationTrajectoryExecutor.cpp
+++ b/tests/control/test_KinematicSimulationTrajectoryExecutor.cpp
@@ -164,7 +164,7 @@ TEST_F(KinematicSimulationTrajectoryExecutorTest, execute_TrajectoryIsAlreadyRun
   {
     EXPECT_EQ(std::string(e.what()), "Another trajectory in execution.");
 
-    // It couldn't finished the trajectory execution yet.
+    // It could not have finished the trajectory execution yet.
     EXPECT_NE(mSkeleton->getDof(0)->getPosition(), 1.0);
   };
 


### PR DESCRIPTION
`KinematicSimulationTrajectoryExecutorTest.execute_TrajectoryIsAlreadyRunning_Throws` test occasionally fails because the result is non-deterministic. This PR fixes the test to take into account the case as well.

Resolves #126