### PR TITLE
Removes locking from step()

### DIFF
--- a/include/aikido/control/BarrettHandKinematicSimulationPositionCommandExecutor.hpp
+++ b/include/aikido/control/BarrettHandKinematicSimulationPositionCommandExecutor.hpp
@@ -47,7 +47,9 @@ public:
   /// \return Future which becomes available when the execution completes.
   std::future<void> execute(const Eigen::VectorXd& goalPositions) override;
 
-  // Documentation inherited.
+  /// If multiple threads are accessing this function or the skeleton associated
+  /// with this executor, it is necessary to lock the skeleton before
+  /// calling this method.
   void step() override;
 
   /// Resets CollisionGroup to check collision with fingers.

--- a/include/aikido/control/BarrettHandKinematicSimulationPositionCommandExecutor.hpp
+++ b/include/aikido/control/BarrettHandKinematicSimulationPositionCommandExecutor.hpp
@@ -47,6 +47,8 @@ public:
   /// \return Future which becomes available when the execution completes.
   std::future<void> execute(const Eigen::VectorXd& goalPositions) override;
 
+  /// \copydoc PositionCommandExecutor::step()
+  ///
   /// If multiple threads are accessing this function or the skeleton associated
   /// with this executor, it is necessary to lock the skeleton before
   /// calling this method.

--- a/include/aikido/control/KinematicSimulationTrajectoryExecutor.hpp
+++ b/include/aikido/control/KinematicSimulationTrajectoryExecutor.hpp
@@ -35,7 +35,9 @@ public:
   std::future<void> execute(
     trajectory::TrajectoryPtr traj) override;
 
-  // Documentation inherited.
+  /// If multiple threads are accessing this function or the skeleton associated
+  /// with this executor, it is necessary to lock the skeleton before
+  /// calling this method.
   void step() override;
 
 private:

--- a/include/aikido/control/KinematicSimulationTrajectoryExecutor.hpp
+++ b/include/aikido/control/KinematicSimulationTrajectoryExecutor.hpp
@@ -35,6 +35,8 @@ public:
   std::future<void> execute(
     trajectory::TrajectoryPtr traj) override;
 
+  /// \copydoc PositionCommandExecutor::step()
+  ///
   /// If multiple threads are accessing this function or the skeleton associated
   /// with this executor, it is necessary to lock the skeleton before
   /// calling this method.

--- a/include/aikido/trajectory/Trajectory.hpp
+++ b/include/aikido/trajectory/Trajectory.hpp
@@ -50,8 +50,8 @@ public:
   /// function is implementation-defined if \c _t is not between
   /// \c getStartTime() and \c getEndTime().
   ///
-  /// \param _t time parameter (in seconds)
-  /// \param[out] _state output state of the trajectory at time \c _t (seconds)
+  /// \param _t time parameter
+  /// \param[out] _state output state of the trajectory at time \c _t
   virtual void evaluate(double _t,
     statespace::StateSpace::State *_state) const = 0;
 

--- a/include/aikido/trajectory/Trajectory.hpp
+++ b/include/aikido/trajectory/Trajectory.hpp
@@ -50,8 +50,8 @@ public:
   /// function is implementation-defined if \c _t is not between
   /// \c getStartTime() and \c getEndTime().
   ///
-  /// \param _t time parameter
-  /// \param[out] _state output state of the trajectory at time \c _t
+  /// \param _t time parameter (in seconds)
+  /// \param[out] _state output state of the trajectory at time \c _t (seconds)
   virtual void evaluate(double _t,
     statespace::StateSpace::State *_state) const = 0;
 

--- a/src/control/KinematicSimulationTrajectoryExecutor.cpp
+++ b/src/control/KinematicSimulationTrajectoryExecutor.cpp
@@ -127,7 +127,6 @@ void KinematicSimulationTrajectoryExecutor::step()
     mPromise->set_value();
     mInExecution = false;
   }
-
 }
 
 }

