### PR TITLE
Update shebangs and shellopts for CI scripts.

### DIFF
--- a/.ci/before_install_linux.sh
+++ b/.ci/before_install_linux.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -e
 
 # Install test fixture dependencies.
 mkdir -p "${HOME}/workspace/src"

--- a/.ci/install_linux.sh
+++ b/.ci/install_linux.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -e
 
 cp -r "${TRAVIS_BUILD_DIR}" src
 ./scripts/internal-distro.py --workspace=src distribution.yml --repository "${REPOSITORY}"

--- a/.ci/install_macos.sh
+++ b/.ci/install_macos.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -e
 
 brew install boost
 brew install dartsim/dart/dartsim6

--- a/.ci/script_linux.sh
+++ b/.ci/script_linux.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -e
 
 ./scripts/internal-build.sh ${PACKAGE_NAMES}
 ./scripts/internal-test.sh ${PACKAGE_NAMES}

--- a/.ci/script_macos.sh
+++ b/.ci/script_macos.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -e
 
 mkdir build
 cd build


### PR DESCRIPTION
The shebang `#!/usr/bin/env bash -e` works on my Mac but not on my Ubuntu workstation (I see `/usr/bin/env: bash -e: No such file or directory` instead). This PR uses `set -e` instead.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
