### PR TITLE
Fix CollisionGroup bugs in Hand executors.

### DIFF
--- a/include/aikido/control/BarrettFingerKinematicSimulationPositionCommandExecutor.hpp
+++ b/include/aikido/control/BarrettFingerKinematicSimulationPositionCommandExecutor.hpp
@@ -81,6 +81,9 @@ public:
   bool setCollideWith(::dart::collision::CollisionGroupPtr collideWith);
 
 private:
+  /// Creates a CollisionGroup in the CollisionDetector for the fingers.
+  void setFingerCollisionGroup();
+
   constexpr static double kMimicRatio = 0.333;
   // TODO: read velocity limit from herb_description
   constexpr static double kProximalSpeed = 2.0;

--- a/include/aikido/control/BarrettFingerKinematicSimulationPositionCommandExecutor.hpp
+++ b/include/aikido/control/BarrettFingerKinematicSimulationPositionCommandExecutor.hpp
@@ -123,6 +123,9 @@ private:
   /// Desired end-position of proximal dof.
   double mProximalGoalPosition;
 
+  /// Desired end-position of distal dof.
+  double mDistalGoalPosition;
+
   /// Indicator that only distal finger is to be moved.
   bool mDistalOnly;
 

--- a/include/aikido/control/BarrettFingerKinematicSimulationSpreadCommandExecutor.hpp
+++ b/include/aikido/control/BarrettFingerKinematicSimulationSpreadCommandExecutor.hpp
@@ -61,6 +61,9 @@ public:
   bool setCollideWith(::dart::collision::CollisionGroupPtr collideWith);
 
 private:
+  /// Creates a CollisionGroup in the CollisionDetector for the fingers.
+  void setFingerCollisionGroup();
+
   constexpr static double kDofSpeed = 1;
 
   /// If (current dof - goalPosition) execution terminates.

--- a/src/control/BarrettFingerKinematicSimulationPositionCommandExecutor.cpp
+++ b/src/control/BarrettFingerKinematicSimulationPositionCommandExecutor.cpp
@@ -111,6 +111,8 @@ BarrettFingerKinematicSimulationPositionCommandExecutor::execute(
     else
       mProximalGoalPosition = goalPositionValue;
 
+    mDistalGoalPosition = mProximalGoalPosition * kMimicRatio;
+
     return mPromise->get_future();
   }
 }
@@ -163,6 +165,10 @@ void BarrettFingerKinematicSimulationPositionCommandExecutor::step()
       newDistal = mDistalLimits.second;
       distalLimitReached = true;
     }
+    if (!mDistalOnly && mDistalGoalPosition <= newDistal)
+    {
+      newDistal = mDistalGoalPosition;
+    }
   }
   else
   {
@@ -171,6 +177,11 @@ void BarrettFingerKinematicSimulationPositionCommandExecutor::step()
     {
       newDistal = mDistalLimits.first;
       distalLimitReached = true;
+    }
+
+    if (!mDistalOnly && mDistalGoalPosition >= newDistal)
+    {
+      newDistal = mDistalGoalPosition;
     }
   }
 

--- a/src/control/BarrettFingerKinematicSimulationPositionCommandExecutor.cpp
+++ b/src/control/BarrettFingerKinematicSimulationPositionCommandExecutor.cpp
@@ -77,11 +77,7 @@ BarrettFingerKinematicSimulationPositionCommandExecutor::
     mCollideWith = mCollisionDetector->createCollisionGroup();
   }
 
-  mProximalCollisionGroup = mCollisionDetector->createCollisionGroup(
-      mProximalDof->getChildBodyNode());
-
-  mDistalCollisionGroup = mCollisionDetector->createCollisionGroup(
-      mDistalDof->getChildBodyNode());
+  setFingerCollisionGroup();
 
   mProximalLimits = mProximalDof->getPositionLimits();
   mDistalLimits = mDistalDof->getPositionLimits();
@@ -242,7 +238,26 @@ bool BarrettFingerKinematicSimulationPositionCommandExecutor::setCollideWith(
 
   mCollideWith = std::move(collideWith);
   mCollisionDetector = mCollideWith->getCollisionDetector();
+
+  setFingerCollisionGroup();
+
   return true;
+}
+
+//==============================================================================
+void BarrettFingerKinematicSimulationPositionCommandExecutor::
+    setFingerCollisionGroup()
+{
+  if (mProximalCollisionGroup
+      && mProximalCollisionGroup->getCollisionDetector() == mCollisionDetector
+      && mDistalCollisionGroup
+      && mDistalCollisionGroup->getCollisionDetector() == mCollisionDetector)
+    return;
+
+  mProximalCollisionGroup = mCollisionDetector->createCollisionGroup(
+      mProximalDof->getChildBodyNode());
+  mDistalCollisionGroup = mCollisionDetector->createCollisionGroup(
+      mDistalDof->getChildBodyNode());
 }
 
 } // namespace control

