### PR TITLE
Add methods for converting trajectories between different (but equivalent) state spaces

### DIFF
--- a/include/aikido/statespace/GeodesicInterpolator.hpp
+++ b/include/aikido/statespace/GeodesicInterpolator.hpp
@@ -53,6 +53,10 @@ public:
       double _alpha,
       Eigen::VectorXd& _tangentVector) const override;
 
+  // Documentation inherited.
+  std::shared_ptr<Interpolator> convertStateSpace(
+      statespace::StateSpacePtr newStateSpace) override;
+
 private:
   statespace::StateSpacePtr mStateSpace;
 };

--- a/include/aikido/statespace/Interpolator.hpp
+++ b/include/aikido/statespace/Interpolator.hpp
@@ -49,6 +49,12 @@ public:
       std::size_t _derivative,
       double _alpha,
       Eigen::VectorXd& _tangentVector) const = 0;
+
+  /// Create a new Interpolator in a different statespace
+  ///
+  /// \param newStateSpace New state space
+  virtual std::shared_ptr<Interpolator> convertStateSpace(
+      statespace::StateSpacePtr newStateSpace) = 0;
 };
 
 using InterpolatorPtr = std::shared_ptr<Interpolator>;

--- a/include/aikido/statespace/Interpolator.hpp
+++ b/include/aikido/statespace/Interpolator.hpp
@@ -54,7 +54,8 @@ public:
   ///
   /// \param newStateSpace New state space
   virtual std::shared_ptr<Interpolator> convertStateSpace(
-      statespace::StateSpacePtr newStateSpace) = 0;
+      statespace::StateSpacePtr newStateSpace)
+      = 0;
 };
 
 using InterpolatorPtr = std::shared_ptr<Interpolator>;

--- a/include/aikido/trajectory/Interpolated.hpp
+++ b/include/aikido/trajectory/Interpolated.hpp
@@ -68,6 +68,10 @@ public:
       int _derivative,
       Eigen::VectorXd& _tangentVector) const override;
 
+  // Documentation inherited
+  std::shared_ptr<Trajectory> convertStateSpace(
+      statespace::StateSpacePtr newStateSpace) override;
+
 private:
   /// Waypoint in the trajectory.
   struct Waypoint

--- a/include/aikido/trajectory/Spline.hpp
+++ b/include/aikido/trajectory/Spline.hpp
@@ -128,6 +128,10 @@ public:
       int _derivative,
       Eigen::VectorXd& _tangentVector) const;
 
+  // Documentation inherited
+  std::shared_ptr<Trajectory> convertStateSpace(
+      statespace::StateSpacePtr newStateSpace) override;
+
 private:
   struct PolynomialSegment
   {

--- a/include/aikido/trajectory/Trajectory.hpp
+++ b/include/aikido/trajectory/Trajectory.hpp
@@ -71,7 +71,8 @@ public:
   ///
   /// \param newStateSpace New statespace to execute this trajectory in
   virtual std::shared_ptr<Trajectory> convertStateSpace(
-      statespace::StateSpacePtr newStateSpace) = 0;
+      statespace::StateSpacePtr newStateSpace)
+      = 0;
 };
 
 using TrajectoryPtr = std::shared_ptr<Trajectory>;

--- a/include/aikido/trajectory/Trajectory.hpp
+++ b/include/aikido/trajectory/Trajectory.hpp
@@ -66,6 +66,12 @@ public:
   /// \param[out] _tangentVector output tangent vector in the local frame
   virtual void evaluateDerivative(
       double _t, int _derivative, Eigen::VectorXd& _tangentVector) const = 0;
+
+  /// Convert a trajectory from the current StateSpace to the new StateSpace.
+  ///
+  /// \param newStateSpace New statespace to execute this trajectory in
+  virtual std::shared_ptr<Trajectory> convertStateSpace(
+      statespace::StateSpacePtr newStateSpace) = 0;
 };
 
 using TrajectoryPtr = std::shared_ptr<Trajectory>;

--- a/src/planner/World.cpp
+++ b/src/planner/World.cpp
@@ -30,7 +30,8 @@ std::unique_ptr<World> World::create(const std::string& name)
 //==============================================================================
 std::unique_ptr<World> World::clone(const std::string& newName) const
 {
-  std::unique_ptr<World> worldClone(new World(newName.empty() ? mName : newName));
+  std::unique_ptr<World> worldClone(
+      new World(newName.empty() ? mName : newName));
 
   // Clone and add each Skeleton
   worldClone->mSkeletons.reserve(mSkeletons.size());

--- a/src/statespace/GeodesicInterpolator.cpp
+++ b/src/statespace/GeodesicInterpolator.cpp
@@ -75,5 +75,12 @@ void GeodesicInterpolator::getDerivative(
   }
 }
 
