### PR TITLE
Changes SnapPlanner to return nullptr when planning fails.

### DIFF
--- a/src/planner/SnapPlanner.cpp
+++ b/src/planner/SnapPlanner.cpp
@@ -33,7 +33,7 @@ trajectory::InterpolatedPtr planSnap(
     if (!constraint->isSatisfied(testState))
     {
       planningResult.message = "Collision detected";
-      return returnTraj;
+      return nullptr;
     }
   }
 

--- a/tests/planner/test_SnapPlanner.cpp
+++ b/tests/planner/test_SnapPlanner.cpp
@@ -101,5 +101,5 @@ TEST_F(SnapPlannerTest, FailIfConstraintNotSatisfied)
 {
   auto traj = planSnap(stateSpace, *startState, *goalState, interpolator,
     failingConstraint, planningResult);
-  EXPECT_EQ(0, traj->getNumWaypoints());  // TODO boost::optional
+  EXPECT_EQ(nullptr, traj);
 }


### PR DESCRIPTION
SnapPlanner's docstring says that it returns `nullptr` when it fails but the implementation returned trajectory.  This PR fixes it to return `nullptr` upon failure.