--- a/src/control/BarrettFingerKinematicSimulationSpreadCommandExecutor.cpp
+++ b/src/control/BarrettFingerKinematicSimulationSpreadCommandExecutor.cpp
@@ -85,12 +85,7 @@ BarrettFingerKinematicSimulationSpreadCommandExecutor::
     mCollideWith = mCollisionDetector->createCollisionGroup();
   }
 
-  mSpreadCollisionGroup = mCollisionDetector->createCollisionGroup();
-  for (auto finger : mFingers)
-  {
-    for (auto body : finger->getBodyNodes())
-      mSpreadCollisionGroup->addShapeFramesOf(body);
-  }
+  setFingerCollisionGroup();
 
   mDofLimits = mSpreadDofs[0]->getPositionLimits();
 
@@ -222,7 +217,26 @@ bool BarrettFingerKinematicSimulationSpreadCommandExecutor::setCollideWith(
 
   mCollideWith = std::move(collideWith);
   mCollisionDetector = mCollideWith->getCollisionDetector();
+
+  setFingerCollisionGroup();
+
   return true;
+}
+
+//==============================================================================
+void BarrettFingerKinematicSimulationSpreadCommandExecutor::
+    setFingerCollisionGroup()
+{
+  if (mSpreadCollisionGroup
+      && mSpreadCollisionGroup->getCollisionDetector() == mCollisionDetector)
+    return;
+
+  mSpreadCollisionGroup = mCollisionDetector->createCollisionGroup();
+  for (const auto& finger : mFingers)
+  {
+    for (const auto& body : finger->getBodyNodes())
+      mSpreadCollisionGroup->addShapeFramesOf(body);
+  }
 }
 
 } // namespace control

--- a/src/control/BarrettHandKinematicSimulationPositionCommandExecutor.cpp
+++ b/src/control/BarrettHandKinematicSimulationPositionCommandExecutor.cpp
@@ -218,6 +218,11 @@ bool BarrettHandKinematicSimulationPositionCommandExecutor::setCollideWith(
 
   mCollideWith = std::move(collideWith);
   mCollisionDetector = mCollideWith->getCollisionDetector();
+
+  for (std::size_t i = 0; i < kNumPositionExecutor; ++i)
+    mPositionCommandExecutors[i]->setCollideWith(mCollideWith);
+  mSpreadCommandExecutor->setCollideWith(mCollideWith);
+
   return true;
 }
 

