### PR TITLE
Add TrajectoryMarker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * RViz
 
   * Added WorldInteractiveMarkerViewer: [#242](https://github.com/personalrobotics/aikido/pull/242)
+  * Added TrajectoryMarker: [#288](https://github.com/personalrobotics/aikido/pull/288)
 
 * Build & Testing & ETC
 

--- a/include/aikido/rviz/InteractiveMarkerViewer.hpp
+++ b/include/aikido/rviz/InteractiveMarkerViewer.hpp
@@ -13,6 +13,7 @@
 #include <aikido/constraint/TSR.hpp>
 #include <aikido/rviz/SmartPointers.hpp>
 #include <aikido/rviz/TSRMarker.hpp>
+#include <aikido/trajectory/Trajectory.hpp>
 
 namespace aikido {
 namespace rviz {
@@ -51,6 +52,28 @@ public:
       int nSamples = 10,
       const std::string& basename = "");
 
+  /// Adds trajectory marker to this viewer.
+  ///
+  /// \param[in] trajectory C-sapce (or joint-space) trajectory.
+  /// \param[in] skeleton Target DART meta skeleton that the C-space trajectory
+  /// will be applied to compute the visualizing task-space trajectory.
+  /// \param[in] frame Target DART frame where the trajectory of its origin
+  /// will be visualized.
+  /// \param[in] rgba Color and alpha of the visualizing task-space trajectory.
+  /// Default is [RGBA: 0.75, 0.75, 0.75, 0.75].
+  /// \param[in] thickness Thickness of the visualizing task-space trajectory.
+  /// Default is 0.01.
+  /// \param[in] numLineSegments Number of line-segments of the visualizing
+  /// task-space trajectory. Default is 16.
+  /// \return Trajectory marker added to this viewer.
+  TrajectoryMarkerPtr addTrajectoryMarker(
+      trajectory::ConstTrajectoryPtr trajectory,
+      const dart::dynamics::MetaSkeleton& skeleton,
+      const dart::dynamics::Frame& frame,
+      const Eigen::Vector4d& rgba = Eigen::Vector4d::Constant(0.75),
+      double thickness = 0.01,
+      std::size_t numLineSegments = 16u);
+
   void setAutoUpdate(bool flag);
   void update();
 
@@ -60,6 +83,7 @@ protected:
   interactive_markers::InteractiveMarkerServer mMarkerServer;
   std::set<SkeletonMarkerPtr> mSkeletonMarkers;
   std::set<FrameMarkerPtr> mFrameMarkers;
+  std::set<TrajectoryMarkerPtr> mTrajectoryMarkers;
 
   std::atomic_bool mRunning;
   std::atomic_bool mUpdating;

--- a/include/aikido/rviz/InteractiveMarkerViewer.hpp
+++ b/include/aikido/rviz/InteractiveMarkerViewer.hpp
@@ -5,6 +5,7 @@
 #include <set>
 #include <thread>
 
+#include <dart/common/NameManager.hpp>
 #include <dart/dynamics/Frame.hpp>
 #include <dart/dynamics/SmartPointer.hpp>
 #include <interactive_markers/interactive_marker_server.h>
@@ -84,6 +85,11 @@ protected:
   std::set<SkeletonMarkerPtr> mSkeletonMarkers;
   std::set<FrameMarkerPtr> mFrameMarkers;
   std::set<TrajectoryMarkerPtr> mTrajectoryMarkers;
+
+  /// NameManager for name uniqueness of trajectories in the same
+  /// InteractiveMarkerServer.
+  dart::common::NameManager<trajectory::ConstTrajectoryPtr>
+      mTrajectoryNameManager;
 
   std::atomic_bool mRunning;
   std::atomic_bool mUpdating;

--- a/include/aikido/rviz/InteractiveMarkerViewer.hpp
+++ b/include/aikido/rviz/InteractiveMarkerViewer.hpp
@@ -54,17 +54,17 @@ public:
 
   /// Adds trajectory marker to this viewer.
   ///
-  /// \param[in] trajectory C-sapce (or joint-space) trajectory.
+  /// \param[in] trajectory C-space (or joint-space) trajectory.
   /// \param[in] skeleton Target DART meta skeleton that the C-space trajectory
   /// will be applied to compute the visualizing task-space trajectory.
   /// \param[in] frame Target DART frame where the trajectory of its origin
   /// will be visualized.
-  /// \param[in] rgba Color and alpha of the visualizing task-space trajectory.
-  /// Default is [RGBA: 0.75, 0.75, 0.75, 0.75].
-  /// \param[in] thickness Thickness of the visualizing task-space trajectory.
-  /// Default is 0.01.
-  /// \param[in] numLineSegments Number of line-segments of the visualizing
-  /// task-space trajectory. Default is 16.
+  /// \param[in] rgba Color and alpha of the visualized trajectory. Default is
+  /// [RGBA: 0.75, 0.75, 0.75, 0.75].
+  /// \param[in] thickness Thickness of the visualized trajectory. Default is
+  /// 0.01.
+  /// \param[in] numLineSegments Number of line segments in the visualized
+  /// trajectory. Default is 16.
   /// \return Trajectory marker added to this viewer.
   TrajectoryMarkerPtr addTrajectoryMarker(
       trajectory::ConstTrajectoryPtr trajectory,

--- a/include/aikido/rviz/SmartPointers.hpp
+++ b/include/aikido/rviz/SmartPointers.hpp
@@ -16,6 +16,7 @@ namespace rviz {
 AIKIDO_DEFINE_SHARED_PTR(FrameMarker)
 AIKIDO_DEFINE_SHARED_PTR(BodyNodeMarker)
 AIKIDO_DEFINE_SHARED_PTR(SkeletonMarker)
+AIKIDO_DEFINE_SHARED_PTR(TrajectoryMarker)
 AIKIDO_DEFINE_SHARED_PTR(TSRMarker)
 
 } // namespace rviz

--- a/include/aikido/rviz/TrajectoryMarker.hpp
+++ b/include/aikido/rviz/TrajectoryMarker.hpp
@@ -17,17 +17,17 @@ public:
   /// Constructor.
   /// \param[in] markerServer RViz marker server.
   /// \param[in] frameId RViz frame ID.
-  /// \param[in] trajectory C-sapce (or joint-space) trajectory.
-  /// \param[in] skeleton Target DART meta skeleton that the C-space trajectory
-  /// will be applied to compute the visualizing task-space trajectory.
-  /// \param[in] frame Target DART frame where the trajectory of its origin
-  /// will be visualized.
-  /// \param[in] rgba Color and alpha of the visualizing task-space trajectory.
-  /// Default is [RGBA: 0.75, 0.75, 0.75, 0.75].
-  /// \param[in] thickness Thickness of the visualizing task-space trajectory.
-  /// Default is 0.01.
-  /// \param[in] numLineSegments Number of line-segments of the visualizing
-  /// task-space trajectory. Default is 16.
+  /// \param[in] trajectory C-space (or joint-space) trajectory.
+  /// \param[in] skeleton DART meta skeleton for visualizing the trajectory in
+  /// task space.
+  /// \param[in] frame DART frame for visualizing the trajectory in task space.
+  /// The trajectory of the origin will be visualized.
+  /// \param[in] rgba Color and alpha of the visualized trajectory. Default is
+  /// [RGBA: 0.75, 0.75, 0.75, 0.75].
+  /// \param[in] thickness Thickness of the visualized trajectory. Default is
+  /// 0.01.
+  /// \param[in] numLineSegments Number of line segments in the visualized
+  /// trajectory. Default is 16.
   TrajectoryMarker(
       interactive_markers::InteractiveMarkerServer* markerServer,
       const std::string& frameId,
@@ -43,36 +43,37 @@ public:
 
   /// Sets or updates trajectory to visualize
   ///
-  /// \param[in] trajectory C-sapce (or joint-space) trajectory. The statespace
-  /// of the trajectory should be MetaSkeletonStateSpace. Otherwise, throw
-  /// invalid_argument exception.
+  /// \param[in] trajectory C-space (or joint-space) trajectory. The statespace
+  /// of the trajectory should be MetaSkeletonStateSpace. Otherwise, throws
+  /// invalid_argument exception. Passing in nullptr will clear the current
+  /// trajectory.
   void setTrajectory(trajectory::ConstTrajectoryPtr trajectory);
 
   /// Returns trajectory associated with this marker
   trajectory::ConstTrajectoryPtr getTrajectory() const;
 
-  /// Sets or updates color (RGB) of visualizing trajectory.
+  /// Sets or updates color (RGB) of visualized trajectory.
   void setColor(const Eigen::Vector3d& rgb);
 
-  /// Returns color (RGB) of visualizing trajectory.
+  /// Returns color (RGB) of visualized trajectory.
   Eigen::Vector3d getColor() const;
 
-  /// Sets or updates alpha of visualizing trajectory.
+  /// Sets or updates alpha of visualized trajectory.
   void setAlpha(double alpha);
 
-  /// Returns alpha of visualizing trajectory.
+  /// Returns alpha of visualized trajectory.
   double getAlpha() const;
 
-  /// Sets or updates RGBA of visualizing trajectory.
+  /// Sets or updates RGBA of visualized trajectory.
   void setRGBA(const Eigen::Vector4d& rgb);
 
-  /// Returns RGBA of visualizing trajectory.
+  /// Returns RGBA of visualized trajectory.
   Eigen::Vector4d getRBGA() const;
 
-  /// Sets or updates thickness of visualizing trajectory.
+  /// Sets or updates thickness of visualized trajectory.
   void setThickness(double thickness);
 
-  /// Returns thickness of visualizing trajectory.
+  /// Returns thickness of visualized trajectory.
   double getThickness() const;
 
   /// Sets or updates number of line segments of the visualizing trajectory.
@@ -106,10 +107,10 @@ private:
   /// RViz interactive marker.
   visualization_msgs::InteractiveMarker mInteractiveMarker;
 
-  ///
+  /// Frame name of RViz interactive marker.
   std::string mFrameId;
 
-  /// C-sapce (or joint-space) trajectory.
+  /// C-space (or joint-space) trajectory.
   trajectory::ConstTrajectoryPtr mTrajectory;
 
   /// Number of line segments of the discretized task-space trajectory.

--- a/include/aikido/rviz/TrajectoryMarker.hpp
+++ b/include/aikido/rviz/TrajectoryMarker.hpp
@@ -17,6 +17,10 @@ public:
   /// Constructor.
   /// \param[in] markerServer RViz marker server.
   /// \param[in] frameId RViz frame ID.
+  /// \param[in] markerName Name of the RViz InteractiveMarker associated with
+  /// this TrajectoryMarker. The name must be unique in the same
+  /// InteractiveMarkerServer. AIKIDO InteractiveMarkerViewer uses a name
+  /// manager for the name uniqueness.
   /// \param[in] trajectory C-space (or joint-space) trajectory.
   /// \param[in] skeleton DART meta skeleton for visualizing the trajectory in
   /// task space.
@@ -31,6 +35,7 @@ public:
   TrajectoryMarker(
       interactive_markers::InteractiveMarkerServer* markerServer,
       const std::string& frameId,
+      const std::string& markerName,
       trajectory::ConstTrajectoryPtr trajectory,
       const dart::dynamics::MetaSkeleton& skeleton,
       const dart::dynamics::Frame& frame,

--- a/include/aikido/rviz/TrajectoryMarker.hpp
+++ b/include/aikido/rviz/TrajectoryMarker.hpp
@@ -1,0 +1,133 @@
+#ifndef AIKIDO_RVIZ_TRAJECTORYMARKER_HPP_
+#define AIKIDO_RVIZ_TRAJECTORYMARKER_HPP_
+
+#include <dart/dynamics/Frame.hpp>
+#include <interactive_markers/interactive_marker_server.h>
+#include <visualization_msgs/InteractiveMarker.h>
+#include "aikido/trajectory/Trajectory.hpp"
+
+namespace aikido {
+namespace rviz {
+
+/// A wrapper class of RViz InteractiveMarker for visualizing AIKIDO trajectory
+/// in RViz.
+class TrajectoryMarker final
+{
+public:
+  /// Constructor.
+  /// \param[in] markerServer RViz marker server.
+  /// \param[in] frameId RViz frame ID.
+  /// \param[in] trajectory C-sapce (or joint-space) trajectory.
+  /// \param[in] skeleton Target DART meta skeleton that the C-space trajectory
+  /// will be applied to compute the visualizing task-space trajectory.
+  /// \param[in] frame Target DART frame where the trajectory of its origin
+  /// will be visualized.
+  /// \param[in] rgba Color and alpha of the visualizing task-space trajectory.
+  /// Default is [RGBA: 0.75, 0.75, 0.75, 0.75].
+  /// \param[in] thickness Thickness of the visualizing task-space trajectory.
+  /// Default is 0.01.
+  /// \param[in] numLineSegments Number of line-segments of the visualizing
+  /// task-space trajectory. Default is 16.
+  TrajectoryMarker(
+      interactive_markers::InteractiveMarkerServer* markerServer,
+      const std::string& frameId,
+      trajectory::ConstTrajectoryPtr trajectory,
+      const dart::dynamics::MetaSkeleton& skeleton,
+      const dart::dynamics::Frame& frame,
+      const Eigen::Vector4d& rgba = Eigen::Vector4d::Constant(0.75),
+      double thickness = 0.01,
+      std::size_t numLineSegments = 16u);
+
+  /// Destructor
+  ~TrajectoryMarker();
+
+  /// Sets or updates trajectory to visualize
+  void setTrajectory(trajectory::ConstTrajectoryPtr trajectory);
+
+  /// Returns trajectory associated with this marker
+  trajectory::ConstTrajectoryPtr getTrajectory() const;
+
+  /// Sets or updates color (RGB) of visualizing trajectory.
+  void setColor(const Eigen::Vector3d& rgb);
+
+  /// Returns color (RGB) of visualizing trajectory.
+  Eigen::Vector3d getColor() const;
+
+  /// Sets or updates alpha of visualizing trajectory.
+  void setAlpha(double alpha);
+
+  /// Returns alpha of visualizing trajectory.
+  double getAlpha() const;
+
+  /// Sets or updates RGBA of visualizing trajectory.
+  void setRGBA(const Eigen::Vector4d& rgb);
+
+  /// Returns RGBA of visualizing trajectory.
+  Eigen::Vector4d getRBGA() const;
+
+  /// Sets or updates thickness of visualizing trajectory.
+  void setThickness(double thickness);
+
+  /// Returns thickness of visualizing trajectory.
+  double getThickness() const;
+
+  /// Sets or updates number of line segments of the visualizing trajectory.
+  void setNumLineSegments(std::size_t numLineSegments);
+
+  /// Returns number of line segments of the visualizing trajectory.
+  std::size_t getNumLineSegments() const;
+
+  /// Updates this marker.
+  ///
+  /// This function should be called after the properties are changed (e.g.,
+  /// trajectory, color, thickness, number of line-segments) so that RViz
+  /// reflects the changes accordingly.
+  void update();
+
+private:
+  /// Updates trajectory points based on trajectory and number of line-segments.
+  ///
+  /// This function is called by update().
+  void updatePoints();
+
+  /// Returns marker.
+  visualization_msgs::Marker& getMarker();
+
+  /// Returns const marker.
+  const visualization_msgs::Marker& getMarker() const;
+
+  /// RViz marker server.
+  interactive_markers::InteractiveMarkerServer* mMarkerServer;
+
+  /// RViz interactive marker.
+  visualization_msgs::InteractiveMarker mInteractiveMarker;
+
+  ///
+  std::string mFrameId;
+
+  /// C-sapce (or joint-space) trajectory.
+  trajectory::ConstTrajectoryPtr mTrajectory;
+
+  /// Number of line segments of the discretized task-space trajectory.
+  std::size_t mNumLineSegments;
+  // TODO(JS): Consider switching to resolution once arc-length calculation is
+  // available for Trajectoy.
+
+  /// Target DART meta skeleton that the C-space trajectory will be applied to
+  /// compute the visualizing task-space trajectory.
+  const dart::dynamics::MetaSkeleton& mSkeleton;
+
+  /// Target DART frame where the trajectory of its origin will be visualized.
+  const dart::dynamics::Frame& mFrame;
+
+  /// Whether the associated RViz maker needs to be updated.
+  bool mNeedUpdate;
+
+  /// Whether the trajectory points need to be updated.
+  bool mNeedPointsUpdate;
+};
+
+} // namespace rviz
+} // namespace aikido
+
+#endif // AIKIDO_RVIZ_TRAJECTORYMARKER_HPP_

--- a/include/aikido/rviz/TrajectoryMarker.hpp
+++ b/include/aikido/rviz/TrajectoryMarker.hpp
@@ -42,6 +42,10 @@ public:
   ~TrajectoryMarker();
 
   /// Sets or updates trajectory to visualize
+  ///
+  /// \param[in] trajectory C-sapce (or joint-space) trajectory. The statespace
+  /// of the trajectory should be MetaSkeletonStateSpace. Otherwise, throw
+  /// invalid_argument exception.
   void setTrajectory(trajectory::ConstTrajectoryPtr trajectory);
 
   /// Returns trajectory associated with this marker

--- a/include/aikido/rviz/shape_conversions.hpp
+++ b/include/aikido/rviz/shape_conversions.hpp
@@ -34,6 +34,7 @@ geometry_msgs::Quaternion convertEigenToROSQuaternion(
     const Eigen::Quaterniond& v);
 geometry_msgs::Pose convertEigenToROSPose(const Eigen::Isometry3d& v);
 std_msgs::ColorRGBA convertEigenToROSColorRGBA(const Eigen::Vector4d& v);
+Eigen::Vector4d convertROSColorRGBAToEigen(const std_msgs::ColorRGBA& v);
 
 bool convertAssimpMeshToROSTriangleList(
     const aiMesh& mesh, std::vector<geometry_msgs::Point>* triangle_list);

--- a/src/planner/vectorfield/detail/VectorFieldIntegrator.cpp
+++ b/src/planner/vectorfield/detail/VectorFieldIntegrator.cpp
@@ -155,7 +155,7 @@ void VectorFieldIntegrator::check(const Eigen::VectorXd& q, double t)
   }
 }
 
-} // namesapce detail
+} // namespace detail
 } // namespace vectorfield
 } // namespace planner
 } // namespace aikido

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -32,6 +32,7 @@ set(sources
   ShapeFrameMarker.cpp
   SkeletonMarker.cpp
   shape_conversions.cpp
+  TrajectoryMarker.cpp
   TSRMarker.cpp
   WorldInteractiveMarkerViewer.cpp
 )

