### PR TITLE
remove compile warning

### DIFF
--- a/include/aikido/statespace/dart/detail/MetaSkeletonStateSpaceSaver-impl.hpp
+++ b/include/aikido/statespace/dart/detail/MetaSkeletonStateSpaceSaver-impl.hpp
@@ -13,17 +13,20 @@ MetaSkeletonStateSpaceSaver::MetaSkeletonStateSpaceSaver(
 
 MetaSkeletonStateSpaceSaver::~MetaSkeletonStateSpaceSaver()
 {
-  if (mPositions.size() != mSpace->getMetaSkeleton()->getNumDofs())
+  if (static_cast<std::size_t>(mPositions.size())
+      != mSpace->getMetaSkeleton()->getNumDofs())
   {
     std::cerr << "[MetaSkeletonStateSpaceSaver] The number of DOFs in the "
               << "MetaSkeleton does not match the saved position.";
   }
-  if (mPositionLowerLimits.size() != mSpace->getMetaSkeleton()->getNumDofs())
+  if (static_cast<std::size_t>(mPositionLowerLimits.size())
+      != mSpace->getMetaSkeleton()->getNumDofs())
   {
     std::cerr << "[MetaSkeletonStateSpaceSaver] The number of DOFs in the "
               << "MetaSkeleton does not match the saved joint lower limits.";
   }
-  if (mPositionUpperLimits.size() != mSpace->getMetaSkeleton()->getNumDofs())
+  if (static_cast<std::size_t>(mPositionUpperLimits.size())
+      != mSpace->getMetaSkeleton()->getNumDofs())
   {
     std::cerr << "[MetaSkeletonStateSpaceSaver] The number of DOFs in the "
               << "MetaSkeleton does not match the saved joint upper limits.";


### PR DESCRIPTION
Remove compile warning in `MetaSkeletonStateSaver`, which is introduced in adding new functions.
#185 

***

**Before creating a pull request**

- [x] Document new methods and classes (N/A)
- [x] Format code with `make format` 

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`(N/A)
- [x] Add unit test(s) for this change(N/A)