--- a/src/control/BarrettHandKinematicSimulationPositionCommandExecutor.cpp
+++ b/src/control/BarrettHandKinematicSimulationPositionCommandExecutor.cpp
@@ -21,6 +21,9 @@ BarrettHandKinematicSimulationPositionCommandExecutor::
   , mCollisionDetector(std::move(collisionDetector))
   , mCollideWith(std::move(collideWith))
 {
+  if (!robot)
+    throw std::invalid_argument("Robot is null");
+
   if (mCollisionDetector && mCollideWith)
   {
     // If a collision group is given and its collision detector does not match
@@ -74,7 +77,7 @@ void BarrettHandKinematicSimulationPositionCommandExecutor::setupExecutors(
     std::stringstream message;
     message << "Invalid prefix '" << prefix << "', "
             << "must be either '/left/' or '/right/'";
-    throw std::runtime_error(message.str());
+    throw std::invalid_argument(message.str());
   }
 
   const auto fingerChains = std::array<ChainPtr, 3>{{

--- a/tests/control/test_BarrettHandKinematicSimulationPositionCommandExecutor.cpp
+++ b/tests/control/test_BarrettHandKinematicSimulationPositionCommandExecutor.cpp
@@ -352,7 +352,7 @@ TEST_F(BarrettHandKinematicSimulationPositionCommandExecutorTest,
   position(0) = goal;
 
   BarrettHandKinematicSimulationPositionCommandExecutor executor(
-    mRobot, mPrefix, mCollisionDetector, mCollideWith);
+    mRobot, mPrefix, mCollisionDetector, collideWith);
 
   auto future = executor.execute(position);
 
@@ -387,7 +387,7 @@ TEST_F(BarrettHandKinematicSimulationPositionCommandExecutorTest,
   position(0) = goal;
 
   BarrettHandKinematicSimulationPositionCommandExecutor executor(
-    mRobot, mPrefix, mCollisionDetector, mCollideWith);
+    mRobot, mPrefix, mCollisionDetector, collideWith);
 
   auto future = executor.execute(position);
   std::future_status status;

--- a/tests/control/test_BarrettHandKinematicSimulationPositionCommandExecutor.cpp
+++ b/tests/control/test_BarrettHandKinematicSimulationPositionCommandExecutor.cpp
@@ -26,7 +26,7 @@ using namespace dart::dynamics;
 using namespace dart::collision;
 using namespace dart::simulation;
 
-const static std::chrono::milliseconds stepTime{100};
+const static std::chrono::milliseconds stepTime{1};
 
 static BodyNode::Properties create_BodyNodeProperties(const std::string& _name)
 {
@@ -369,7 +369,7 @@ TEST_F(BarrettHandKinematicSimulationPositionCommandExecutorTest,
   double distal = mFingerChains[0]->getDof(2)->getPosition();
 
   // Values made by visual inspection
-  EXPECT_NEAR(0.56548, primal, eps);
+  EXPECT_NEAR(0.55506, primal, eps);
   EXPECT_NEAR(2.81718, distal, eps);
 
 }

--- a/tests/control/test_BarrettHandKinematicSimulationPositionCommandExecutor.cpp
+++ b/tests/control/test_BarrettHandKinematicSimulationPositionCommandExecutor.cpp
@@ -70,11 +70,12 @@ public:
     RevoluteJoint::Properties properties1;
     properties1.mAxis = spreadAxis;
     properties1.mName = fingerName + "Joint1";
-    auto bn1
-        = mRobot
-              ->createJointAndBodyNodePair<RevoluteJoint>(
-                  nullptr, properties1, create_BodyNodeProperties(fingerName + "_0"))
-              .second;
+    auto bn1 = mRobot
+                   ->createJointAndBodyNodePair<RevoluteJoint>(
+                       nullptr,
+                       properties1,
+                       create_BodyNodeProperties(fingerName + "_0"))
+                   .second;
     bn1->getParentJoint()->setTransformFromParentBodyNode(transform);
     bn1->getParentJoint()->setPositionUpperLimit(0, M_PI);
     bn1->getParentJoint()->setPositionLowerLimit(0, 0);
@@ -85,7 +86,9 @@ public:
     properties2.mName = fingerName + "Joint2";
     auto bn2 = mRobot
                    ->createJointAndBodyNodePair<RevoluteJoint>(
-                       bn1, properties2, create_BodyNodeProperties(fingerName + "_1"))
+                       bn1,
+                       properties2,
+                       create_BodyNodeProperties(fingerName + "_1"))
                    .second;
     bn2->getParentJoint()->setPositionUpperLimit(0, M_PI);
     bn2->getParentJoint()->setPositionLowerLimit(0, -M_PI);
@@ -98,7 +101,9 @@ public:
     properties3.mT_ParentBodyToJoint.translation() = Eigen::Vector3d(0, 0, 1);
     auto bn3 = mRobot
                    ->createJointAndBodyNodePair<RevoluteJoint>(
-                       bn2, properties3, create_BodyNodeProperties(fingerName + "_2"))
+                       bn2,
+                       properties3,
+                       create_BodyNodeProperties(fingerName + "_2"))
                    .second;
     bn3->getParentJoint()->setPositionUpperLimit(0, M_PI);
     bn3->getParentJoint()->setPositionLowerLimit(0, -M_PI);
@@ -114,15 +119,16 @@ public:
     Eigen::Vector3d fingerSize(0.1, 0.1, 0.7);
     std::shared_ptr<BoxShape> fingerShape(new BoxShape(fingerSize));
 
-    // primal joint
+    // proximal joint
     RevoluteJoint::Properties properties2;
     properties2.mAxis = Eigen::Vector3d::UnitY();
     properties2.mName = fingerName + "Joint2";
-    auto mBn1
-        = mRobot
-              ->createJointAndBodyNodePair<RevoluteJoint>(
-                  nullptr, properties2, create_BodyNodeProperties(fingerName + "_1"))
-              .second;
+    auto mBn1 = mRobot
+                    ->createJointAndBodyNodePair<RevoluteJoint>(
+                        nullptr,
+                        properties2,
+                        create_BodyNodeProperties(fingerName + "_1"))
+                    .second;
     mBn1->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(
         fingerShape);
     mBn1->getParentJoint()->setTransformFromParentBodyNode(transform);
@@ -137,7 +143,9 @@ public:
     properties3.mT_ParentBodyToJoint.translation() = Eigen::Vector3d(0, 0, 1);
     auto mBn2 = mRobot
                     ->createJointAndBodyNodePair<RevoluteJoint>(
-                        mBn1, properties3, create_BodyNodeProperties(fingerName + "_2"))
+                        mBn1,
+                        properties3,
+                        create_BodyNodeProperties(fingerName + "_2"))
                     .second;
     mBn2->getParentJoint()->setPositionUpperLimit(0, M_PI);
     mBn2->getParentJoint()->setPositionLowerLimit(0, -M_PI);
@@ -174,7 +182,7 @@ public:
     // Fingers
     mFingerChains.reserve(3);
     mFingerChains.push_back(
-      create3DoFFinger(mPrefix + "finger0", Eigen::Isometry3d::Identity()));
+        create3DoFFinger(mPrefix + "finger0", Eigen::Isometry3d::Identity()));
 
     Eigen::Isometry3d transform(Eigen::Isometry3d::Identity());
     Eigen::Matrix3d rotation;
@@ -183,164 +191,140 @@ public:
                * Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitX());
     transform.linear() = rotation;
     mFingerChains.push_back(
-      create3DoFFinger(mPrefix + "finger1", transform, -Eigen::Vector3d::UnitX()));
+        create3DoFFinger(
+            mPrefix + "finger1", transform, -Eigen::Vector3d::UnitX()));
 
     rotation = Eigen::AngleAxisd(0, Eigen::Vector3d::UnitZ())
                * Eigen::AngleAxisd(0, Eigen::Vector3d::UnitY())
                * Eigen::AngleAxisd(-M_PI / 2, Eigen::Vector3d::UnitX());
     transform.linear() = rotation;
     transform.translation() = Eigen::Vector3d(0, 1.0, 0.0);
