### PR TITLE
Fix ResourceServer::resourceReaderCallback types.

### DIFF
--- a/include/aikido/rviz/ResourceServer.hpp
+++ b/include/aikido/rviz/ResourceServer.hpp
@@ -84,8 +84,10 @@ private:
       unsigned int code,
       const std::string& message);
 
-  static std::size_t resourceReaderCallback(
-      void* cls, uint64_t pos, char* buf, std::size_t max);
+  // This must match MHD_ContentReaderCallback (i.e. ssize_t and size_t rather
+  // than std::size_t).
+  static ssize_t resourceReaderCallback(
+      void* cls, uint64_t pos, char* buf, size_t max);
 
   static void resourceReaderFreeCallback(void* cls);
 

--- a/src/rviz/ResourceServer.cpp
+++ b/src/rviz/ResourceServer.cpp
@@ -299,8 +299,8 @@ int ResourceServer::queueHttpError(
 }
 
 //==============================================================================
-std::size_t ResourceServer::resourceReaderCallback(
-    void* cls, uint64_t pos, char* buf, std::size_t max)
+ssize_t ResourceServer::resourceReaderCallback(
+    void* cls, uint64_t pos, char* buf, size_t max)
 {
   auto resourceRequest = reinterpret_cast<ResourceRequest*>(cls);
 


### PR DESCRIPTION
Resolves #233. I don't know why this passed through Travis.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
