### PR TITLE
Add group field to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ dist: trusty
 
 sudo: required
 
+group: travis_lts
+
 language: generic
 
 env:


### PR DESCRIPTION
Travis CI recently added `group` field to specify which image to be used. `group: travis_lts` (default) is a stable image while `group: travis_latest` is an image that is frequently being updated with new packages.

I believe we want to use `group: travis_latest`.

Related links:
* https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch
* https://blog.travis-ci.com/2017-12-01-new-update-schedule-for-linux-build-images