### PR TITLE
Add rviz dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
   * Changed to use size_t over std::size_t: [#230](https://github.com/personalrobotics/aikido/pull/230)
   * Included test code to formatting code list: [#239](https://github.com/personalrobotics/aikido/pull/239)
+  * Fixed RViz component dependencies: [#253](https://github.com/personalrobotics/aikido/pull/253)
 
 ### [0.1.0 (2017-10-02)](https://github.com/personalrobotics/aikido/milestone/4?closed=1)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory("external/hauser_parabolic_smoother")
 
 add_subdirectory("common")     # boost, dart
 add_subdirectory("io")         # [common], boost, dart, tinyxml2, yaml-cpp
-add_subdirectory("rviz")       # boost, dart, roscpp, geometry_msgs, interactive_markers, std_msgs, visualization_msgs, libmicrohttpd
+add_subdirectory("rviz")       # [constraint], [planner], boost, dart, roscpp, geometry_msgs, interactive_markers, std_msgs, visualization_msgs, libmicrohttpd
 add_subdirectory("statespace") # dart
 add_subdirectory("perception") # [io], boost, dart, yaml-cpp, geometry_msgs, roscpp, std_msgs, visualization_msgs
 add_subdirectory("distance")   # [statespace], dart

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,12 +5,12 @@ add_subdirectory("external/hauser_parabolic_smoother")
 
 add_subdirectory("common")     # boost, dart
 add_subdirectory("io")         # [common], boost, dart, tinyxml2, yaml-cpp
-add_subdirectory("rviz")       # [constraint], [planner], boost, dart, roscpp, geometry_msgs, interactive_markers, std_msgs, visualization_msgs, libmicrohttpd
 add_subdirectory("statespace") # dart
 add_subdirectory("perception") # [io], boost, dart, yaml-cpp, geometry_msgs, roscpp, std_msgs, visualization_msgs
 add_subdirectory("distance")   # [statespace], dart
 add_subdirectory("trajectory") # [common], [statespace]
 add_subdirectory("constraint") # [common], [statespace]
 add_subdirectory("planner")    # [external], [common], [statespace], [trajectory], [constraint], [distance], dart, ompl
+add_subdirectory("rviz")       # [constraint], [planner], boost, dart, roscpp, geometry_msgs, interactive_markers, std_msgs, visualization_msgs, libmicrohttpd
 add_subdirectory("control")    # [statespace], [trajectory]
 #add_subdirectory("python")     # everything

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -67,6 +67,10 @@ target_compile_options("${PROJECT_NAME}_rviz"
 
 add_component(${PROJECT_NAME} rviz)
 add_component_targets(${PROJECT_NAME} rviz "${PROJECT_NAME}_rviz")
+add_component_dependencies(${PROJECT_NAME} rviz
+  constraint
+  planner
+)
 
 # Intentionally omit tests for or_rviz. It's not clear how to test a viewer.
 

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries("${PROJECT_NAME}_rviz"
   PUBLIC
     "${PROJECT_NAME}_constraint"
     "${PROJECT_NAME}_planner"
-    "${PROJECT_NAME}_statespace"
     ${Boost_FILESYSTEM_LIBRARY}
     ${DART_LIBRARIES}
     ${geometry_msgs_LIBRARIES}

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -50,6 +50,9 @@ target_include_directories("${PROJECT_NAME}_rviz" SYSTEM
 )
 target_link_libraries("${PROJECT_NAME}_rviz"
   PUBLIC
+    "${PROJECT_NAME}_constraint"
+    "${PROJECT_NAME}_planner"
+    "${PROJECT_NAME}_statespace"
     ${Boost_FILESYSTEM_LIBRARY}
     ${DART_LIBRARIES}
     ${geometry_msgs_LIBRARIES}


### PR DESCRIPTION
I was having trouble compiling dart_examples while working on https://github.com/personalrobotics/dart_examples/pull/8. This seemed to fix it.

- `constraint` is used because we visualize TSRs
- `planner` is used because we visualize `World`s

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
