### PR TITLE
Fix WorldInteractiveMarkerViewer bug when removing Skeletons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * Planner
 
-  * Added World class: [#243](https://github.com/personalrobotics/aikido/pull/243)
+  * Added World class: [#243](https://github.com/personalrobotics/aikido/pull/243), [#252](https://github.com/personalrobotics/aikido/pull/252)
   * Added vector field planner [#246](https://github.com/personalrobotics/aikido/pull/246)
 
 * RViz

--- a/include/aikido/planner/World.hpp
+++ b/include/aikido/planner/World.hpp
@@ -39,6 +39,11 @@ public:
   /// \param name Name of desired Skeleton
   dart::dynamics::SkeletonPtr getSkeleton(const std::string& name) const;
 
+  /// Find a Skeleton by Skeleton, returning null if it is not in the World
+  /// \param skel Desired Skeleton
+  dart::dynamics::SkeletonPtr getSkeleton(
+      const dart::dynamics::SkeletonPtr skel) const;
+
   /// Get the number of Skeletons
   std::size_t getNumSkeletons() const;
 

--- a/include/aikido/planner/World.hpp
+++ b/include/aikido/planner/World.hpp
@@ -39,10 +39,10 @@ public:
   /// \param name Name of desired Skeleton
   dart::dynamics::SkeletonPtr getSkeleton(const std::string& name) const;
 
-  /// Find a Skeleton by Skeleton, returning null if it is not in the World
+  /// Returns true if the Skeleton is in this World.
   /// \param skel Desired Skeleton
-  dart::dynamics::SkeletonPtr getSkeleton(
-      const dart::dynamics::SkeletonPtr skel) const;
+  /// \return True if succeeded to find the Skeleton
+  bool hasSkeleton(const dart::dynamics::SkeletonPtr& skel) const;
 
   /// Get the number of Skeletons
   std::size_t getNumSkeletons() const;

--- a/include/aikido/rviz/WorldInteractiveMarkerViewer.hpp
+++ b/include/aikido/rviz/WorldInteractiveMarkerViewer.hpp
@@ -38,8 +38,8 @@ protected:
   /// Thread target for auto-updating the viewer
   void autoUpdate();
 
-  /// Mapping of Skeleton names to SkeletonMarkers
-  std::map<std::string, SkeletonMarkerPtr> mSkeletonMarkers;
+  /// Mapping of Skeletons to SkeletonMarkers
+  std::map<dart::dynamics::SkeletonPtr, SkeletonMarkerPtr> mSkeletonMarkers;
 
   /// World that automatically updates the viewer
   aikido::planner::WorldPtr mWorld;

--- a/src/planner/World.cpp
+++ b/src/planner/World.cpp
@@ -77,6 +77,16 @@ dart::dynamics::SkeletonPtr World::getSkeleton(const std::string& name) const
 }
 
 //==============================================================================
+dart::dynamics::SkeletonPtr World::getSkeleton(
+    const dart::dynamics::SkeletonPtr skel) const
+{
+  auto it = std::find(mSkeletons.begin(), mSkeletons.end(), skel);
+  if (it == mSkeletons.end())
+    return nullptr;
+  return skel;
+}
+
+//==============================================================================
 std::size_t World::getNumSkeletons() const
 {
   return mSkeletons.size();

--- a/src/planner/World.cpp
+++ b/src/planner/World.cpp
@@ -77,13 +77,10 @@ dart::dynamics::SkeletonPtr World::getSkeleton(const std::string& name) const
 }
 
 //==============================================================================
-dart::dynamics::SkeletonPtr World::getSkeleton(
-    const dart::dynamics::SkeletonPtr skel) const
+bool World::hasSkeleton(const dart::dynamics::SkeletonPtr& skel) const
 {
-  auto it = std::find(mSkeletons.begin(), mSkeletons.end(), skel);
-  if (it == mSkeletons.end())
-    return nullptr;
-  return skel;
+  return std::find(mSkeletons.begin(), mSkeletons.end(), skel)
+         != mSkeletons.end();
 }
 
 //==============================================================================

--- a/src/rviz/WorldInteractiveMarkerViewer.cpp
+++ b/src/rviz/WorldInteractiveMarkerViewer.cpp
@@ -63,7 +63,7 @@ void WorldInteractiveMarkerViewer::update()
     {
       // Either a new SkeletonMarker or a previously-inserted SkeletonMarker
       auto result = mSkeletonMarkers.emplace(
-          skeleton->getName(), CreateSkeletonMarker(skeleton, mFrameId));
+          skeleton, CreateSkeletonMarker(skeleton, mFrameId));
 
       std::unique_lock<std::mutex> lock(skeleton->getMutex(), std::try_to_lock);
       if (lock.owns_lock())

--- a/src/rviz/WorldInteractiveMarkerViewer.cpp
+++ b/src/rviz/WorldInteractiveMarkerViewer.cpp
@@ -76,7 +76,7 @@ void WorldInteractiveMarkerViewer::update()
   while (it != std::end(mSkeletonMarkers))
   {
     // Skeleton still exists in the World, do nothing.
-    if (mWorld->getSkeleton(it->first))
+    if (mWorld->hasSkeleton(it->first))
     {
       ++it;
     }


### PR DESCRIPTION
If a `Skeleton` is removed and a new `Skeleton` with the same name is added quickly enough (before the viewer refreshes and removes the original `Skeleton`), the new `Skeleton` is not visualized. This PR fixes this bug by using the actual `SkeletonPtr` as the key in `WorldInteractiveMarkerViewer`, rather than its name.

At some point, we could fix this by registering callbacks to `World` that are called when adding or removing `Skeleton`s.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