-    mFingerChains.push_back(
-      create2DoFFinger(mPrefix + "finger2", transform));
+    mFingerChains.push_back(create2DoFFinger(mPrefix + "finger2", transform));
 
     // CollisionDetector
     mCollisionDetector = FCLCollisionDetector::create();
     mCollideWith = mCollisionDetector->createCollisionGroupAsSharedPtr();
-
-    /*
-    int spreadDof = 0;
-    int primalDof[3] = {1, 1, 0};
-    int distalDof[3] = {2, 2, 1};
-
-    for (int i = 0; i < 3; ++i)
-    {
-      mPositionExecutors[i]
-          = (std::
-                 make_shared<BarrettFingerKinematicSimulationPositionCommandExecutor>(
-                     mFingerChains[i],
-                     primalDof[i],
-                     distalDof[i],
-                     mCollisionDetector,
-                     mCollideWith));
-    }
-
-    std::array<ChainPtr, 2> spreadFingers;
-    spreadFingers[0] = mFingerChains[0];
-    spreadFingers[1] = mFingerChains[1];
-    mSpreadExecutor = std::
-        make_shared<BarrettFingerKinematicSimulationSpreadCommandExecutor>(
-            spreadFingers, spreadDof, mCollisionDetector, mCollideWith);
-    */
 
     mPositions = Eigen::Matrix<double, 4, 1>::Ones() * 0.1;
     mPositions(3) = M_PI / 8;
   }
 
 protected:
+  std::string mPrefix;
+  SkeletonPtr mRobot;
   std::vector<ChainPtr> mFingerChains;
   CollisionDetectorPtr mCollisionDetector;
   CollisionGroupPtr mCollideWith;
-  // std::array<BarrettFingerKinematicSimulationPositionCommandExecutorPtr, 3>
-  //     mPositionExecutors;
-  // BarrettFingerKinematicSimulationSpreadCommandExecutorPtr mSpreadExecutor;
-  SkeletonPtr mRobot;
-  std::string mPrefix;
 
   Eigen::Matrix<double, 4, 1> mPositions;
   static constexpr double eps = 0.01;
 };
 
