### PR TITLE
Increase minimum required DART version to 6.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ include(FindPkgConfig)
 
 find_package(Boost REQUIRED COMPONENTS filesystem)
 
-find_package(DART 6.1.0 REQUIRED
+find_package(DART 6.2.0 REQUIRED
   COMPONENTS optimizer-nlopt utils
   OPTIONAL_COMPONENTS utils-urdf # for 'perception' target
   CONFIG

--- a/src/rviz/shape_conversions.cpp
+++ b/src/rviz/shape_conversions.cpp
@@ -136,7 +136,7 @@ bool convertShape(
 {
   marker->type = Marker::SPHERE;
   marker->pose.orientation.w = 1.;
-  marker->scale = convertEigenToROSVector3(shape.getSize());
+  marker->scale = convertEigenToROSVector3(shape.getDiameters());
   return true;
 }
 

--- a/tests/constraint/test_DifferentiableIntersection.cpp
+++ b/tests/constraint/test_DifferentiableIntersection.cpp
@@ -31,7 +31,7 @@ TEST(DifferentiableIntersection, InvalidConstructor)
   // constraints have different space
   constraints.push_back(std::make_shared<PolynomialConstraint<1>>(
     Eigen::Vector3d(1, 2, 3), rvss));
-  constraints.push_back(Eigen::make_aligned_shared<TSR>());
+  constraints.push_back(dart::common::make_aligned_shared<TSR>());
   EXPECT_THROW(DifferentiableIntersection(constraints, rvss), std::invalid_argument);
 }
 

--- a/tests/constraint/test_FramePairDifferentiable.cpp
+++ b/tests/constraint/test_FramePairDifferentiable.cpp
@@ -28,7 +28,7 @@ class FramePairDifferentiableTest : public ::testing::Test {
   protected:
     virtual void SetUp() {
 
-      tsr = Eigen::make_aligned_shared<TSR>(
+      tsr = dart::common::make_aligned_shared<TSR>(
         std::unique_ptr<RNG>(new RNGWrapper<std::default_random_engine>(0)));
 
       Eigen::MatrixXd Bw = Eigen::Matrix<double, 6, 2>::Zero();


### PR DESCRIPTION
This PR increases the minimum required DART version to 6.2.0, which is just released today and available installing through the PPA. Also, this PR suppresses warnings due to the use of deprecated API in DART 6.2.0.