### PR TITLE
Initial implementation of kinematic World

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### 0.2.0 (201X-XX-XX)
 
+* Planner
+
+  * Added World class: [#243](https://github.com/personalrobotics/aikido/pull/243)
+
 * Build & Testing & ETC
 
   * Changed to use size_t over std::size_t: [#230](https://github.com/personalrobotics/aikido/pull/230)

--- a/include/aikido/planner.hpp
+++ b/include/aikido/planner.hpp
@@ -1,5 +1,6 @@
 #include "planner/PlanningResult.hpp"
 #include "planner/SnapPlanner.hpp"
+#include "planner/World.hpp"
 #include "planner/ompl/BackwardCompatibility.hpp"
 #include "planner/ompl/CRRT.hpp"
 #include "planner/ompl/CRRTConnect.hpp"

--- a/include/aikido/planner/World.hpp
+++ b/include/aikido/planner/World.hpp
@@ -11,41 +11,48 @@ class World
 {
 public:
   /// Construct a kinematic World.
+  /// \param name Name for the new World
   World(const std::string& name = "");
 
   virtual ~World();
+
+  /// Create a new World inside of a shared_ptr
+  /// \param name Name for the new World
+  static std::shared_ptr<World> create(const std::string& name = "");
 
   /// Create a clone of this World. All Skeletons will be copied over.
   /// \param newName Name for the cloned World
   std::shared_ptr<World> clone(const std::string& newName = "") const;
 
-  /// Create a new World inside of a shared_ptr
-  static std::shared_ptr<World> create(const std::string& name = "");
-
   /// Set the name of this World
+  /// \param newName New name for this World
   std::string setName(const std::string& newName);
 
   /// Get the name of this World
   const std::string& getName() const;
 
   /// Find a Skeleton by index
+  /// \param i Index of desired Skeleton
   dart::dynamics::SkeletonPtr getSkeleton(std::size_t i) const;
 
   /// Find a Skeleton by name
+  /// \param name Name of desired Skeleton
   dart::dynamics::SkeletonPtr getSkeleton(const std::string& name) const;
 
   /// Get the number of Skeletons
   std::size_t getNumSkeletons() const;
 
   /// Add a Skeleton to this World
+  /// \param skeleton Skeleton to add to the World
   std::string addSkeleton(const dart::dynamics::SkeletonPtr& skeleton);
 
   /// Remove a Skeleton from this World
+  /// \param skeleton Skeleton to remove from the World
   void removeSkeleton(const dart::dynamics::SkeletonPtr& skeleton);
 
   // TODO: Add methods for registering callbacks?
 
-  // Get the mutex that protects the state of this World.
+  /// Get the mutex that protects the state of this World.
   std::mutex& getMutex() const;
 
 protected:
@@ -55,6 +62,7 @@ protected:
   /// Skeletons in this World
   std::vector<dart::dynamics::SkeletonPtr> mSkeletons;
 
+  /// Mutex to protect this World
   mutable std::mutex mMutex;
 
   /// NameManager for keeping track of Worlds

--- a/include/aikido/planner/World.hpp
+++ b/include/aikido/planner/World.hpp
@@ -16,7 +16,8 @@ public:
   virtual ~World() = default;
 
   /// Create a clone of this World. All Skeletons will be copied over.
-  std::shared_ptr<World> clone(const std::string& name) const;
+  /// \param newName Name for the cloned World
+  std::shared_ptr<World> clone(const std::string& newName) const;
 
   /// Create a clone of this World with the same name.
   std::shared_ptr<World> clone() const;

--- a/include/aikido/planner/World.hpp
+++ b/include/aikido/planner/World.hpp
@@ -23,7 +23,7 @@ public:
   std::shared_ptr<World> clone() const;
 
   /// Set the name of this World
-  const std::string& setName(const std::string& newName);
+  void setName(const std::string& newName);
 
   /// Get the name of this World
   const std::string& getName() const;

--- a/include/aikido/planner/World.hpp
+++ b/include/aikido/planner/World.hpp
@@ -18,11 +18,11 @@ public:
 
   /// Create a new World inside of a shared_ptr
   /// \param name Name for the new World
-  static std::shared_ptr<World> create(const std::string& name = "");
+  static std::unique_ptr<World> create(const std::string& name = "");
 
   /// Create a clone of this World. All Skeletons will be copied over.
   /// \param newName Name for the cloned World
-  std::shared_ptr<World> clone(const std::string& newName = "") const;
+  std::unique_ptr<World> clone(const std::string& newName = "") const;
 
   /// Set the name of this World
   /// \param newName New name for this World
@@ -66,13 +66,13 @@ protected:
   mutable std::mutex mMutex;
 
   /// NameManager for keeping track of Worlds
-  static dart::common::NameManager<World*> worldNameManager;
+  static dart::common::NameManager<World*> mWorldNameManager;
 
   /// NameManager for keeping track of Skeletons
   dart::common::NameManager<dart::dynamics::SkeletonPtr> mSkeletonNameManager;
 };
 
-typedef std::shared_ptr<World> WorldPtr;
+using WorldPtr = std::shared_ptr<World>;
 
 } // namespace planner
 } // namespace aikido