-TEST_F(BarrettHandKinematicSimulationPositionCommandExecutorTest,
-  constructor_nullRobot_throws)
+TEST_F(
+    BarrettHandKinematicSimulationPositionCommandExecutorTest,
+    constructor_nullRobot_throws)
 {
   EXPECT_THROW(
-    BarrettHandKinematicSimulationPositionCommandExecutor(
-      nullptr, mPrefix, mCollisionDetector, mCollideWith), std::invalid_argument);
+      BarrettHandKinematicSimulationPositionCommandExecutor(
+          nullptr, mPrefix, mCollisionDetector, mCollideWith),
+      std::invalid_argument);
 }
 
-TEST_F(BarrettHandKinematicSimulationPositionCommandExecutorTest,
-  constructor_invalidPrefix_throws)
+TEST_F(
+    BarrettHandKinematicSimulationPositionCommandExecutorTest,
+    constructor_invalidPrefix_throws)
 {
   EXPECT_THROW(
-    BarrettHandKinematicSimulationPositionCommandExecutor(
-      mRobot, "/invalid/", mCollisionDetector, mCollideWith), std::invalid_argument);
+      BarrettHandKinematicSimulationPositionCommandExecutor(
+          mRobot, "/invalid/", mCollisionDetector, mCollideWith),
+      std::invalid_argument);
 }
 
-TEST_F(BarrettHandKinematicSimulationPositionCommandExecutorTest,
-constructor_no_throw)
+TEST_F(
+    BarrettHandKinematicSimulationPositionCommandExecutorTest,
+    constructor_no_throw)
 {
   EXPECT_NO_THROW(
-    BarrettHandKinematicSimulationPositionCommandExecutor(
-      mRobot, mPrefix, mCollisionDetector, mCollideWith));
+      BarrettHandKinematicSimulationPositionCommandExecutor(
+          mRobot, mPrefix, mCollisionDetector, mCollideWith));
 }
 
-TEST_F(BarrettHandKinematicSimulationPositionCommandExecutorTest,
-  execute_WaitOnFuture_CommandExecuted)
+TEST_F(
+    BarrettHandKinematicSimulationPositionCommandExecutorTest,
+    execute_WaitOnFuture_CommandExecuted)
 {
   // Setup
   BarrettHandKinematicSimulationPositionCommandExecutor executor(
-    mRobot, mPrefix, mCollisionDetector, mCollideWith);
+      mRobot, mPrefix, mCollisionDetector, mCollideWith);
 
-  double mimicRatio =
-BarrettFingerKinematicSimulationPositionCommandExecutor::getMimicRatio();
+  double mimicRatio = BarrettFingerKinematicSimulationPositionCommandExecutor::
+      getMimicRatio();
 
   // Execute trajectory
   auto future = executor.execute(mPositions);
-
   std::future_status status;
   do
   {
     executor.step();
     status = future.wait_for(stepTime);
-  } while(status != std::future_status::ready);
-
+  } while (status != std::future_status::ready);
   future.get();
 
   // Validate dof values
-  for(int i = 0; i < 2; ++i)
+  for (int i = 0; i < 2; ++i)
   {
-    double primal = mFingerChains[i]->getDof(1)->getPosition();
+    double proximal = mFingerChains[i]->getDof(1)->getPosition();
     double distal = mFingerChains[i]->getDof(2)->getPosition();
 
-    EXPECT_NEAR(mPositions(i), primal, eps);
-    EXPECT_NEAR(mPositions(i)*mimicRatio, distal, eps);
+    EXPECT_NEAR(mPositions(i), proximal, eps);
+    EXPECT_NEAR(mPositions(i) * mimicRatio, distal, eps);
 
     double spread = mFingerChains[i]->getDof(0)->getPosition();
     EXPECT_NEAR(spread, mPositions(3), eps);
   }
 
-  double primal = mFingerChains[2]->getDof(0)->getPosition();
+  double proximal = mFingerChains[2]->getDof(0)->getPosition();
   double distal = mFingerChains[2]->getDof(1)->getPosition();
 
-  EXPECT_NEAR(mPositions(2), primal, eps);
-  EXPECT_NEAR(mPositions(2)*mimicRatio, distal, eps);
+  EXPECT_NEAR(mPositions(2), proximal, eps);
+  EXPECT_NEAR(mPositions(2) * mimicRatio, distal, eps);
 }
 
