### PR TITLE
Disable CI tests on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,6 @@ matrix:
     - os: linux
       compiler: gcc
       env: BUILD_TYPE=Release CODECOV=OFF COMPILER=GCC CATKIN_CONFIG_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DTREAT_WARNINGS_AS_ERRORS=ON"
-    - os: linux
-      compiler: clang
-      env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG CATKIN_CONFIG_OPTIONS="-DCMAKE_BUILD_TYPE=Debug -DTREAT_WARNINGS_AS_ERRORS=ON"
-    - os: linux
-      compiler: clang
-      env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG CATKIN_CONFIG_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DTREAT_WARNINGS_AS_ERRORS=ON"
 
 before_install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then . "${TRAVIS_BUILD_DIR}/.ci/before_install_linux.sh"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ matrix:
     - os: linux
       compiler: gcc
       env: BUILD_TYPE=Release CODECOV=OFF COMPILER=GCC CATKIN_CONFIG_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DTREAT_WARNINGS_AS_ERRORS=ON"
-    #- os: osx
-    #  compiler: clang
-    #  env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG CATKIN_CONFIG_OPTIONS="-DCMAKE_BUILD_TYPE=Debug -DTREAT_WARNINGS_AS_ERRORS=ON"
-    #- os: osx
-    #  compiler: clang
-    #  env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG CATKIN_CONFIG_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DTREAT_WARNINGS_AS_ERRORS=ON"
+    - os: linux
+      compiler: clang
+      env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG CATKIN_CONFIG_OPTIONS="-DCMAKE_BUILD_TYPE=Debug -DTREAT_WARNINGS_AS_ERRORS=ON"
+    - os: linux
+      compiler: clang
+      env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG CATKIN_CONFIG_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DTREAT_WARNINGS_AS_ERRORS=ON"
 
 before_install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then . "${TRAVIS_BUILD_DIR}/.ci/before_install_linux.sh"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ matrix:
     - os: linux
       compiler: gcc
       env: BUILD_TYPE=Release CODECOV=OFF COMPILER=GCC CATKIN_CONFIG_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DTREAT_WARNINGS_AS_ERRORS=ON"
-    - os: osx
-      compiler: clang
-      env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG CATKIN_CONFIG_OPTIONS="-DCMAKE_BUILD_TYPE=Debug -DTREAT_WARNINGS_AS_ERRORS=ON"
-    - os: osx
-      compiler: clang
-      env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG CATKIN_CONFIG_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DTREAT_WARNINGS_AS_ERRORS=ON"
+    #- os: osx
+    #  compiler: clang
+    #  env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG CATKIN_CONFIG_OPTIONS="-DCMAKE_BUILD_TYPE=Debug -DTREAT_WARNINGS_AS_ERRORS=ON"
+    #- os: osx
+    #  compiler: clang
+    #  env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG CATKIN_CONFIG_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DTREAT_WARNINGS_AS_ERRORS=ON"
 
 before_install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then . "${TRAVIS_BUILD_DIR}/.ci/before_install_linux.sh"; fi


### PR DESCRIPTION
Currently, Travis CI tests on macOS almost always timeout. This PR disables it as we don't have any actual use AIKIDO on macOS.

***

**Before creating a pull request**

- [x] Document new methods and classes (N/A)
- [x] Format code with `make format` (N/A)

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side (N/A)
- [x] Summarize this change in `CHANGELOG.md` (N/A)
- [x] Add unit test(s) for this change (N/A)