--- a/include/aikido/planner/World.hpp
+++ b/include/aikido/planner/World.hpp
@@ -22,6 +22,9 @@ public:
   /// Create a clone of this World with the same name.
   std::shared_ptr<World> clone() const;
 
+  /// Create a new World inside of a shared_ptr
+  static std::shared_ptr<World> create(const std::string& name);
+
   /// Set the name of this World
   void setName(const std::string& newName);
 

--- a/include/aikido/planner/World.hpp
+++ b/include/aikido/planner/World.hpp
@@ -11,22 +11,19 @@ class World
 {
 public:
   /// Construct a kinematic World.
-  World(const std::string& name);
+  World(const std::string& name = "");
 
-  virtual ~World() = default;
+  virtual ~World();
 
   /// Create a clone of this World. All Skeletons will be copied over.
   /// \param newName Name for the cloned World
-  std::shared_ptr<World> clone(const std::string& newName) const;
-
-  /// Create a clone of this World with the same name.
-  std::shared_ptr<World> clone() const;
+  std::shared_ptr<World> clone(const std::string& newName = "") const;
 
   /// Create a new World inside of a shared_ptr
-  static std::shared_ptr<World> create(const std::string& name);
+  static std::shared_ptr<World> create(const std::string& name = "");
 
   /// Set the name of this World
-  void setName(const std::string& newName);
+  std::string setName(const std::string& newName);
 
   /// Get the name of this World
   const std::string& getName() const;
@@ -59,6 +56,12 @@ protected:
   std::vector<dart::dynamics::SkeletonPtr> mSkeletons;
 
   mutable std::mutex mMutex;
+
+  /// NameManager for keeping track of Worlds
+  static dart::common::NameManager<World*> worldNameManager;
+
+  /// NameManager for keeping track of Skeletons
+  dart::common::NameManager<dart::dynamics::SkeletonPtr> mSkeletonNameManager;
 };
 
 typedef std::shared_ptr<World> WorldPtr;

