### PR TITLE
Add yaml-cpp to package.xml as dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <depend>ompl</depend>
   <depend>python</depend>
   <depend>tinyxml2</depend>
+  <depend>yaml-cpp</depend>
   <doc_depend>doxygen</doc_depend>
   <!-- Workaround to build DART with optional features enabled. -->
   <depend>nlopt</depend>


### PR DESCRIPTION
[`yaml-cpp` was added to CMake script as an optional dependency](https://github.com/personalrobotics/aikido/blob/master/src/perception/CMakeLists.txt#L4-L5). This PR adds `yaml-cpp` to `package.xml` as required dependency because `package.xml` doesn't support adding an optional dependency.

Resolves #134