### PR TITLE
Fixes to work on real hardware

### DIFF
--- a/include/aikido/control/ros/RosTrajectoryExecutor.hpp
+++ b/include/aikido/control/ros/RosTrajectoryExecutor.hpp
@@ -40,11 +40,11 @@ public:
   virtual ~RosTrajectoryExecutor();
 
   /// Sends trajectory to ROS server for execution.
-  /// \param[in] traj Trajecotry to be executed.
+  /// \param[in] traj Trajectory to be executed.
   std::future<void> execute(trajectory::TrajectoryPtr traj) override;
 
   /// Sends trajectory to ROS server for execution.
-  /// \param[in] traj Trajectrory to be executed.
+  /// \param[in] traj Trajectory to be executed.
   /// \param[in] startTime Start time for the trajectory.
   std::future<void> execute(
       trajectory::TrajectoryPtr traj, const ::ros::Time& startTime);

--- a/src/control/ros/RosJointStateClient.cpp
+++ b/src/control/ros/RosJointStateClient.cpp
@@ -94,7 +94,7 @@ void RosJointStateClient::jointStateCallback(
         boost::circular_buffer<JointStateRecord>{mCapacity});
     auto& buffer = result.first->second;
 
-    if (_jointState.header.stamp < buffer.back().mStamp)
+    if (!buffer.empty() && _jointState.header.stamp < buffer.back().mStamp)
     {
       // Ignore out of order JointState message.
       ROS_WARN_STREAM(

--- a/src/control/ros/RosJointStateClient.cpp
+++ b/src/control/ros/RosJointStateClient.cpp
@@ -33,7 +33,7 @@ void RosJointStateClient::spin()
   std::lock_guard<std::mutex> skeletonLock{mSkeleton->getMutex()};
   std::lock_guard<std::mutex> bufferLock{mMutex};
 
-  mCallbackQueue.callAvailable();
+  mCallbackQueue.callAvailable(::ros::WallDuration(1.0));
 }
 
 //=============================================================================

--- a/src/control/ros/RosJointStateClient.cpp
+++ b/src/control/ros/RosJointStateClient.cpp
@@ -33,7 +33,7 @@ void RosJointStateClient::spin()
   std::lock_guard<std::mutex> skeletonLock{mSkeleton->getMutex()};
   std::lock_guard<std::mutex> bufferLock{mMutex};
 
-  mCallbackQueue.callAvailable(::ros::WallDuration(1.0));
+  mCallbackQueue.callAvailable();
 }
 
 //=============================================================================


### PR DESCRIPTION
Issues:

- [x] `RosJointStateClient::jointStateCallback` was incorrectly handling empty buffers. Messages were being ignored because the timestamp was being read from the last record in an empty buffer.
- [x] For some reason, `RosJointStateClient::spin` doesn't seem to be waiting long enough for callbacks to be placed on its queue. I've temporarily added a duration of 1 second here.
- [x] The future returned by `RosTrajectoryExecutor::execute` never seems to be fulfilled. Calling `future::wait` waits forever (even after the trajectory seems to be successfully executed). I have a temporary hack in `pantry_loading` that sleeps for the duration of the trajectory instead of calling `future::wait`, but that needs to be fixed.

  It seems that `RosTrajectoryExecutor::transitionCallback` is sometimes not being called at all. On other trajectories, it _is_ being called and `isSuccessful` is true (the resulting message is `"Execution failed"`, which seems like a [typo](https://github.com/personalrobotics/aikido/blob/427f7be13b5b65a87316a2e7c7109dd8a0b07a37/src/control/ros/RosTrajectoryExecutor.cpp#L178)?) and the promise's value seems to be set. In both cases, the future still doesn't seem to be fulfilled. I thought that calling `future::wait` would return once a value is set by `promise::set_value`, but I could be misunderstanding.

   When `RosTrajectoryExecutor::transitionCallback` is being called, it also seems that it is called with `handle.getCommState() == DONE` well before the trajectory actually terminates (basically immediately). Is this expected behavior?
- [x] ~Calling `future::wait` on the future returned by `RosPositionCommandExecutor` results in the error message: `Exception thrown by callback: Promise already satisfied`.~

  This was because I forgot to start `right_hand_controller` 😓 Now the communication state is stuck at `ACTIVE` forever...