### PR TITLE
Queue trajectories in TrajectoryExecutor

### DIFF
--- a/include/aikido/control/KinematicSimulationTrajectoryExecutor.hpp
+++ b/include/aikido/control/KinematicSimulationTrajectoryExecutor.hpp
@@ -33,7 +33,8 @@ public:
   /// \return future<void> for trajectory execution. If trajectory terminates
   ///        before completion, future will be set to a runtime_error.
   /// \throws invalid_argument if traj is invalid.
-  std::future<void> execute(trajectory::TrajectoryPtr traj, bool skip) override;
+  std::future<void> execute(
+      trajectory::TrajectoryPtr traj, bool skip = false) override;
 
   /// \copydoc PositionCommandExecutor::step()
   ///

--- a/include/aikido/control/KinematicSimulationTrajectoryExecutor.hpp
+++ b/include/aikido/control/KinematicSimulationTrajectoryExecutor.hpp
@@ -29,10 +29,11 @@ public:
   /// \param traj Trajectory to be executed. Its StateSpace should be a
   ///        MetaStateSpace over MetaSkeleton, and the dofs in the metaskeleton
   ///        should be all in skeleton passed to the constructor.
+  /// \param skip Whether to skip to the end of the trajectory
   /// \return future<void> for trajectory execution. If trajectory terminates
   ///        before completion, future will be set to a runtime_error.
   /// \throws invalid_argument if traj is invalid.
-  std::future<void> execute(trajectory::TrajectoryPtr traj) override;
+  std::future<void> execute(trajectory::TrajectoryPtr traj, bool skip) override;
 
   /// \copydoc PositionCommandExecutor::step()
   ///

--- a/include/aikido/control/TrajectoryExecutor.hpp
+++ b/include/aikido/control/TrajectoryExecutor.hpp
@@ -1,7 +1,11 @@
 #ifndef AIKIDO_CONTROL_TRAJECTORYEXECUTOR_HPP_
 #define AIKIDO_CONTROL_TRAJECTORYEXECUTOR_HPP_
 
+#include <atomic>
 #include <future>
+#include <mutex>
+#include <queue>
+#include <thread>
 #include <aikido/trajectory/Trajectory.hpp>
 #include "TrajectoryResult.hpp"
 