--- a/src/control/KinematicSimulationTrajectoryExecutor.cpp
+++ b/src/control/KinematicSimulationTrajectoryExecutor.cpp
@@ -105,7 +105,7 @@ void KinematicSimulationTrajectoryExecutor::step()
     mInExecution = false;
   }
 
-  using seconds = std::chrono::duration<float>;
+  using seconds = std::chrono::duration<double>;
   auto timeSinceBeginning = system_clock::now() - mExecutionStartTime;
   auto tsec = duration_cast<seconds>(timeSinceBeginning).count();
 

--- a/src/control/KinematicSimulationTrajectoryExecutor.cpp
+++ b/src/control/KinematicSimulationTrajectoryExecutor.cpp
@@ -105,8 +105,9 @@ void KinematicSimulationTrajectoryExecutor::step()
     mInExecution = false;
   }
 
+  using seconds = std::chrono::duration<float>;
   auto timeSinceBeginning = system_clock::now() - mExecutionStartTime;
-  auto t = duration<double>(timeSinceBeginning).count();
+  auto tsec = duration_cast<seconds>(timeSinceBeginning).count();
 
   // Can't do static here because MetaSkeletonStateSpace inherits
   // CartesianProduct which inherits virtual StateSpace
@@ -115,12 +116,12 @@ void KinematicSimulationTrajectoryExecutor::step()
   auto metaSkeleton = space->getMetaSkeleton();
   auto state = space->createState();
 
-  mTraj->evaluate(t, state);
+  mTraj->evaluate(tsec, state);
 
   space->setState(state);
 
   // Check if trajectory has completed.
-  bool const is_done = (t >= mTraj->getEndTime());
+  bool const is_done = (tsec >= mTraj->getEndTime());
   if (is_done) {
     mTraj.reset();
     mPromise->set_value();

--- a/src/control/KinematicSimulationTrajectoryExecutor.cpp
+++ b/src/control/KinematicSimulationTrajectoryExecutor.cpp
@@ -106,7 +106,7 @@ void KinematicSimulationTrajectoryExecutor::step()
   }
 
   auto timeSinceBeginning = system_clock::now() - mExecutionStartTime;
-  double t = duration_cast<seconds>(timeSinceBeginning).count();
+  auto t = duration<double>(timeSinceBeginning).count();
 
   // Can't do static here because MetaSkeletonStateSpace inherits
   // CartesianProduct which inherits virtual StateSpace
@@ -117,10 +117,7 @@ void KinematicSimulationTrajectoryExecutor::step()
 
   mTraj->evaluate(t, state);
 
-  // Lock the skeleton, set state.
-  std::unique_lock<std::mutex> skeleton_lock(mSkeleton->getMutex());
   space->setState(state);
-  skeleton_lock.unlock();
 
   // Check if trajectory has completed.
   bool const is_done = (t >= mTraj->getEndTime());
@@ -129,6 +126,7 @@ void KinematicSimulationTrajectoryExecutor::step()
     mPromise->set_value();
     mInExecution = false;
   }
+
 }
 
 }

--- a/src/control/KinematicSimulationTrajectoryExecutor.cpp
+++ b/src/control/KinematicSimulationTrajectoryExecutor.cpp
@@ -105,9 +105,9 @@ void KinematicSimulationTrajectoryExecutor::step()
     mInExecution = false;
   }
 
-  using seconds = std::chrono::duration<double>;
   auto timeSinceBeginning = system_clock::now() - mExecutionStartTime;
-  auto tsec = duration_cast<seconds>(timeSinceBeginning).count();
+  auto tsec = duration_cast<std::chrono::duration<double>>(
+    timeSinceBeginning).count();
 
   // Can't do static here because MetaSkeletonStateSpace inherits
   // CartesianProduct which inherits virtual StateSpace


### PR DESCRIPTION
`KinematicSimulationTrajectoryExecutor::step()` should no longer lock the skeleton and let the caller be responsible for locking if it's running under multi-threaded setting. This is consistent with other executors.