--- a/src/rviz/InteractiveMarkerViewer.cpp
+++ b/src/rviz/InteractiveMarkerViewer.cpp
@@ -17,11 +17,12 @@ namespace rviz {
 InteractiveMarkerViewer::InteractiveMarkerViewer(
     const std::string& topicNamespace, const std::string& frameId)
   : mMarkerServer(topicNamespace, "", true)
+  , mTrajectoryNameManager("Trajectory Name Manager", "Trajectory")
   , mRunning(false)
   , mUpdating(false)
   , mFrameId(frameId)
 {
-  // Do nothing
+  mTrajectoryNameManager.setPattern("Frame[%s(%d)]");
 }
 
 //==============================================================================
@@ -119,6 +120,7 @@ TrajectoryMarkerPtr InteractiveMarkerViewer::addTrajectoryMarker(
   auto marker = std::make_shared<TrajectoryMarker>(
       &mMarkerServer,
       mFrameId,
+      mTrajectoryNameManager.issueNewNameAndAdd("", trajectory),
       std::move(trajectory),
       skeleton,
       frame,

--- a/src/rviz/TrajectoryMarker.cpp
+++ b/src/rviz/TrajectoryMarker.cpp
@@ -69,6 +69,17 @@ void TrajectoryMarker::setTrajectory(trajectory::ConstTrajectoryPtr trajectory)
 {
   using visualization_msgs::Marker;
 
+  if (trajectory)
+  {
+    auto statespace = trajectory->getStateSpace();
+    if (!std::dynamic_pointer_cast<statespace::dart::MetaSkeletonStateSpace>(
+            statespace))
+    {
+      throw std::invalid_argument(
+          "The statespace in the trajectory should be MetaSkeletonStateSpace");
+    }
+  }
+
   mTrajectory = std::move(trajectory);
 
   mNeedPointsUpdate = true;

--- a/src/rviz/TrajectoryMarker.cpp
+++ b/src/rviz/TrajectoryMarker.cpp
@@ -29,9 +29,6 @@ TrajectoryMarker::TrajectoryMarker(
   using visualization_msgs::InteractiveMarkerControl;
   using visualization_msgs::Marker;
 
-  // TODO(JS): Check the compatibility of statespaces of the skeleton and the
-  // spline
-
   // Setting invariant properties
   mInteractiveMarker.header.frame_id = mFrameId;
   mInteractiveMarker.name = "Frame[Trajectory]";
@@ -78,6 +75,15 @@ void TrajectoryMarker::setTrajectory(trajectory::ConstTrajectoryPtr trajectory)
       throw std::invalid_argument(
           "The statespace in the trajectory should be MetaSkeletonStateSpace");
     }
+
+    if (statespace->getDimension() != mSkeleton.getNumDofs())
+    {
+      throw std::invalid_argument(
+          "The statespace in the trajectory is not compatible (dimensions are "
+          "different) to DART meta skeleton for visualizing the trajectory");
+    }
+    // TODO: Use more comprehensive compatibility check once available than
+    // just checking the dimensions.
   }
 
   mTrajectory = std::move(trajectory);

--- a/src/rviz/TrajectoryMarker.cpp
+++ b/src/rviz/TrajectoryMarker.cpp
@@ -2,6 +2,7 @@
 
 #include "aikido/rviz/shape_conversions.hpp"
 #include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpaceSaver.hpp"
 
 namespace aikido {
 namespace rviz {
@@ -217,12 +218,13 @@ void TrajectoryMarker::updatePoints()
     return;
   }
 
-  Eigen::VectorXd savedPositions = mSkeleton.getPositions();
-
   statespace::StateSpacePtr statespace = mTrajectory->getStateSpace();
   auto metaSkeletonSs
       = std::dynamic_pointer_cast<statespace::dart::MetaSkeletonStateSpace>(
           statespace);
+
+  auto saver = statespace::dart::MetaSkeletonStateSpaceSaver(metaSkeletonSs);
+  DART_UNUSED(saver);
 
   auto state = metaSkeletonSs->createState();
   double t = mTrajectory->getStartTime();
@@ -242,9 +244,6 @@ void TrajectoryMarker::updatePoints()
   metaSkeletonSs->setState(state);
   pose = mFrame.getTransform().translation();
   points.emplace_back(convertEigenToROSPoint(pose));
-
-  const_cast<dart::dynamics::MetaSkeleton&>(mSkeleton).setPositions(
-      savedPositions);
 
   mNeedPointsUpdate = false;
 

--- a/src/rviz/TrajectoryMarker.cpp
+++ b/src/rviz/TrajectoryMarker.cpp
@@ -166,10 +166,10 @@ double TrajectoryMarker::getThickness() const
 //==============================================================================
 void TrajectoryMarker::setNumLineSegments(std::size_t numLineSegments)
 {
-  if (numLineSegments < 2)
+  if (numLineSegments == 0u)
   {
-    throw std::invalid_argument(
-        "Number of line segments should be greater than 2");
+    dtwarn << "[TrajectoryMarker::setNumLineSegments] numLineSegments is set to"
+              "zero. This trajectory will not be rendered.";
   }
 
   mNumLineSegments = numLineSegments;
@@ -209,8 +209,12 @@ void TrajectoryMarker::updatePoints()
   auto& points = marker.points;
   points.clear();
 
-  if (!mTrajectory)
+  if (!mTrajectory || mNumLineSegments == 0u)
+  {
+    mNeedPointsUpdate = false;
+    mNeedUpdate = true;
     return;
+  }
 
   Eigen::VectorXd savedPositions = mSkeleton.getPositions();
 

--- a/src/rviz/TrajectoryMarker.cpp
+++ b/src/rviz/TrajectoryMarker.cpp
@@ -10,6 +10,7 @@ namespace rviz {
 TrajectoryMarker::TrajectoryMarker(
     interactive_markers::InteractiveMarkerServer* markerServer,
     const std::string& frameId,
+    const std::string& markerName,
     trajectory::ConstTrajectoryPtr trajectory,
     const dart::dynamics::MetaSkeleton& targetSkeleton,
     const dart::dynamics::Frame& frame,
@@ -31,7 +32,7 @@ TrajectoryMarker::TrajectoryMarker(
 
   // Setting invariant properties
   mInteractiveMarker.header.frame_id = mFrameId;
-  mInteractiveMarker.name = "Frame[Trajectory]";
+  mInteractiveMarker.name = markerName;
   // TODO: Assign trajectory name once available
   mInteractiveMarker.pose.orientation.w = 1;
   mInteractiveMarker.scale = 1;

--- a/src/rviz/TrajectoryMarker.cpp
+++ b/src/rviz/TrajectoryMarker.cpp
@@ -1,0 +1,248 @@
+#include "aikido/rviz/TrajectoryMarker.hpp"
+
+#include "aikido/rviz/shape_conversions.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
+
+namespace aikido {
+namespace rviz {
+
+//==============================================================================
+TrajectoryMarker::TrajectoryMarker(
+    interactive_markers::InteractiveMarkerServer* markerServer,
+    const std::string& frameId,
+    trajectory::ConstTrajectoryPtr trajectory,
+    const dart::dynamics::MetaSkeleton& targetSkeleton,
+    const dart::dynamics::Frame& frame,
+    const Eigen::Vector4d& rgba,
+    double thickness,
+    std::size_t numLineSegments)
+  : mMarkerServer(markerServer)
+  , mInteractiveMarker()
+  , mFrameId(frameId)
+  , mTrajectory(nullptr)
+  , mNumLineSegments()
+  , mSkeleton(targetSkeleton)
+  , mFrame(frame)
+  , mNeedUpdate(true)
+  , mNeedPointsUpdate(true)
+{
+  using visualization_msgs::InteractiveMarkerControl;
+  using visualization_msgs::Marker;
+
+  // TODO(JS): Check the compatibility of statespaces of the skeleton and the
+  // spline
+
+  // Setting invariant properties
+  mInteractiveMarker.header.frame_id = mFrameId;
+  mInteractiveMarker.name = "Frame[Trajectory]";
+  // TODO: Assign trajectory name once available
+  mInteractiveMarker.pose.orientation.w = 1;
+  mInteractiveMarker.scale = 1;
+
+  mInteractiveMarker.controls.resize(1);
+  InteractiveMarkerControl& control = mInteractiveMarker.controls.front();
+  control.orientation.w = 1;
+  control.orientation_mode = InteractiveMarkerControl::INHERIT;
+  control.interaction_mode = InteractiveMarkerControl::NONE;
+  control.always_visible = true;
+  control.markers.resize(1);
+
+  auto& marker = getMarker();
+  marker.type = Marker::LINE_STRIP;
+  marker.pose.orientation.w = 1.0;
+
+  // Setting variant properties
+  setTrajectory(std::move(trajectory));
+  setRGBA(rgba);
+  setThickness(thickness);
+  setNumLineSegments(numLineSegments);
+}
+
+//==============================================================================
+TrajectoryMarker::~TrajectoryMarker()
+{
+  mMarkerServer->erase(mInteractiveMarker.name);
+}
+
+//==============================================================================
+void TrajectoryMarker::setTrajectory(trajectory::ConstTrajectoryPtr trajectory)
+{
+  using visualization_msgs::Marker;
+
+  mTrajectory = std::move(trajectory);
+
+  mNeedPointsUpdate = true;
+}
+
+//==============================================================================
+trajectory::ConstTrajectoryPtr TrajectoryMarker::getTrajectory() const
+{
+  return mTrajectory;
+}
+
+//==============================================================================
+void TrajectoryMarker::setColor(const Eigen::Vector3d& rgb)
+{
+  auto& marker = getMarker();
+  marker.color.r = rgb[0];
+  marker.color.g = rgb[1];
+  marker.color.b = rgb[2];
+
+  mNeedUpdate = true;
+}
+
+//==============================================================================
+Eigen::Vector3d TrajectoryMarker::getColor() const
+{
+  const auto& marker = getMarker();
+  return convertROSColorRGBAToEigen(marker.color).head<3>();
+}
+
+//==============================================================================
+void TrajectoryMarker::setAlpha(double alpha)
+{
+  auto& marker = getMarker();
+  marker.color.a = alpha;
+
+  mNeedUpdate = true;
+}
+
+//==============================================================================
+double TrajectoryMarker::getAlpha() const
+{
+  const auto& marker = getMarker();
+  return marker.color.a;
+}
+
+//==============================================================================
+void TrajectoryMarker::setRGBA(const Eigen::Vector4d& rgba)
+{
+  auto& marker = getMarker();
+  marker.color = convertEigenToROSColorRGBA(rgba);
+
+  mNeedUpdate = true;
+}
+
+//==============================================================================
+Eigen::Vector4d TrajectoryMarker::getRBGA() const
+{
+  const auto& marker = getMarker();
+  return convertROSColorRGBAToEigen(marker.color);
+}
+
+//==============================================================================
+void TrajectoryMarker::setThickness(double thickness)
+{
+  auto& marker = getMarker();
+  marker.scale.x = thickness;
+
+  mNeedUpdate = true;
+}
+
+//==============================================================================
+double TrajectoryMarker::getThickness() const
+{
+  const auto& marker = getMarker();
+  return marker.scale.x;
+}
+
+//==============================================================================
+void TrajectoryMarker::setNumLineSegments(std::size_t numLineSegments)
+{
+  if (numLineSegments < 2)
+  {
+    throw std::invalid_argument(
+        "Number of line segments should be greater than 2");
+  }
+
+  mNumLineSegments = numLineSegments;
+
+  mNeedPointsUpdate = true;
+}
+
+//==============================================================================
+std::size_t TrajectoryMarker::getNumLineSegments() const
+{
+  return mNumLineSegments;
+}
+
+//==============================================================================
+void TrajectoryMarker::update()
+{
+  if (mNeedPointsUpdate)
+    updatePoints();
+
+  if (!mNeedUpdate)
+    return;
+
+  mMarkerServer->insert(mInteractiveMarker);
+
+  mNeedUpdate = false;
+}
+
+//==============================================================================
+void TrajectoryMarker::updatePoints()
+{
+  using visualization_msgs::Marker;
+
+  if (!mNeedPointsUpdate)
+    return;
+
+  auto& marker = getMarker();
+  auto& points = marker.points;
+  points.clear();
+
+  if (!mTrajectory)
+    return;
+
+  Eigen::VectorXd savedPositions = mSkeleton.getPositions();
+
+  statespace::StateSpacePtr statespace = mTrajectory->getStateSpace();
+  auto metaSkeletonSs
+      = std::dynamic_pointer_cast<statespace::dart::MetaSkeletonStateSpace>(
+          statespace);
+
+  auto state = metaSkeletonSs->createState();
+  double t = mTrajectory->getStartTime();
+  const double dt = mTrajectory->getDuration() / mNumLineSegments;
+
+  points.reserve(mNumLineSegments + 1u);
+  Eigen::Vector3d pose;
+  for (std::size_t i = 0u; i < mNumLineSegments - 1u; ++i)
+  {
+    mTrajectory->evaluate(t, state);
+    metaSkeletonSs->setState(state);
+    pose = mFrame.getTransform().translation();
+    points.emplace_back(convertEigenToROSPoint(pose));
+    t += dt;
+  }
+  mTrajectory->evaluate(mTrajectory->getEndTime(), state);
+  metaSkeletonSs->setState(state);
+  pose = mFrame.getTransform().translation();
+  points.emplace_back(convertEigenToROSPoint(pose));
+
+  const_cast<dart::dynamics::MetaSkeleton&>(mSkeleton).setPositions(
+      savedPositions);
+
+  mNeedPointsUpdate = false;
+
+  mNeedUpdate = true;
+}
+
+//==============================================================================
+visualization_msgs::Marker& TrajectoryMarker::getMarker()
+{
+  using visualization_msgs::Marker;
+  Marker& marker = mInteractiveMarker.controls.front().markers.front();
+  return marker;
+}
+
+//==============================================================================
+const visualization_msgs::Marker& TrajectoryMarker::getMarker() const
+{
+  auto& marker = const_cast<TrajectoryMarker*>(this)->getMarker();
+  return const_cast<const visualization_msgs::Marker&>(marker);
+}
+
+} // namespace rviz
+} // namespace aikido

--- a/src/rviz/WorldInteractiveMarkerViewer.cpp
+++ b/src/rviz/WorldInteractiveMarkerViewer.cpp
@@ -2,6 +2,7 @@
 #include <aikido/rviz/FrameMarker.hpp>
 #include <aikido/rviz/InteractiveMarkerViewer.hpp>
 #include <aikido/rviz/SkeletonMarker.hpp>
+#include <aikido/rviz/TrajectoryMarker.hpp>
 #include <aikido/rviz/WorldInteractiveMarkerViewer.hpp>
 
 using aikido::rviz::InteractiveMarkerViewer;
@@ -90,6 +91,9 @@ void WorldInteractiveMarkerViewer::update()
 
   // TODO: Merge this into a unified update loop.
   for (const FrameMarkerPtr& marker : mFrameMarkers)
+    marker->update();
+
+  for (const auto& marker : mTrajectoryMarkers)
     marker->update();
 
   mMarkerServer.applyChanges();

--- a/src/rviz/shape_conversions.cpp
+++ b/src/rviz/shape_conversions.cpp
@@ -51,6 +51,17 @@ std_msgs::ColorRGBA convertEigenToROSColorRGBA(const Eigen::Vector4d& v)
 }
 
 //==============================================================================
+Eigen::Vector4d convertROSColorRGBAToEigen(const std_msgs::ColorRGBA& v)
+{
+  Eigen::Vector4d vec4;
+  vec4[0] = v.r;
+  vec4[1] = v.g;
+  vec4[2] = v.b;
+  vec4[3] = v.a;
+  return vec4;
+}
+
+//==============================================================================
 geometry_msgs::Quaternion convertEigenToROSQuaternion(
     const Eigen::Quaterniond& v)
 {


### PR DESCRIPTION
This PR adds `aikido::rviz::TrajectoryMarker` for visualizing trajectories in RViz.

The inputs are:
* `aikido::trajectory::Trajectory`: A C-space trajectory used to compute task-space trajectory
* `dart::dynamics::Skeleton`: Target skeleton the trajectory is applied to.
* `dart::dynamics::Frame`: Target frame to visualize the trajectory of the origin.

`aikido::rviz::TrajectoryMarker` has several rendering options:
* trajectory color (RBGA)
* trajectory thickness
* number of line-segments of the task-space trajectory

Example:
![image](https://user-images.githubusercontent.com/4038467/33862410-6e079414-de97-11e7-8ced-94e4953eef40.png)

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change (N/A)