@@ -11,7 +15,7 @@ namespace control {
 class TrajectoryExecutor
 {
 public:
-  virtual ~TrajectoryExecutor() = default;
+  virtual ~TrajectoryExecutor();
 
   /// Execute traj and set future upon completion.
   /// \param traj Trajectory to be executed.
@@ -19,6 +23,39 @@ public:
 
   /// Executes one step.
   virtual void step() = 0;
+
+  /// Queue a trajectory for future execution. If there are no trajectories on
+  /// the queue or currently being executed, the trajectory should be executed
+  /// immediately.
+  /// \param traj Trajectory to queue and execute
+  void queue(trajectory::TrajectoryPtr _traj);
+
+  /// Toggle whether trajectories should be automatically dequeued and executed.
+  /// \param flag Whether to automatically execute trajectories from the queue
+  void setExecuteFromQueue(bool flag);
+
+  /// Block until all trajectories in the queue have been executed.
+  void executeAllFromQueue();
+
+protected:
+  TrajectoryExecutor();
+
+  /// Thread target for automatically checking queue and executing trajectories
+  void executeFromQueue();
+
+  /// Queue of trajectories
+  std::queue<trajectory::TrajectoryPtr> mTrajectoryQueue;
+
+  /// Manages access to mTrajectoryQueue
+  mutable std::mutex mTrajectoryQueueMutex;
+
+  /// Whether trajectories are automatically dequeued and executed
+  std::atomic_bool mRunning;
+
+  /// Whether the thread should stop running when the queue is empty
+  std::atomic_bool mReturnWhenEmpty;
+
+  std::thread mThread;
 };
 
 using TrajectoryExecutorPtr = std::shared_ptr<TrajectoryExecutor>;

--- a/include/aikido/control/TrajectoryExecutor.hpp
+++ b/include/aikido/control/TrajectoryExecutor.hpp
@@ -19,7 +19,11 @@ public:
 
   /// Execute traj and set future upon completion.
   /// \param traj Trajectory to be executed.
-  virtual std::future<void> execute(trajectory::TrajectoryPtr _traj) = 0;
+  /// \param skip Whether to skip to the end of the trajectory (only used by
+  ///        simulation trajectory executors)
+  virtual std::future<void> execute(
+      trajectory::TrajectoryPtr _traj, bool _skip = false)
+      = 0;
 
   /// Executes one step.
   virtual void step() = 0;

--- a/include/aikido/control/ros/RosTrajectoryExecutor.hpp
+++ b/include/aikido/control/ros/RosTrajectoryExecutor.hpp
@@ -41,7 +41,11 @@ public:
 
   /// Sends trajectory to ROS server for execution.
   /// \param[in] traj Trajectory to be executed.
-  std::future<void> execute(trajectory::TrajectoryPtr traj) override;
+  std::future<void> execute(trajectory::TrajectoryPtr traj, bool) override;
+
+  /// Sends trajectory to ROS server for execution.
+  /// \param[in] traj Trajectory to be executed.
+  std::future<void> execute(trajectory::TrajectoryPtr traj);
 
   /// Sends trajectory to ROS server for execution.
   /// \param[in] traj Trajectory to be executed.

--- a/src/control/CMakeLists.txt
+++ b/src/control/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(sources
+  TrajectoryExecutor.cpp
   KinematicSimulationTrajectoryExecutor.cpp
   BarrettHandKinematicSimulationPositionCommandExecutor.cpp
   BarrettFingerKinematicSimulationPositionCommandExecutor.cpp

--- a/src/control/KinematicSimulationTrajectoryExecutor.cpp
+++ b/src/control/KinematicSimulationTrajectoryExecutor.cpp
@@ -16,7 +16,8 @@ namespace control {
 //==============================================================================
 KinematicSimulationTrajectoryExecutor::KinematicSimulationTrajectoryExecutor(
     ::dart::dynamics::SkeletonPtr skeleton)
-  : mSkeleton(std::move(skeleton))
+  : TrajectoryExecutor()
+  , mSkeleton(std::move(skeleton))
   , mPromise(nullptr)
   , mTraj(nullptr)
   , mMutex()

--- a/src/control/TrajectoryExecutor.cpp
+++ b/src/control/TrajectoryExecutor.cpp
@@ -1,5 +1,5 @@
-#include <ros/ros.h>
 #include <aikido/control/TrajectoryExecutor.hpp>
+#include <chrono>
 
 namespace aikido {
 namespace control {
@@ -37,9 +37,10 @@ void TrajectoryExecutor::setExecuteFromQueue(bool flag)
 //==============================================================================
 void TrajectoryExecutor::executeFromQueue()
 {
-  ::ros::Rate rate(30);
+  // TODO: can this be rewritten with aikido::common::ExecutorThread?
 
-  while (mRunning.load() && ::ros::ok())
+  const auto period = std::chrono::milliseconds(100);
+  while (mRunning.load())
   {
     trajectory::TrajectoryPtr traj;
 
@@ -63,7 +64,7 @@ void TrajectoryExecutor::executeFromQueue()
     if (traj)
       execute(traj).wait();
 
-    rate.sleep();
+    std::this_thread::sleep_until(std::chrono::steady_clock::now() + period);
   }
 
   mRunning.store(false);

--- a/src/control/TrajectoryExecutor.cpp
+++ b/src/control/TrajectoryExecutor.cpp
@@ -75,6 +75,7 @@ void TrajectoryExecutor::executeAllFromQueue()
   mReturnWhenEmpty.store(true);
   if (mThread.joinable())
     mThread.join();
+  mReturnWhenEmpty.store(false);
 }
 
 } // namespace control

--- a/src/control/TrajectoryExecutor.cpp
+++ b/src/control/TrajectoryExecutor.cpp
@@ -1,0 +1,82 @@
+#include <iostream>
+#include <ros/ros.h>
+#include <aikido/control/TrajectoryExecutor.hpp>
+
+namespace aikido {
+namespace control {
+
+//==============================================================================
+TrajectoryExecutor::TrajectoryExecutor()
+  : mRunning(false), mReturnWhenEmpty(false)
+{
+  // Do nothing.
+}
+
+//==============================================================================
+TrajectoryExecutor::~TrajectoryExecutor()
+{
+  mRunning.store(false);
+  if (mThread.joinable())
+    mThread.join();
+}
+
+//==============================================================================
+void TrajectoryExecutor::queue(trajectory::TrajectoryPtr traj)
+{
+  std::lock_guard<std::mutex> lock(mTrajectoryQueueMutex);
+  mTrajectoryQueue.push(std::move(traj));
+}
+
+//==============================================================================
+void TrajectoryExecutor::setExecuteFromQueue(bool flag)
+{
+  const bool isRunning = mRunning.exchange(flag);
+  if (flag && !isRunning)
+    mThread = std::thread(&TrajectoryExecutor::executeFromQueue, this);
+}
+
+//==============================================================================
+void TrajectoryExecutor::executeFromQueue()
+{
+  ::ros::Rate rate(30);
+
+  while (mRunning.load() && ::ros::ok())
+  {
+    trajectory::TrajectoryPtr traj;
+
+    std::unique_lock<std::mutex> lock(mTrajectoryQueueMutex);
+    if (!mTrajectoryQueue.empty())
+    {
+      traj = mTrajectoryQueue.front();
+      mTrajectoryQueue.pop();
+    }
+    else
+    {
+      if (mReturnWhenEmpty.load())
+        mRunning.store(false);
+    }
+    lock.unlock();
+
+    // TODO: we should verify that this trajectory can actually be run, i.e.
+    // that the start of this trajectory is close to the current state
+    // See https://github.com/personalrobotics/rewd_controllers/issues/6
+
+    if (traj)
+      execute(traj).wait();
+
+    rate.sleep();
+  }
+
+  mRunning.store(false);
+}
+
+//==============================================================================
+void TrajectoryExecutor::executeAllFromQueue()
+{
+  mReturnWhenEmpty.store(true);
+  if (mThread.joinable())
+    mThread.join();
+}
+
+} // namespace control
+} // namespace aikido

--- a/src/control/TrajectoryExecutor.cpp
+++ b/src/control/TrajectoryExecutor.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <ros/ros.h>
 #include <aikido/control/TrajectoryExecutor.hpp>
 

--- a/src/control/ros/RosTrajectoryExecutor.cpp
+++ b/src/control/ros/RosTrajectoryExecutor.cpp
@@ -82,6 +82,13 @@ RosTrajectoryExecutor::~RosTrajectoryExecutor()
 }
 
 //==============================================================================
+std::future<void> RosTrajectoryExecutor::execute(
+    trajectory::TrajectoryPtr traj, bool)
+{
+  return execute(traj);
+}
+
+//==============================================================================
 std::future<void> RosTrajectoryExecutor::execute(trajectory::TrajectoryPtr traj)
 {
   static const ::ros::Time invalidTime;

--- a/src/control/ros/RosTrajectoryExecutor.cpp
+++ b/src/control/ros/RosTrajectoryExecutor.cpp
@@ -57,7 +57,8 @@ RosTrajectoryExecutor::RosTrajectoryExecutor(
     double goalTimeTolerance,
     const std::chrono::milliseconds& connectionTimeout,
     const std::chrono::milliseconds& connectionPollingPeriod)
-  : mNode{std::move(node)}
+  : TrajectoryExecutor()
+  , mNode{std::move(node)}
   , mCallbackQueue{}
   , mClient{mNode, serverName, &mCallbackQueue}
   , mTimestep{timestep}


### PR DESCRIPTION
This PR adds methods to `aikido::control::TrajectoryExecutor` to support queuing of trajectories. This is useful for pipelining, since we no longer have to wait for a trajectory to finish executing before sending the next trajectory.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