+//==============================================================================
+std::shared_ptr<Interpolator> GeodesicInterpolator::convertStateSpace(
+    statespace::StateSpacePtr newStateSpace)
+{
+  return std::shared_ptr<Interpolator>(new GeodesicInterpolator(newStateSpace));
+}
+
 } // namespace statespace
 } // namespace aikido

--- a/src/trajectory/Interpolated.cpp
+++ b/src/trajectory/Interpolated.cpp
@@ -143,6 +143,18 @@ void Interpolated::evaluateDerivative(
 }
 
 //==============================================================================
+TrajectoryPtr Interpolated::convertStateSpace(
+    statespace::StateSpacePtr newStateSpace)
+{
+  auto newInterpolator = mInterpolator->convertStateSpace(newStateSpace);
+  auto returnTraj
+    = std::make_shared<trajectory::Interpolated>(newStateSpace, newInterpolator);
+  for (const auto& waypoint : mWaypoints)
+    returnTraj->addWaypoint(waypoint.t, waypoint.state);
+  return returnTraj;
+}
+
+//==============================================================================
 void Interpolated::addWaypoint(double _t, const State* _state)
 {
   State* state = mStateSpace->allocateState();

--- a/src/trajectory/Interpolated.cpp
+++ b/src/trajectory/Interpolated.cpp
@@ -147,8 +147,8 @@ TrajectoryPtr Interpolated::convertStateSpace(
     statespace::StateSpacePtr newStateSpace)
 {
   auto newInterpolator = mInterpolator->convertStateSpace(newStateSpace);
-  auto returnTraj
-    = std::make_shared<trajectory::Interpolated>(newStateSpace, newInterpolator);
+  auto returnTraj = std::make_shared<trajectory::Interpolated>(
+      newStateSpace, newInterpolator);
   for (const auto& waypoint : mWaypoints)
     returnTraj->addWaypoint(waypoint.t, waypoint.state);
   return returnTraj;

--- a/src/trajectory/Spline.cpp
+++ b/src/trajectory/Spline.cpp
@@ -252,5 +252,17 @@ void Spline::getWaypointDerivative(
   }
 }
 
+//==============================================================================
+TrajectoryPtr Spline::convertStateSpace(
+    statespace::StateSpacePtr newStateSpace)
+{
+  auto returnTraj
+    = std::make_shared<trajectory::Spline>(newStateSpace, mStartTime);
+  for (const auto& segment : mSegments)
+    returnTraj->addSegment(segment.mCoefficients, segment.mDuration, segment.mStartState);
+  return returnTraj;
+}
+
+
 } // namespace trajectory
 } // namespace aikido

--- a/src/trajectory/Spline.cpp
+++ b/src/trajectory/Spline.cpp
@@ -253,16 +253,15 @@ void Spline::getWaypointDerivative(
 }
 
 //==============================================================================
-TrajectoryPtr Spline::convertStateSpace(
-    statespace::StateSpacePtr newStateSpace)
+TrajectoryPtr Spline::convertStateSpace(statespace::StateSpacePtr newStateSpace)
 {
   auto returnTraj
-    = std::make_shared<trajectory::Spline>(newStateSpace, mStartTime);
+      = std::make_shared<trajectory::Spline>(newStateSpace, mStartTime);
   for (const auto& segment : mSegments)
-    returnTraj->addSegment(segment.mCoefficients, segment.mDuration, segment.mStartState);
+    returnTraj->addSegment(
+        segment.mCoefficients, segment.mDuration, segment.mStartState);
   return returnTraj;
 }
-
 
 } // namespace trajectory
 } // namespace aikido


### PR DESCRIPTION
We need to be able to plan trajectories for one `MetaSkeleton` in `MetaSkeletonStateSpace`, while being able to execute them in _different but equivalent_ state spaces. This is important for pipelining planning and execution: since trajectories are tied to a specific state space (a `MetaSkeletonStateSpace` for a `MetaSkeleton` in a specific `World`), trajectories from the planning environment cannot be executed in the execution environment.

This should probably have better error-checking to prevent converting between incompatible `StateSpace`s. Without knowing the exact type of the `StateSpace`, is the best thing I can do here just compare the dimensions? Is it fair to assume that the two spaces will always be a `MetaSkeletonStateSpace`? (When else would one need to convert the state space into an equivalent one?)

I'm open to better suggestions, but this is the best way that I've thought of so far.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