-TEST_F(BarrettHandKinematicSimulationPositionCommandExecutorTest,
-  execute_CommandIsAlreadyRunning_Throws)
+TEST_F(
+    BarrettHandKinematicSimulationPositionCommandExecutorTest,
+    execute_CommandIsAlreadyRunning_Throws)
 {
   BarrettHandKinematicSimulationPositionCommandExecutor executor(
-    mRobot, mPrefix, mCollisionDetector, mCollideWith);
+      mRobot, mPrefix, mCollisionDetector, mCollideWith);
 
   // Execute trajectory
   auto future = executor.execute(mPositions);
-  EXPECT_THROW(executor.execute(mPositions),
-    std::runtime_error);
+  EXPECT_THROW(executor.execute(mPositions), std::runtime_error);
 }
 
-TEST_F(BarrettHandKinematicSimulationPositionCommandExecutorTest,
-  execute_PrevCommandFinished_DoesNotThrow)
+TEST_F(
+    BarrettHandKinematicSimulationPositionCommandExecutorTest,
+    execute_PrevCommandFinished_DoesNotThrow)
 {
   BarrettHandKinematicSimulationPositionCommandExecutor executor(
-    mRobot, mPrefix, mCollisionDetector, mCollideWith);
+      mRobot, mPrefix, mCollisionDetector, mCollideWith);
 
   // Execute trajectory
   auto future = executor.execute(mPositions);
-
   std::future_status status;
   do
   {
     executor.step();
     status = future.wait_for(stepTime);
-  } while(status != std::future_status::ready);
-
+  } while (status != std::future_status::ready);
   future.get();
 
   EXPECT_NO_THROW(executor.execute(mPositions));
 }
 
-TEST_F(BarrettHandKinematicSimulationPositionCommandExecutorTest,
-  execute_PrimalStopsAtCollisionDistalContinues)
+TEST_F(
+    BarrettHandKinematicSimulationPositionCommandExecutorTest,
+    execute_ProximalStopsAtCollisionDistalContinues)
 {
   Eigen::Isometry3d transform(Eigen::Isometry3d::Identity());
   transform.translation() = Eigen::Vector3d(0.3, 0, 0.3);
@@ -352,30 +336,28 @@ TEST_F(BarrettHandKinematicSimulationPositionCommandExecutorTest,
   position(0) = goal;
 
   BarrettHandKinematicSimulationPositionCommandExecutor executor(
-    mRobot, mPrefix, mCollisionDetector, collideWith);
+      mRobot, mPrefix, mCollisionDetector, collideWith);
 
   auto future = executor.execute(position);
-
   std::future_status status;
   do
   {
     executor.step();
     status = future.wait_for(stepTime);
-  } while(status != std::future_status::ready);
-
+  } while (status != std::future_status::ready);
   future.get();
 
-  double primal = mFingerChains[0]->getDof(1)->getPosition();
+  double proximal = mFingerChains[0]->getDof(1)->getPosition();
   double distal = mFingerChains[0]->getDof(2)->getPosition();
 
   // Values made by visual inspection
-  EXPECT_NEAR(0.55506, primal, eps);
+  EXPECT_NEAR(0.55506, proximal, eps);
   EXPECT_NEAR(2.81718, distal, eps);
-
 }
 
-TEST_F(BarrettHandKinematicSimulationPositionCommandExecutorTest,
-  execute_DistalStopsAtCollisionPrimalAlsoStops)
+TEST_F(
+    BarrettHandKinematicSimulationPositionCommandExecutorTest,
+    execute_DistalStopsAtCollisionProximalAlsoStops)
 {
   Eigen::Isometry3d transform(Eigen::Isometry3d::Identity());
   transform.translation() = Eigen::Vector3d(1.3, 0, 1.3);
@@ -383,11 +365,11 @@ TEST_F(BarrettHandKinematicSimulationPositionCommandExecutorTest,
   auto collideWith = mCollisionDetector->createCollisionGroupAsSharedPtr(ball);
 
   Eigen::VectorXd position(Eigen::VectorXd::Zero(4));
-  double goal = M_PI/4;
+  double goal = M_PI / 4;
   position(0) = goal;
 
   BarrettHandKinematicSimulationPositionCommandExecutor executor(
-    mRobot, mPrefix, mCollisionDetector, collideWith);
+      mRobot, mPrefix, mCollisionDetector, collideWith);
 
   auto future = executor.execute(position);
   std::future_status status;
@@ -395,18 +377,16 @@ TEST_F(BarrettHandKinematicSimulationPositionCommandExecutorTest,
   {
     executor.step();
     status = future.wait_for(stepTime);
-  } while(status != std::future_status::ready);
-
+  } while (status != std::future_status::ready);
   future.get();
 
-  double primal = mFingerChains[0]->getDof(1)->getPosition();
+  double proximal = mFingerChains[0]->getDof(1)->getPosition();
   double distal = mFingerChains[0]->getDof(2)->getPosition();
-
-  double mimicRatio =
-BarrettFingerKinematicSimulationPositionCommandExecutor::getMimicRatio();
+  double mimicRatio = BarrettFingerKinematicSimulationPositionCommandExecutor::
+      getMimicRatio();
 
   // Values made by visual inspection
   EXPECT_NEAR(0.211845, distal, eps);
-  EXPECT_NEAR(0.636173, primal, eps);
-  EXPECT_NEAR(primal*mimicRatio, distal, eps);
+  EXPECT_NEAR(0.636173, proximal, eps);
+  EXPECT_NEAR(proximal * mimicRatio, distal, eps);
 }

