### PR TITLE
Move MetaSkeletonStateSpaceSaver implementation to a cpp file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### 0.2.0 (201X-XX-XX)
 
+* State Space
+  * Moved MetaSkeletonStateSpaceSaver implementation to src: [#273](https://github.com/personalrobotics/aikido/pull/273)
+
 * Constraint
 
   * Added methods for removing groups from NonColliding constraints: [#247](https://github.com/personalrobotics/aikido/pull/247)

--- a/include/aikido/statespace/dart/MetaSkeletonStateSpaceSaver.hpp
+++ b/include/aikido/statespace/dart/MetaSkeletonStateSpaceSaver.hpp
@@ -40,6 +40,4 @@ private:
 } // namespace statespace
 } // namespace aikido
 
-#include "detail/MetaSkeletonStateSpaceSaver-impl.hpp"
-
 #endif // ifndef AIKIDO_STATESPACE_DART_METASKELETONSTATESPACESAVER_HPP_

--- a/src/statespace/CMakeLists.txt
+++ b/src/statespace/CMakeLists.txt
@@ -10,6 +10,7 @@ set(sources
   dart/JointStateSpace.cpp
   dart/JointStateSpaceHelpers.cpp
   dart/MetaSkeletonStateSpace.cpp
+  dart/MetaSkeletonStateSpaceSaver.cpp
   dart/SE2Joint.cpp
   dart/SE3Joint.cpp
   dart/SO2Joint.cpp

--- a/src/statespace/dart/MetaSkeletonStateSpaceSaver.cpp
+++ b/src/statespace/dart/MetaSkeletonStateSpaceSaver.cpp
@@ -1,7 +1,10 @@
+#include <aikido/statespace/dart/MetaSkeletonStateSpaceSaver.hpp>
+
 namespace aikido {
 namespace statespace {
 namespace dart {
 
+//==============================================================================
 MetaSkeletonStateSpaceSaver::MetaSkeletonStateSpaceSaver(
     MetaSkeletonStateSpacePtr _space)
   : mSpace(std::move(_space))
@@ -11,6 +14,7 @@ MetaSkeletonStateSpaceSaver::MetaSkeletonStateSpaceSaver(
 {
 }
 
+//==============================================================================
 MetaSkeletonStateSpaceSaver::~MetaSkeletonStateSpaceSaver()
 {
   if (static_cast<std::size_t>(mPositions.size())

--- a/src/statespace/dart/MetaSkeletonStateSpaceSaver.cpp
+++ b/src/statespace/dart/MetaSkeletonStateSpaceSaver.cpp
@@ -12,6 +12,7 @@ MetaSkeletonStateSpaceSaver::MetaSkeletonStateSpaceSaver(
   , mPositionLowerLimits(mSpace->getMetaSkeleton()->getPositionLowerLimits())
   , mPositionUpperLimits(mSpace->getMetaSkeleton()->getPositionUpperLimits())
 {
+  // Do nothing
 }
 
 //==============================================================================

--- a/tests/statespace/CMakeLists.txt
+++ b/tests/statespace/CMakeLists.txt
@@ -21,5 +21,10 @@ aikido_add_test(test_MetaSkeletonStateSpace
 target_link_libraries(test_MetaSkeletonStateSpace
   "${PROJECT_NAME}_statespace")
 
+aikido_add_test(test_MetaSkeletonStateSpaceSaver
+  dart/test_MetaSkeletonStateSpaceSaver.cpp)
+target_link_libraries(test_MetaSkeletonStateSpaceSaver
+  "${PROJECT_NAME}_statespace")
+
 aikido_add_test(test_DartJointStateSpaces dart/test_DartJointStateSpaces.cpp)
 target_link_libraries(test_DartJointStateSpaces "${PROJECT_NAME}_statespace")

--- a/tests/statespace/dart/test_MetaSkeletonStateSpaceSaver.cpp
+++ b/tests/statespace/dart/test_MetaSkeletonStateSpaceSaver.cpp
@@ -12,7 +12,6 @@ using aikido::statespace::SO2;
 
 TEST(MetaSkeletonStateSpaceSaver, MetaSkeletonStateSpaceReturnsToOriginal)
 {
-
   auto skeleton = Skeleton::create();
   skeleton->createJointAndBodyNodePair<RevoluteJoint>();
 

--- a/tests/statespace/dart/test_MetaSkeletonStateSpaceSaver.cpp
+++ b/tests/statespace/dart/test_MetaSkeletonStateSpaceSaver.cpp
@@ -1,0 +1,39 @@
+#include <dart/dynamics/dynamics.hpp>
+#include <gtest/gtest.h>
+#include <aikido/statespace/CartesianProduct.hpp>
+#include <aikido/statespace/SO2.hpp>
+#include <aikido/statespace/dart/MetaSkeletonStateSpace.hpp>
+#include <aikido/statespace/dart/MetaSkeletonStateSpaceSaver.hpp>
+
+using dart::dynamics::Skeleton;
+using dart::dynamics::RevoluteJoint;
+using aikido::statespace::dart::MetaSkeletonStateSpace;
+using aikido::statespace::dart::MetaSkeletonStateSpaceSaver;
+using aikido::statespace::SO2;
+
+TEST(MetaSkeletonStateSpaceSaver, MetaSkeletonStateSpaceReturnsToOriginal)
+{
+
+  auto skeleton = Skeleton::create();
+  skeleton->createJointAndBodyNodePair<RevoluteJoint>();
+
+  auto space = std::make_shared<MetaSkeletonStateSpace>(skeleton);
+  ASSERT_EQ(1, space->getNumSubspaces());
+
+  auto state = space->createState();
+  auto substate = state.getSubStateHandle<SO2>(0);
+
+  substate.setAngle(1.);
+  space->setState(state);
+  EXPECT_DOUBLE_EQ(1., skeleton->getPosition(0));
+
+  {
+    auto saver = MetaSkeletonStateSpaceSaver(space);
+    DART_UNUSED(saver);
+
+    substate.setAngle(6.);
+    space->setState(state);
+    EXPECT_DOUBLE_EQ(6., skeleton->getPosition(0));
+  }
+  EXPECT_DOUBLE_EQ(1., skeleton->getPosition(0));
+}

--- a/tests/statespace/dart/test_MetaSkeletonStateSpaceSaver.cpp
+++ b/tests/statespace/dart/test_MetaSkeletonStateSpaceSaver.cpp
@@ -1,6 +1,5 @@
 #include <dart/dynamics/dynamics.hpp>
 #include <gtest/gtest.h>
-#include <aikido/statespace/CartesianProduct.hpp>
 #include <aikido/statespace/SO2.hpp>
 #include <aikido/statespace/dart/MetaSkeletonStateSpace.hpp>
 #include <aikido/statespace/dart/MetaSkeletonStateSpaceSaver.hpp>


### PR DESCRIPTION
This PR moves `MetaSkeletonStateSpaceSaver`'s implementation from a header file to a cpp file. The current version results in multiple definition error when two classes import `MetaSkeletonStateSpaceSaver`.
 
***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
