### PR TITLE
Set default `_numOutputs` to 1 in `splitEngine`

### DIFF
--- a/include/aikido/util/RNG.hpp
+++ b/include/aikido/util/RNG.hpp
@@ -137,7 +137,7 @@ Quaternion sampleQuaternion(
 /// \param _numSeeds number of seeds to use for initialization
 /// \return new random number generators
 std::vector<std::unique_ptr<util::RNG>> splitEngine(
-    RNG& _engine, size_t _numOutputs, size_t _numSeeds = NUM_DEFAULT_SEEDS);
+    RNG& _engine, size_t _numOutputs = 1, size_t _numSeeds = NUM_DEFAULT_SEEDS);
 
 } // namespace util
 } // namespace aikido

--- a/include/aikido/util/RNG.hpp
+++ b/include/aikido/util/RNG.hpp
@@ -11,7 +11,7 @@
 namespace aikido {
 namespace util {
 
-/// Default number of seeds to by \c splitEngine to seed new engines.
+/// Default number of seeds to by \c cloneRNGsFrom to seed new engines.
 constexpr int NUM_DEFAULT_SEEDS{100};
 
 /// Implementation of the C++11 "random engine" concept that uses virtual
@@ -136,8 +136,19 @@ Quaternion sampleQuaternion(
 /// \param _numOutputs number of RNGs to create
 /// \param _numSeeds number of seeds to use for initialization
 /// \return new random number generators
-std::vector<std::unique_ptr<util::RNG>> splitEngine(
-    RNG& _engine, size_t _numOutputs = 1, size_t _numSeeds = NUM_DEFAULT_SEEDS);
+std::vector<std::unique_ptr<util::RNG>> cloneRNGsFrom(
+    RNG& _engine, size_t _numOutputs, size_t _numSeeds = NUM_DEFAULT_SEEDS);
+
+/// Deterministically create a random number generator of the same type as the
+/// input \c _engine. This is implemented by using \c _engine to generate \c
+/// _numSeeds seeds, then using \c std::seed_seq to generate an uncorrelated
+/// seed to create the output engine.
+///
+/// \param _engine random engine
+/// \param _numSeeds number of seeds to use for initialization
+/// \return new random number generators
+std::vector<std::unique_ptr<util::RNG>> cloneRNGFrom(
+    RNG& _engine, size_t _numSeeds = NUM_DEFAULT_SEEDS);
 
 } // namespace util
 } // namespace aikido

--- a/src/constraint/JointStateSpaceHelpers.cpp
+++ b/src/constraint/JointStateSpaceHelpers.cpp
@@ -136,7 +136,7 @@ std::unique_ptr<Sampleable> createSampleableBounds(
   const auto n = _metaSkeleton->getNumSubspaces();
 
   // Create a new RNG for each subspace.
-  auto engines = splitEngine(*_rng, n, util::NUM_DEFAULT_SEEDS);
+  auto engines = cloneRNGsFrom(*_rng, n, util::NUM_DEFAULT_SEEDS);
 
   std::vector<std::shared_ptr<Sampleable>> constraints;
   constraints.reserve(n);

--- a/src/util/RNG.cpp
+++ b/src/util/RNG.cpp
@@ -8,7 +8,7 @@ namespace util {
 constexpr std::size_t RNG::NUM_BITS;
 
 //=============================================================================
-std::vector<std::unique_ptr<util::RNG>> splitEngine(
+std::vector<std::unique_ptr<util::RNG>> cloneRNGsFrom(
     RNG& _engine, size_t _numOutputs, size_t _numSeeds)
 {
   // Use the input RNG to create an initial batch of seeds.
@@ -31,6 +31,13 @@ std::vector<std::unique_ptr<util::RNG>> splitEngine(
     output.emplace_back(_engine.clone(improvedSeed));
 
   return output;
+}
+
+//=============================================================================
+std::vector<std::unique_ptr<util::RNG>> cloneRNGFrom(
+    RNG& _engine, size_t _numSeeds)
+{
+  return cloneRNGsFrom(_engine, 1, _numSeeds);
 }
 
 } // namespace util


### PR DESCRIPTION
Resolves #187.

@mkoval is this what you meant? My initial thought was to have the two methods:
- `splitEngine(RNG& _engine, size_t _numOutputs, size_t _numSeeds = NUM_DEFAULT_SEEDS)` (already exists)
- `splitEngine(RNG& _engine, size_t _numSeeds = NUM_DEFAULT_SEEDS)` (call the former with `_numOutputs = 1`)

but this makes `splitEngine(RNG&, size_t)` ambiguous.