--- a/tests/control/test_BarrettHandKinematicSimulationPositionCommandExecutor.cpp
+++ b/tests/control/test_BarrettHandKinematicSimulationPositionCommandExecutor.cpp
@@ -390,3 +390,147 @@ TEST_F(
   EXPECT_NEAR(0.636173, proximal, eps);
   EXPECT_NEAR(proximal * mimicRatio, distal, eps);
 }
+
+TEST_F(
+    BarrettHandKinematicSimulationPositionCommandExecutorTest,
+    setCollideWith_SameCollisionDetector_ProximalStopsAtCollisionDistalContinues)
+{
+  Eigen::Isometry3d transform(Eigen::Isometry3d::Identity());
+  transform.translation() = Eigen::Vector3d(0.3, 0, 0.3);
+  auto ball = createBall(transform, mCollisionDetector);
+  auto collideWith = mCollisionDetector->createCollisionGroupAsSharedPtr(ball);
+
+  Eigen::VectorXd position(Eigen::VectorXd::Zero(4));
+  double goal = M_PI;
+  position(0) = goal;
+
+  BarrettHandKinematicSimulationPositionCommandExecutor executor(
+      mRobot, mPrefix, mCollisionDetector, mCollideWith);
+  executor.setCollideWith(collideWith);
+
+  auto future = executor.execute(position);
+  std::future_status status;
+  do
+  {
+    executor.step();
+    status = future.wait_for(stepTime);
+  } while (status != std::future_status::ready);
+  future.get();
+
+  double proximal = mFingerChains[0]->getDof(1)->getPosition();
+  double distal = mFingerChains[0]->getDof(2)->getPosition();
+
+  // Values made by visual inspection
+  EXPECT_NEAR(0.55506, proximal, eps);
+  EXPECT_NEAR(2.81718, distal, eps);
+}
+
+TEST_F(
+    BarrettHandKinematicSimulationPositionCommandExecutorTest,
+    setCollideWith_SameCollisionDetector_DistalStopsAtCollisionProximalAlsoStops)
+{
+  Eigen::Isometry3d transform(Eigen::Isometry3d::Identity());
+  transform.translation() = Eigen::Vector3d(1.3, 0, 1.3);
+  auto ball = createBall(transform, mCollisionDetector);
+  auto collideWith = mCollisionDetector->createCollisionGroupAsSharedPtr(ball);
+
+  Eigen::VectorXd position(Eigen::VectorXd::Zero(4));
+  double goal = M_PI / 4;
+  position(0) = goal;
+
+  BarrettHandKinematicSimulationPositionCommandExecutor executor(
+      mRobot, mPrefix, mCollisionDetector, mCollideWith);
+  executor.setCollideWith(collideWith);
+
+  auto future = executor.execute(position);
+  std::future_status status;
+  do
+  {
+    executor.step();
+    status = future.wait_for(stepTime);
+  } while (status != std::future_status::ready);
+  future.get();
+
+  double proximal = mFingerChains[0]->getDof(1)->getPosition();
+  double distal = mFingerChains[0]->getDof(2)->getPosition();
+  double mimicRatio = BarrettFingerKinematicSimulationPositionCommandExecutor::
+      getMimicRatio();
+
+  // Values made by visual inspection
+  EXPECT_NEAR(0.211845, distal, eps);
+  EXPECT_NEAR(0.636173, proximal, eps);
+  EXPECT_NEAR(proximal * mimicRatio, distal, eps);
+}
+
+TEST_F(
+    BarrettHandKinematicSimulationPositionCommandExecutorTest,
+    setCollideWith_DifferentCollisionDetector_ProximalStopsAtCollisionDistalContinues)
+{
+  Eigen::Isometry3d transform(Eigen::Isometry3d::Identity());
+  transform.translation() = Eigen::Vector3d(0.3, 0, 0.3);
+  auto newDetector = FCLCollisionDetector::create();
+  auto ball = createBall(transform, newDetector);
+  auto collideWith = newDetector->createCollisionGroupAsSharedPtr(ball);
+
+  Eigen::VectorXd position(Eigen::VectorXd::Zero(4));
+  double goal = M_PI;
+  position(0) = goal;
+
+  BarrettHandKinematicSimulationPositionCommandExecutor executor(
+      mRobot, mPrefix, mCollisionDetector, mCollideWith);
+  executor.setCollideWith(collideWith);
+
+  auto future = executor.execute(position);
+  std::future_status status;
+  do
+  {
+    executor.step();
+    status = future.wait_for(stepTime);
+  } while (status != std::future_status::ready);
+  future.get();
+
+  double proximal = mFingerChains[0]->getDof(1)->getPosition();
+  double distal = mFingerChains[0]->getDof(2)->getPosition();
+
+  // Values made by visual inspection
+  EXPECT_NEAR(0.55506, proximal, eps);
+  EXPECT_NEAR(2.81718, distal, eps);
+}
+
+TEST_F(
+    BarrettHandKinematicSimulationPositionCommandExecutorTest,
+    setCollideWith_DifferentCollisionDetector_DistalStopsAtCollisionProximalAlsoStops)
+{
+  Eigen::Isometry3d transform(Eigen::Isometry3d::Identity());
+  transform.translation() = Eigen::Vector3d(1.3, 0, 1.3);
+  auto newDetector = FCLCollisionDetector::create();
+  auto ball = createBall(transform, newDetector);
+  auto collideWith = newDetector->createCollisionGroupAsSharedPtr(ball);
+
+  Eigen::VectorXd position(Eigen::VectorXd::Zero(4));
+  double goal = M_PI / 4;
+  position(0) = goal;
+
+  BarrettHandKinematicSimulationPositionCommandExecutor executor(
+      mRobot, mPrefix, mCollisionDetector, mCollideWith);
+  executor.setCollideWith(collideWith);
+
+  auto future = executor.execute(position);
+  std::future_status status;
+  do
+  {
+    executor.step();
+    status = future.wait_for(stepTime);
+  } while (status != std::future_status::ready);
+  future.get();
+
+  double proximal = mFingerChains[0]->getDof(1)->getPosition();
+  double distal = mFingerChains[0]->getDof(2)->getPosition();
+  double mimicRatio = BarrettFingerKinematicSimulationPositionCommandExecutor::
+      getMimicRatio();
+
+  // Values made by visual inspection
+  EXPECT_NEAR(0.211845, distal, eps);
+  EXPECT_NEAR(0.636173, proximal, eps);
+  EXPECT_NEAR(proximal * mimicRatio, distal, eps);
+}

--- a/tests/control/test_BarrettHandKinematicSimulationPositionCommandExecutor.cpp
+++ b/tests/control/test_BarrettHandKinematicSimulationPositionCommandExecutor.cpp
@@ -410,5 +410,3 @@ BarrettFingerKinematicSimulationPositionCommandExecutor::getMimicRatio();
   EXPECT_NEAR(0.636173, primal, eps);
   EXPECT_NEAR(primal*mimicRatio, distal, eps);
 }
-
-*/


### PR DESCRIPTION
`BarrettHandKinematicSimulationPositionCommandExecutor::setCollideWith` didn't call `setCollideWith` on the underlying position or spread executors. In addition, calling `BarrettFingerKinematicSimulationPositionCommandExecutor::setCollideWith` and `BarrettFingerKinematicSimulationSpreadCommandExecutor::setCollideWith` could result in a mismatch if the new `CollisionGroup` came from a different `CollisionDetector`.

This PR fixes the first issue and adds a `setFingerCollisionGroup` method to both finger executors, which updates the appropriate finger collision groups (if necessary).

I think this resolves #271. (I didn't see the `setCollideWith` methods when I created the issue earlier.)

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
