### PR TITLE
Add guidelines for use of smart pointers

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -149,6 +149,15 @@ int ExampleClass::exampleMethod(int _A, int _B, int *_out) const
 } // namespace aikido
 ```
 
+### Smart Pointers
+
+> This guidelines is based on [this article](https://herbsutter.com/2013/06/05/gotw-91-solution-smart-pointer-parameters/). Consider looking at the article for the details.
+
+* Use a by-value `std::shared_ptr` as a parameter if the function surely takes the shared ownership.
+* Use a `const std::shared_ptr&` as a parameter only if you're not sure whether or not you'll take a copy and share ownership.
+* Use a non-const `std::shared_ptr&` parameter only to modify the `std::shared_ptr`.
+* Otherwise use `Object*` instead, or `Object&` if not nullable
+
 ### Autoformatting using ClangFormat
 
 You can automatically format the entire Aikido code using [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) through CMake. Make sure `clang-format 3.8` is installed.

--- a/STYLE.md
+++ b/STYLE.md
@@ -153,10 +153,15 @@ int ExampleClass::exampleMethod(int _A, int _B, int *_out) const
 
 > This guidelines is based on [this article](https://herbsutter.com/2013/06/05/gotw-91-solution-smart-pointer-parameters/). Consider looking at the article for the details.
 
-* Use a by-value `std::shared_ptr` as a parameter if the function surely takes the shared ownership.
-* Use a `const std::shared_ptr&` as a parameter only if you're not sure whether or not you'll take a copy and share ownership.
-* Use a non-const `std::shared_ptr&` parameter only to modify the `std::shared_ptr`.
-* Otherwise use `Object*` instead, or `Object&` if not nullable
+* General Rules
+  * Use a by-value `std::shared_ptr` as a parameter if the function surely takes the shared ownership.
+  * Use a `const std::shared_ptr&` as a parameter only if you're not sure whether or not you'll take a copy and share ownership.
+  * Use a non-const `std::shared_ptr&` parameter only to modify the `std::shared_ptr`.
+  * Use `std::unique_ptr` anytime you want to use a `std::shared_ptr` but don't need to share ownership.
+  * Otherwise use `Object*` instead, or `Object&` if not nullable.
+
+* Exception: 
+  * Always pass AIKIDO `State`s by raw pointer. This is due to some of the tricks we play with placement-`new` to reduce `State` memory overhead, deferencing a `State *` could theoretically invoke undefined behavior even if you store it in a reference.
 
 ### Autoformatting using ClangFormat
 


### PR DESCRIPTION
I think we've been struggling from whether we should pass a `std::shared_ptr` by value or by const reference. I found a reliable article about this and think it would be good to add this to our guideline.

This isn't a complete guideline about `shared_ptr`, but it would be worth to start to have.
