### PR TITLE
Fix Travis builds

### DIFF
--- a/.ci/install_linux.sh
+++ b/.ci/install_linux.sh
@@ -1,2 +1,2 @@
-cp "${TRAVIS_BUILD_DIR}" src
+cp -r "${TRAVIS_BUILD_DIR}" src
 ./scripts/internal-distro.py --workspace=src distribution.yml --repository "${REPOSITORY}"


### PR DESCRIPTION
Resolves #227.

The issue was that `cp "${TRAVIS_BUILD_DIR}" src` doesn't copy the source directory (missing `-r`), so the next line ` ./scripts/internal-distro.py --workspace=src distribution.yml --repository "${REPOSITORY}"` will clone the repository into the workspace. The cloned repository will be on the default branch.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
