### PR TITLE
Bugfix: renaming spin to step and removing template from RosTrajectoryExecutor

### DIFF
--- a/include/aikido/control/ros/RosPositionCommandExecutor.hpp
+++ b/include/aikido/control/ros/RosPositionCommandExecutor.hpp
@@ -41,7 +41,10 @@ public:
   /// \param[in] goalPositions Vector of target positions for each joint
   std::future<void> execute(const Eigen::VectorXd& goalPositions) override;
 
-
+  /// \copydoc PositionCommandExecutor::step()
+  ///
+  /// To be executed on a separate thread.
+  /// Regularly checks for the completion of a sent trajectory.
   void step() override;
 
 private:

--- a/include/aikido/control/ros/RosTrajectoryExecutor.hpp
+++ b/include/aikido/control/ros/RosTrajectoryExecutor.hpp
@@ -27,15 +27,16 @@ public:
   /// \param[in] goalTimeTolerance
   /// \param[in] connectionTimeout Timeout for server connection.
   /// \param[in] connectionPollingPeriod Polling period for server connection.
-  template <typename DurationA, typename DurationB>
   RosTrajectoryExecutor(
     statespace::dart::MetaSkeletonStateSpacePtr space,
     ::ros::NodeHandle node,
     const std::string& serverName,
     double timestep,
     double goalTimeTolerance,
-    const DurationA& connectionTimeout = std::chrono::milliseconds{1000},
-    const DurationB& connectionPollingPeriod = std::chrono::milliseconds{20}
+    const std::chrono::milliseconds& connectionTimeout
+      = std::chrono::milliseconds{1000},
+    const std::chrono::milliseconds& connectionPollingPeriod
+      = std::chrono::milliseconds{20}
   );
 
   virtual ~RosTrajectoryExecutor();
@@ -50,9 +51,11 @@ public:
   std::future<void> execute(
     trajectory::TrajectoryPtr traj, const ::ros::Time& startTime);
 
+  /// \copydoc TrajectoryExecutor::step()
+  ///
   /// To be executed on a separate thread.
   /// Regularly checks for the completion of a sent trajectory.
-  void spin();
+  void step() override;
 
 private:
   using TrajectoryActionClient

--- a/src/control/ros/CMakeLists.txt
+++ b/src/control/ros/CMakeLists.txt
@@ -47,6 +47,7 @@ target_include_directories("${PROJECT_NAME}_control_ros" SYSTEM
 )
 
 target_link_libraries("${PROJECT_NAME}_control_ros"
+  PUBLIC
   "${PROJECT_NAME}_control"
   "${PROJECT_NAME}_statespace"
   "${PROJECT_NAME}_trajectory"

--- a/src/control/ros/RosTrajectoryExecutor.cpp
+++ b/src/control/ros/RosTrajectoryExecutor.cpp
@@ -48,25 +48,22 @@ std::string getFollowJointTrajectoryErrorMessage(int32_t errorCode)
 } // namespace
 
 //=============================================================================
-template <typename DurationA, typename DurationB>
 RosTrajectoryExecutor::RosTrajectoryExecutor(
       statespace::dart::MetaSkeletonStateSpacePtr space,
       ::ros::NodeHandle node,
       const std::string& serverName,
       double timestep,
       double goalTimeTolerance,
-      const DurationA& connectionTimeout,
-      const DurationB& connectionPollingPeriod)
+      const std::chrono::milliseconds& connectionTimeout,
+      const std::chrono::milliseconds& connectionPollingPeriod)
   : mSpace{std::move(space)}
   , mNode{std::move(node)}
   , mCallbackQueue{}
   , mClient{mNode, serverName, &mCallbackQueue}
   , mTimestep{timestep}
   , mGoalTimeTolerance{goalTimeTolerance}
-  , mConnectionTimeout{
-    std::chrono::duration_cast<milliseconds>(connectionTimeout)}
-  , mConnectionPollingPeriod{
-    std::chrono::duration_cast<milliseconds>(connectionPollingPeriod)}
+  , mConnectionTimeout{connectionTimeout}
+  , mConnectionPollingPeriod{connectionPollingPeriod}
   , mInProgress{false}
 {
   if (!mSpace)
@@ -231,7 +228,7 @@ void RosTrajectoryExecutor::transitionCallback(GoalHandle handle)
 }
 
 //=============================================================================
-void RosTrajectoryExecutor::spin()
+void RosTrajectoryExecutor::step()
 {
   std::lock_guard<std::mutex> lock(mMutex);
   DART_UNUSED(lock); // Suppress unused variable warning.


### PR DESCRIPTION
This PR renames `spin` to `step` so that the method properly overrides `TrajectoryExecutor::step`. It also removes templating of `connectionTimeout` and `connectionPollingPeriod` in the constructor.