--- a/include/aikido/planner/World.hpp
+++ b/include/aikido/planner/World.hpp
@@ -1,0 +1,65 @@
+#ifndef AIKIDO_PLANNER_WORLD_HPP_
+#define AIKIDO_PLANNER_WORLD_HPP_
+
+#include <string>
+#include <dart/dart.hpp>
+
+namespace aikido {
+namespace planner {
+
+class World
+{
+public:
+  /// Construct a kinematic World.
+  World(const std::string& name);
+
+  virtual ~World() = default;
+
+  /// Create a clone of this World. All Skeletons will be copied over.
+  std::shared_ptr<World> clone(const std::string& name) const;
+
+  /// Create a clone of this World with the same name.
+  std::shared_ptr<World> clone() const;
+
+  /// Set the name of this World
+  const std::string& setName(const std::string& newName);
+
+  /// Get the name of this World
+  const std::string& getName() const;
+
+  /// Find a Skeleton by index
+  dart::dynamics::SkeletonPtr getSkeleton(std::size_t i) const;
+
+  /// Find a Skeleton by name
+  dart::dynamics::SkeletonPtr getSkeleton(const std::string& name) const;
+
+  /// Get the number of Skeletons
+  std::size_t getNumSkeletons() const;
+
+  /// Add a Skeleton to this World
+  std::string addSkeleton(const dart::dynamics::SkeletonPtr& skeleton);
+
+  /// Remove a Skeleton from this World
+  void removeSkeleton(const dart::dynamics::SkeletonPtr& skeleton);
+
+  // TODO: Add methods for registering callbacks?
+
+  // Get the mutex that protects the state of this World.
+  std::mutex& getMutex() const;
+
+protected:
+  /// Name of this World
+  std::string mName;
+
+  /// Skeletons in this World
+  std::vector<dart::dynamics::SkeletonPtr> mSkeletons;
+
+  mutable std::mutex mMutex;
+};
+
+typedef std::shared_ptr<World> WorldPtr;
+
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_WORLD_HPP_

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -1,4 +1,6 @@
-set(sources SnapPlanner.cpp)
+set(sources
+  SnapPlanner.cpp
+  World.cpp)
 
 add_library("${PROJECT_NAME}_planner" SHARED ${sources})
 target_link_libraries("${PROJECT_NAME}_planner"

--- a/src/planner/World.cpp
+++ b/src/planner/World.cpp
@@ -1,0 +1,134 @@
+#include <aikido/planner/World.hpp>
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+World::World(const std::string& name) : mName(name)
+{
+  // Do nothing
+}
+
+//==============================================================================
+WorldPtr World::clone(const std::string& newName) const
+{
+  WorldPtr worldClone(new World(newName));
+
+  // Clone and add each Skeleton
+  worldClone->mSkeletons.reserve(mSkeletons.size());
+  for (std::size_t i = 0; i < mSkeletons.size(); ++i)
+  {
+    const auto clonedSkeleton = mSkeletons[i]->clone();
+    clonedSkeleton->setConfiguration(mSkeletons[i]->getConfiguration());
+    worldClone->addSkeleton(std::move(clonedSkeleton));
+  }
+
+  return worldClone;
+}
+
+//==============================================================================
+WorldPtr World::clone() const
+{
+  return clone(mName);
+}
+
+//==============================================================================
+const std::string& World::setName(const std::string& newName)
+{
+  mName = newName;
+  return mName;
+}
+
+//==============================================================================
+const std::string& World::getName() const
+{
+  return mName;
+}
+
+//==============================================================================
+dart::dynamics::SkeletonPtr World::getSkeleton(std::size_t i) const
+{
+  if (i < mSkeletons.size())
+    return mSkeletons[i];
+
+  return nullptr;
+}
+
+//==============================================================================
+dart::dynamics::SkeletonPtr World::getSkeleton(const std::string& name) const
+{
+  for (const auto& skeleton : mSkeletons)
+    if (skeleton->getName() == name)
+      return skeleton;
+
+  return nullptr;
+}
+
+//==============================================================================
+std::size_t World::getNumSkeletons() const
+{
+  return mSkeletons.size();
+}
+
+//==============================================================================
+std::string World::addSkeleton(const dart::dynamics::SkeletonPtr& skeleton)
+{
+  std::lock_guard<std::mutex> lock(mMutex);
+
+  if (!skeleton)
+  {
+    std::cout << "[World::addSkeleton] Attempting to add a nullptr Skeleton to "
+              << "the world!" << std::endl;
+    return "";
+  }
+
+  // If mSkeletons already has skeleton, then do nothing.
+  if (std::find(mSkeletons.begin(), mSkeletons.end(), skeleton)
+      != mSkeletons.end())
+  {
+    std::cout << "[World::addSkeleton] Skeleton named [" << skeleton->getName()
+              << "] is already in the world." << std::endl;
+    return skeleton->getName();
+  }
+
+  mSkeletons.push_back(skeleton);
+
+  // TODO: handle name conflicts
+  // dart::simulation::World uses dart::common::NameManager
+
+  return skeleton->getName();
+}
+
+//==============================================================================
+void World::removeSkeleton(const dart::dynamics::SkeletonPtr& skeleton)
+{
+  std::lock_guard<std::mutex> lock(mMutex);
+
+  if (!skeleton)
+  {
+    std::cout << "[World::removeSkeleton] Attempting to remove a nullptr "
+              << "Skeleton from the world!" << std::endl;
+    return;
+  }
+
+  // If mSkeletons doesn't have skeleton, then do nothing.
+  auto skelIt = std::find(mSkeletons.begin(), mSkeletons.end(), skeleton);
+  if (skelIt == mSkeletons.end())
+  {
+    std::cout << "[World::removeSkeleton] Skeleton [" << skeleton->getName()
+              << "] is not in the world." << std::endl;
+    return;
+  }
+
+  // Remove skeleton from mSkeletons
+  mSkeletons.erase(skelIt);
+}
+
+//==============================================================================
+std::mutex& World::getMutex() const
+{
+  return mMutex;
+}
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/World.cpp
+++ b/src/planner/World.cpp
@@ -21,6 +21,13 @@ World::~World()
 }
 
 //==============================================================================
+WorldPtr World::create(const std::string& name)
+{
+  WorldPtr world(new World(name));
+  return world;
+}
+
+//==============================================================================
 WorldPtr World::clone(const std::string& newName) const
 {
   WorldPtr worldClone(new World(newName.empty() ? mName : newName));
@@ -35,13 +42,6 @@ WorldPtr World::clone(const std::string& newName) const
   }
 
   return worldClone;
-}
-
-//==============================================================================
-WorldPtr World::create(const std::string& name)
-{
-  WorldPtr world(new World(name));
-  return world;
 }
 
 //==============================================================================

--- a/src/planner/World.cpp
+++ b/src/planner/World.cpp
@@ -58,8 +58,10 @@ dart::dynamics::SkeletonPtr World::getSkeleton(std::size_t i) const
 dart::dynamics::SkeletonPtr World::getSkeleton(const std::string& name) const
 {
   for (const auto& skeleton : mSkeletons)
+  {
     if (skeleton->getName() == name)
       return skeleton;
+  }
 
   return nullptr;
 }
@@ -73,14 +75,14 @@ std::size_t World::getNumSkeletons() const
 //==============================================================================
 std::string World::addSkeleton(const dart::dynamics::SkeletonPtr& skeleton)
 {
-  std::lock_guard<std::mutex> lock(mMutex);
-
   if (!skeleton)
   {
     std::cout << "[World::addSkeleton] Attempting to add a nullptr Skeleton to "
               << "the world!" << std::endl;
     return "";
   }
+
+  std::lock_guard<std::mutex> lock(mMutex);
 
   // If mSkeletons already has skeleton, then do nothing.
   if (std::find(mSkeletons.begin(), mSkeletons.end(), skeleton)
@@ -102,14 +104,14 @@ std::string World::addSkeleton(const dart::dynamics::SkeletonPtr& skeleton)
 //==============================================================================
 void World::removeSkeleton(const dart::dynamics::SkeletonPtr& skeleton)
 {
-  std::lock_guard<std::mutex> lock(mMutex);
-
   if (!skeleton)
   {
     std::cout << "[World::removeSkeleton] Attempting to remove a nullptr "
               << "Skeleton from the world!" << std::endl;
     return;
   }
+
+  std::lock_guard<std::mutex> lock(mMutex);
 
   // If mSkeletons doesn't have skeleton, then do nothing.
   auto skelIt = std::find(mSkeletons.begin(), mSkeletons.end(), skeleton);

--- a/src/planner/World.cpp
+++ b/src/planner/World.cpp
@@ -33,10 +33,9 @@ WorldPtr World::clone() const
 }
 
 //==============================================================================
-const std::string& World::setName(const std::string& newName)
+void World::setName(const std::string& newName)
 {
   mName = newName;
-  return mName;
 }
 
 //==============================================================================

--- a/src/planner/World.cpp
+++ b/src/planner/World.cpp
@@ -3,7 +3,7 @@
 namespace aikido {
 namespace planner {
 
-dart::common::NameManager<World*> World::worldNameManager{"World", "world"};
+dart::common::NameManager<World*> World::mWorldNameManager{"World", "world"};
 
 //==============================================================================
 World::World(const std::string& name)
@@ -17,20 +17,20 @@ World::World(const std::string& name)
 //==============================================================================
 World::~World()
 {
-  World::worldNameManager.removeName(mName);
+  World::mWorldNameManager.removeName(mName);
 }
 
 //==============================================================================
-WorldPtr World::create(const std::string& name)
+std::unique_ptr<World> World::create(const std::string& name)
 {
-  WorldPtr world(new World(name));
+  std::unique_ptr<World> world(new World(name));
   return world;
 }
 
 //==============================================================================
-WorldPtr World::clone(const std::string& newName) const
+std::unique_ptr<World> World::clone(const std::string& newName) const
 {
-  WorldPtr worldClone(new World(newName.empty() ? mName : newName));
+  std::unique_ptr<World> worldClone(new World(newName.empty() ? mName : newName));
 
   // Clone and add each Skeleton
   worldClone->mSkeletons.reserve(mSkeletons.size());
@@ -48,9 +48,9 @@ WorldPtr World::clone(const std::string& newName) const
 std::string World::setName(const std::string& newName)
 {
   if (mName.empty())
-    mName = World::worldNameManager.issueNewNameAndAdd(newName, this);
+    mName = World::mWorldNameManager.issueNewNameAndAdd(newName, this);
   else
-    mName = World::worldNameManager.changeObjectName(this, newName);
+    mName = World::mWorldNameManager.changeObjectName(this, newName);
   return mName;
 }
 

--- a/src/planner/World.cpp
+++ b/src/planner/World.cpp
@@ -33,6 +33,13 @@ WorldPtr World::clone() const
 }
 
 //==============================================================================
+WorldPtr World::create(const std::string& name)
+{
+  WorldPtr world(new World(name));
+  return world;
+}
+
+//==============================================================================
 void World::setName(const std::string& newName)
 {
   mName = newName;

--- a/tests/planner/CMakeLists.txt
+++ b/tests/planner/CMakeLists.txt
@@ -7,3 +7,7 @@ target_link_libraries(test_SnapPlanner
   "${PROJECT_NAME}_distance"
   "${PROJECT_NAME}_trajectory"
   "${PROJECT_NAME}_planner")
+
+aikido_add_test(test_World test_World.cpp)
+target_link_libraries(test_World
+  "${PROJECT_NAME}_planner")

--- a/tests/planner/test_World.cpp
+++ b/tests/planner/test_World.cpp
@@ -14,8 +14,8 @@ public:
     : skel1{dart::dynamics::Skeleton::create("skel1")}
     , skel2{dart::dynamics::Skeleton::create("skel2")}
     , skel3{dart::dynamics::Skeleton::create("skel3")}
+    , mWorld{aikido::planner::World::create("test")}
   {
-    mWorld = std::make_shared<aikido::planner::World>("test");
   }
 
   // DART setup

--- a/tests/planner/test_World.cpp
+++ b/tests/planner/test_World.cpp
@@ -69,7 +69,7 @@ TEST_F(WorldTest, CloningPreservesSkeletonNamesAndConfigurations)
   mWorld->addSkeleton(skel3);
 
   auto clone1 = mWorld->clone();
-  EXPECT_EQ(mWorld->getName(), clone1->getName());
+  EXPECT_NE(mWorld->getName(), clone1->getName());
 
   auto clone2 = clone1->clone("clone2");
   EXPECT_EQ("clone2", clone2->getName());

--- a/tests/planner/test_World.cpp
+++ b/tests/planner/test_World.cpp
@@ -1,0 +1,93 @@
+#include <dart/dart.hpp>
+#include <gtest/gtest.h>
+#include <aikido/planner/World.hpp>
+
+using std::shared_ptr;
+using std::make_shared;
+
+class WorldTest : public ::testing::Test
+{
+public:
+  using SkeletonPtr = dart::dynamics::SkeletonPtr;
+
+  WorldTest()
+    : skel1{dart::dynamics::Skeleton::create("skel1")}
+    , skel2{dart::dynamics::Skeleton::create("skel2")}
+    , skel3{dart::dynamics::Skeleton::create("skel3")}
+  {
+    mWorld = std::make_shared<aikido::planner::World>("test");
+  }
+
+  // DART setup
+  SkeletonPtr skel1, skel2, skel3;
+  aikido::planner::WorldPtr mWorld;
+};
+
+TEST_F(WorldTest, NameTest)
+{
+  EXPECT_EQ("test", mWorld->getName());
+  mWorld->setName("different");
+  EXPECT_EQ("different", mWorld->getName());
+}
+
+TEST_F(WorldTest, AddGetRemoveSkeletons)
+{
+  // Add Skeletons
+  EXPECT_EQ(0, mWorld->getNumSkeletons());
+  mWorld->addSkeleton(skel1);
+  EXPECT_EQ(1, mWorld->getNumSkeletons());
+  mWorld->addSkeleton(skel1);
+  EXPECT_EQ(1, mWorld->getNumSkeletons());
+  mWorld->addSkeleton(skel2);
+  EXPECT_EQ(2, mWorld->getNumSkeletons());
+
+  // Getting Skeletons by index
+  EXPECT_EQ(skel1, mWorld->getSkeleton(0));
+  EXPECT_EQ(skel2, mWorld->getSkeleton(1));
+  EXPECT_TRUE(mWorld->getSkeleton(2) == nullptr);
+
+  // Getting Skeletons by name
+  EXPECT_EQ(skel1, mWorld->getSkeleton("skel1"));
+  EXPECT_EQ(skel2, mWorld->getSkeleton("skel2"));
+  EXPECT_TRUE(mWorld->getSkeleton("skel3") == nullptr);
+
+  // Remove Skeletons
+  mWorld->removeSkeleton(skel3);
+  EXPECT_EQ(2, mWorld->getNumSkeletons());
+  mWorld->removeSkeleton(skel2);
+  EXPECT_EQ(1, mWorld->getNumSkeletons());
+  mWorld->removeSkeleton(skel2);
+  EXPECT_EQ(1, mWorld->getNumSkeletons());
+  mWorld->removeSkeleton(skel1);
+  EXPECT_EQ(0, mWorld->getNumSkeletons());
+}
+
+TEST_F(WorldTest, CloningPreservesSkeletonNamesAndConfigurations)
+{
+  mWorld->addSkeleton(skel1);
+  mWorld->addSkeleton(skel2);
+  mWorld->addSkeleton(skel3);
+
+  auto clone1 = mWorld->clone();
+  EXPECT_EQ(mWorld->getName(), clone1->getName());
+
+  auto clone2 = clone1->clone("clone2");
+  EXPECT_EQ("clone2", clone2->getName());
+
+  EXPECT_EQ(mWorld->getNumSkeletons(), clone1->getNumSkeletons());
+  EXPECT_EQ(mWorld->getNumSkeletons(), clone2->getNumSkeletons());
+  for (std::size_t i = 0; i < mWorld->getNumSkeletons(); ++i)
+  {
+    auto origSkeleton = mWorld->getSkeleton(i);
+    auto clonedSkeleton1 = clone1->getSkeleton(i);
+    auto clonedSkeleton2 = clone2->getSkeleton(i);
+
+    EXPECT_EQ(origSkeleton->getName(), clonedSkeleton1->getName());
+    EXPECT_EQ(origSkeleton->getName(), clonedSkeleton2->getName());
+
+    EXPECT_EQ(
+        origSkeleton->getConfiguration(), clonedSkeleton1->getConfiguration());
+    EXPECT_EQ(
+        origSkeleton->getConfiguration(), clonedSkeleton2->getConfiguration());
+  }
+}


### PR DESCRIPTION
This is a first attempt at a kinematic version of `dart::simulation::World`. Using a DART `World` as our default environment representation forces users to instantiate a dynamics engine, which is unnecessary overhead for many of our tasks. We'll add more functionality in future PRs.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
