### PR TITLE
Add WorldInteractiveMarkerViewer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
   * Added World class: [#243](https://github.com/personalrobotics/aikido/pull/243)
 
+* RViz
+
+  * Added WorldInteractiveMarkerViewer: [#242](https://github.com/personalrobotics/aikido/pull/242)
+
 * Build & Testing & ETC
 
   * Changed to use size_t over std::size_t: [#230](https://github.com/personalrobotics/aikido/pull/230)

--- a/include/aikido/perception/AprilTagsModule.hpp
+++ b/include/aikido/perception/AprilTagsModule.hpp
@@ -53,7 +53,7 @@ public:
 
   // Documentation inherited
   bool detectObjects(
-      const dart::simulation::WorldPtr& env,
+      const aikido::planner::WorldPtr& env,
       ros::Duration timeout = ros::Duration(0.0),
       ros::Time timestamp = ros::Time(0.0)) override;
 

--- a/include/aikido/perception/PerceptionModule.hpp
+++ b/include/aikido/perception/PerceptionModule.hpp
@@ -1,6 +1,8 @@
 #ifndef AIKIDO_PERCEPTION_PERCEPTIONMODULE_HPP_
 #define AIKIDO_PERCEPTION_PERCEPTIONMODULE_HPP_
 
+#include <aikido/planner/World.hpp>
+
 namespace aikido {
 namespace perception {
 
@@ -29,7 +31,7 @@ public:
   /// detections has a more recent timestamp than the parameter. Returns \c true
   /// otherwise.
   virtual bool detectObjects(
-      const dart::simulation::WorldPtr& env,
+      const aikido::planner::WorldPtr& env,
       ros::Duration timeout,
       ros::Time timestamp)
       = 0;

--- a/include/aikido/rviz.hpp
+++ b/include/aikido/rviz.hpp
@@ -6,4 +6,5 @@
 #include "rviz/SkeletonMarker.hpp"
 #include "rviz/SmartPointers.hpp"
 #include "rviz/TSRMarker.hpp"
+#include "rviz/WorldInteractiveMarkerViewer.hpp"
 #include "rviz/shape_conversions.hpp"

--- a/include/aikido/rviz/InteractiveMarkerViewer.hpp
+++ b/include/aikido/rviz/InteractiveMarkerViewer.hpp
@@ -57,7 +57,6 @@ public:
 private:
   void autoUpdate();
 
-  ros::NodeHandle mNodeHandle;
   interactive_markers::InteractiveMarkerServer mMarkerServer;
   std::set<SkeletonMarkerPtr> mSkeletonMarkers;
   std::set<FrameMarkerPtr> mFrameMarkers;

--- a/include/aikido/rviz/InteractiveMarkerViewer.hpp
+++ b/include/aikido/rviz/InteractiveMarkerViewer.hpp
@@ -54,7 +54,7 @@ public:
   void setAutoUpdate(bool flag);
   void update();
 
-private:
+protected:
   void autoUpdate();
 
   interactive_markers::InteractiveMarkerServer mMarkerServer;

--- a/include/aikido/rviz/WorldInteractiveMarkerViewer.hpp
+++ b/include/aikido/rviz/WorldInteractiveMarkerViewer.hpp
@@ -12,6 +12,10 @@ namespace rviz {
 class WorldInteractiveMarkerViewer : public InteractiveMarkerViewer
 {
 public:
+  /// Create an InteractiveMarkerViewer that reflects skeletons in a World.
+  /// \param env World to update viewer with
+  /// \param topicNamespace ROS topic to publish marker updates to
+  /// \param frameId Base frame name
   WorldInteractiveMarkerViewer(
       aikido::planner::WorldPtr env,
       const std::string& topicNamespace,
@@ -23,13 +27,21 @@ public:
   WorldInteractiveMarkerViewer& operator=(const WorldInteractiveMarkerViewer&)
       = delete;
 
+  /// Set viewer auto-updating
+  /// \param flag Whether to auto-update the viewer
   void setAutoUpdate(bool flag);
+
+  /// Update viewer with Skeletons from the World
   void update();
 
 protected:
+  /// Thread target for auto-updating the viewer
   void autoUpdate();
 
+  /// Mapping of Skeleton names to SkeletonMarkers
   std::map<std::string, SkeletonMarkerPtr> mSkeletonMarkers;
+
+  /// World that automatically updates the viewer
   aikido::planner::WorldPtr mWorld;
 };
 

--- a/include/aikido/rviz/WorldInteractiveMarkerViewer.hpp
+++ b/include/aikido/rviz/WorldInteractiveMarkerViewer.hpp
@@ -1,0 +1,39 @@
+#ifndef AIKIDO_RVIZ_WORLDINTERACTIVEMARKERVIEWER_HPP_
+#define AIKIDO_RVIZ_WORLDINTERACTIVEMARKERVIEWER_HPP_
+
+#include <map>
+#include <dart/simulation/World.hpp>
+#include <aikido/rviz/InteractiveMarkerViewer.hpp>
+#include <aikido/rviz/SmartPointers.hpp>
+
+namespace aikido {
+namespace rviz {
+
+class WorldInteractiveMarkerViewer : public InteractiveMarkerViewer
+{
+public:
+  WorldInteractiveMarkerViewer(
+      dart::simulation::WorldPtr env,
+      const std::string& topicNamespace,
+      const std::string& frameId);
+  virtual ~WorldInteractiveMarkerViewer();
+
+  WorldInteractiveMarkerViewer(const WorldInteractiveMarkerViewer&) = delete;
+  WorldInteractiveMarkerViewer(const WorldInteractiveMarkerViewer&&) = delete;
+  WorldInteractiveMarkerViewer& operator=(const WorldInteractiveMarkerViewer&)
+      = delete;
+
+  void setAutoUpdate(bool flag);
+  void update();
+
+protected:
+  void autoUpdate();
+
+  std::map<std::string, SkeletonMarkerPtr> mSkeletonMarkers;
+  dart::simulation::WorldPtr mWorld;
+};
+
+} // namespace rviz
+} // namespace aikido
+
+#endif

--- a/include/aikido/rviz/WorldInteractiveMarkerViewer.hpp
+++ b/include/aikido/rviz/WorldInteractiveMarkerViewer.hpp
@@ -2,7 +2,7 @@
 #define AIKIDO_RVIZ_WORLDINTERACTIVEMARKERVIEWER_HPP_
 
 #include <map>
-#include <dart/simulation/World.hpp>
+#include <aikido/planner/World.hpp>
 #include <aikido/rviz/InteractiveMarkerViewer.hpp>
 #include <aikido/rviz/SmartPointers.hpp>
 
@@ -13,7 +13,7 @@ class WorldInteractiveMarkerViewer : public InteractiveMarkerViewer
 {
 public:
   WorldInteractiveMarkerViewer(
-      dart::simulation::WorldPtr env,
+      aikido::planner::WorldPtr env,
       const std::string& topicNamespace,
       const std::string& frameId);
   virtual ~WorldInteractiveMarkerViewer();
@@ -30,7 +30,7 @@ protected:
   void autoUpdate();
 
   std::map<std::string, SkeletonMarkerPtr> mSkeletonMarkers;
-  dart::simulation::WorldPtr mWorld;
+  aikido::planner::WorldPtr mWorld;
 };
 
 } // namespace rviz

--- a/src/perception/AprilTagsModule.cpp
+++ b/src/perception/AprilTagsModule.cpp
@@ -39,7 +39,7 @@ AprilTagsModule::AprilTagsModule(
 
 //==============================================================================
 bool AprilTagsModule::detectObjects(
-    const dart::simulation::WorldPtr& env,
+    const aikido::planner::WorldPtr& env,
     ros::Duration timeout,
     ros::Time timestamp)
 {

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -33,6 +33,7 @@ set(sources
   SkeletonMarker.cpp
   shape_conversions.cpp
   TSRMarker.cpp
+  WorldInteractiveMarkerViewer.cpp
 )
 
 add_library("${PROJECT_NAME}_rviz" SHARED ${sources})

--- a/src/rviz/FrameMarker.cpp
+++ b/src/rviz/FrameMarker.cpp
@@ -74,7 +74,7 @@ FrameMarker::FrameMarker(
   CreateAxis(Eigen::Vector3d::UnitZ(), length, thickness, &control.markers[2]);
   control.markers[0].color = makeColorRGBA(1, 0, 0, alpha);
   control.markers[1].color = makeColorRGBA(0, 1, 0, alpha);
-  control.markers[2].color = makeColorRGBA(0, 0, 3, alpha);
+  control.markers[2].color = makeColorRGBA(0, 0, 1, alpha);
 
   mMarkerServer->insert(mInteractiveMarker);
   update();

--- a/src/rviz/WorldInteractiveMarkerViewer.cpp
+++ b/src/rviz/WorldInteractiveMarkerViewer.cpp
@@ -1,0 +1,99 @@
+#include <dart/dart.hpp>
+#include <aikido/rviz/FrameMarker.hpp>
+#include <aikido/rviz/InteractiveMarkerViewer.hpp>
+#include <aikido/rviz/SkeletonMarker.hpp>
+#include <aikido/rviz/WorldInteractiveMarkerViewer.hpp>
+
+using dart::dynamics::SkeletonPtr;
+using aikido::rviz::InteractiveMarkerViewer;
+
+namespace aikido {
+namespace rviz {
+
+//==============================================================================
+WorldInteractiveMarkerViewer::WorldInteractiveMarkerViewer(
+    dart::simulation::WorldPtr env,
+    const std::string& topicNamespace,
+    const std::string& frameId)
+  : InteractiveMarkerViewer(topicNamespace, frameId), mWorld(std::move(env))
+{
+  // Do nothing
+}
+
+//==============================================================================
+WorldInteractiveMarkerViewer::~WorldInteractiveMarkerViewer()
+{
+  // Do nothing
+}
+
+//==============================================================================
+void WorldInteractiveMarkerViewer::setAutoUpdate(bool flag)
+{
+  mUpdating.store(flag, std::memory_order_release);
+
+  const bool isRunning = mRunning.exchange(flag);
+  if (flag && !isRunning)
+    mThread = std::thread(&WorldInteractiveMarkerViewer::autoUpdate, this);
+}
+
+//==============================================================================
+void WorldInteractiveMarkerViewer::autoUpdate()
+{
+  ros::Rate rate(30);
+
+  while (mRunning.load() && ros::ok())
+  {
+    update();
+    rate.sleep();
+  }
+
+  mRunning.store(false);
+}
+
+//==============================================================================
+void WorldInteractiveMarkerViewer::update()
+{
+  std::lock_guard<std::mutex> lock(mMutex);
+
+  // Update SkeletonMarkers
+  for (std::size_t i = 0; i < mWorld->getNumSkeletons(); ++i)
+  {
+    const dart::dynamics::SkeletonPtr skeleton = mWorld->getSkeleton(i);
+
+    if (skeleton)
+    {
+      // Either a new SkeletonMarker or a previously-inserted SkeletonMarker
+      auto result = mSkeletonMarkers.emplace(
+          skeleton->getName(), CreateSkeletonMarker(skeleton, mFrameId));
+
+      std::unique_lock<std::mutex> lock(skeleton->getMutex(), std::try_to_lock);
+      if (lock.owns_lock())
+        result.first->second->update();
+    }
+  }
+
+  // Clear removed skeletons
+  auto it = std::begin(mSkeletonMarkers);
+  while (it != std::end(mSkeletonMarkers))
+  {
+    // Skeleton still exists in the World, do nothing.
+    if (mWorld->getSkeleton(it->first))
+    {
+      ++it;
+    }
+    // Skeleton does not exist. Delete our existing ShapeFrameMarker.
+    else
+    {
+      it = mSkeletonMarkers.erase(it);
+    }
+  }
+
+  // TODO: Merge this into a unified update loop.
+  for (const FrameMarkerPtr& marker : mFrameMarkers)
+    marker->update();
+
+  mMarkerServer.applyChanges();
+}
+
+} // namespace rviz
+} // namespace aikido

--- a/src/rviz/WorldInteractiveMarkerViewer.cpp
+++ b/src/rviz/WorldInteractiveMarkerViewer.cpp
@@ -4,7 +4,6 @@
 #include <aikido/rviz/SkeletonMarker.hpp>
 #include <aikido/rviz/WorldInteractiveMarkerViewer.hpp>
 
-using dart::dynamics::SkeletonPtr;
 using aikido::rviz::InteractiveMarkerViewer;
 
 namespace aikido {
@@ -12,7 +11,7 @@ namespace rviz {
 
 //==============================================================================
 WorldInteractiveMarkerViewer::WorldInteractiveMarkerViewer(
-    dart::simulation::WorldPtr env,
+    aikido::planner::WorldPtr env,
     const std::string& topicNamespace,
     const std::string& frameId)
   : InteractiveMarkerViewer(topicNamespace, frameId), mWorld(std::move(env))


### PR DESCRIPTION
This subclasses `aikido::rviz::InteractiveMarkerViewer` to create a viewer for a `dart::simulation::World`. This would automatically update the viewer as skeletons are added to the `World`, which is a first step toward using them properly in all of our demo scripts.

@psigen mentioned that `dart::simulation::World` has some additional overhead if we aren't doing things with dynamics. I'm using `World` for now for lack of something better in DART, but we should seriously think about a better longer-term solution.

Other issues:
- [x] There doesn't seem to be a mutex associated with `World`s, so there might be some thread-safety issues here?
- [x] Cloning a `World` doesn't replicate the transforms or the joint states. [This line](https://github.com/dartsim/dart/blob/master/dart/simulation/World.hpp#L94) in DART suggests that this is still a TODO...

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
