### PR TITLE
Support new ErrorStr API in tinyxml2 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 
   * Added WorldInteractiveMarkerViewer: [#242](https://github.com/personalrobotics/aikido/pull/242)
 
+* IO
+
+  * Added support for new ErrorStr API in tinyxml2 6.0.0: [#290](https://github.com/personalrobotics/aikido/pull/290)
+
 * Build & Testing & ETC
 
   * Changed to use size_t over std::size_t: [#230](https://github.com/personalrobotics/aikido/pull/230)

--- a/cmake/FindTinyXML2.cmake
+++ b/cmake/FindTinyXML2.cmake
@@ -1,15 +1,45 @@
-# Copyright (c) 2014 Andrew Kelley
-# This file is MIT licensed.
-# See http://opensource.org/licenses/MIT
+# Copyright (c) 2011-2017, The DART development contributors
+# All rights reserved.
+#
+# The list of contributors can be found at:
+#   https://github.com/dartsim/dart/blob/master/LICENSE
+#
+# This file is provided under the "BSD-style" License
 
-# TinyXML2_FOUND
-# TinyXML2_INCLUDE_DIRS
-# TinyXML2_LIBRARIES
+# Find TINYXML2
+#
+# This sets the following variables:
+# TINYXML2_FOUND
+# TINYXML2_INCLUDE_DIRS
+# TINYXML2_LIBRARIES
+# TINYXML2_VERSION
 
-find_path(TinyXML2_INCLUDE_DIRS NAMES tinyxml2.h)
-find_library(TinyXML2_LIBRARIES NAMES tinyxml2)
+find_package(PkgConfig QUIET)
 
+# Check if the pkgconfig file is installed
+pkg_check_modules(PC_TINYXML2 tinyxml2 QUIET)
+
+# Include directories
+find_path(TinyXML2_INCLUDE_DIRS
+    NAMES tinyxml2.h
+    HINTS ${PC_TinyXML2_INCLUDEDIR}
+    PATHS "${CMAKE_INSTALL_PREFIX}/include")
+
+# Libraries
+if(MSVC)
+  set(TinyXML2_LIBRARIES optimized tinyxml2 debug tinyxml2d)
+else()
+  find_library(TinyXML2_LIBRARIES
+      NAMES tinyxml2
+      HINTS ${PC_TinyXML2_LIBDIR})
+endif()
+
+# Version
+set(TinyXML2_VERSION ${PC_TINYXML2_VERSION})
+
+# Set (NAME)_FOUND if all the variables and the version are satisfied.
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(TinyXML2 DEFAULT_MSG TinyXML2_LIBRARIES TinyXML2_INCLUDE_DIRS)
-
-mark_as_advanced(TinyXML2_INCLUDE_DIRS TinyXML2_LIBRARIES)
+find_package_handle_standard_args(TinyXML2
+    FAIL_MESSAGE  DEFAULT_MSG
+    REQUIRED_VARS TinyXML2_INCLUDE_DIRS TinyXML2_LIBRARIES
+    VERSION_VAR   TinyXML2_VERSION)

--- a/cmake/FindTinyXML2.cmake
+++ b/cmake/FindTinyXML2.cmake
@@ -6,13 +6,13 @@
 #
 # This file is provided under the "BSD-style" License
 
-# Find TINYXML2
+# Find TinyXML2
 #
 # This sets the following variables:
-# TINYXML2_FOUND
-# TINYXML2_INCLUDE_DIRS
-# TINYXML2_LIBRARIES
-# TINYXML2_VERSION
+# TinyXML2_FOUND
+# TinyXML2_INCLUDE_DIRS
+# TinyXML2_LIBRARIES
+# TinyXML2_VERSION
 
 find_package(PkgConfig QUIET)
 

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -56,6 +56,13 @@ if(YAMLCPP_NODE_HAS_MARK)
     PUBLIC YAMLCPP_NODE_HAS_MARK)
 endif()
 
+# Define TINYXML2_MAJOR_VERSION_GE_6 to support API breaking changes of
+# tinyxml2 6
+if (NOT TINYXML2_VERSION VERSION_LESS "6.0.0")
+  target_compile_definitions("${PROJECT_NAME}_io"
+    PRIVATE "TINYXML2_MAJOR_VERSION_GE_6")
+endif()
+
 add_component(${PROJECT_NAME} io)
 add_component_targets(${PROJECT_NAME} io "${PROJECT_NAME}_io")
 add_component_dependencies(${PROJECT_NAME} io common)

--- a/src/io/CatkinResourceRetriever.cpp
+++ b/src/io/CatkinResourceRetriever.cpp
@@ -28,9 +28,9 @@ std::string getPackageNameFromXML(const std::string& _path)
   {
     dtwarn << "[CatkinResourceRetriever] Failed loading package.xml file '"
 #ifdef TINYXML2_MAJOR_VERSION_GE_6
-           << _path << "': " << document.GetErrorStr1() << "\n";
-#else
            << _path << "': " << document.ErrorStr() << "\n";
+#else
+           << _path << "': " << document.GetErrorStr1() << "\n";
 #endif
     return "";
   }

--- a/src/io/CatkinResourceRetriever.cpp
+++ b/src/io/CatkinResourceRetriever.cpp
@@ -1,4 +1,4 @@
-#include <aikido/io/CatkinResourceRetriever.hpp>
+#include "aikido/io/CatkinResourceRetriever.hpp"
 
 #include <fstream>
 #include <iostream>
@@ -27,7 +27,11 @@ std::string getPackageNameFromXML(const std::string& _path)
   if (document.LoadFile(_path.c_str()))
   {
     dtwarn << "[CatkinResourceRetriever] Failed loading package.xml file '"
+#ifdef TINYXML2_MAJOR_VERSION_GE_6
            << _path << "': " << document.GetErrorStr1() << "\n";
+#else
+           << _path << "': " << document.ErrorStr() << "\n";
+#endif
     return "";
   }
 


### PR DESCRIPTION
There were API breaking changes in tinyxml2 6.0.0. This PR adds band-aid to support tinyxml2 6.0.0 and less.

Referenced https://bitbucket.org/ignitionrobotics/ign-common/pull-requests/87/support-new-errorstr-api-in-tinyxml2-600/diff

***

**Before creating a pull request**

- [x] Document new methods and classes (N/A)
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change (N/A)

  