### PR TITLE
fix step sequence iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### 0.3.0 (201X-XX-XX)
 
+* Common
+  
+  * Fixed bug in StepSequence::getMaxSteps(): [#305](https://github.com/personalrobotics/aikido/pull/305)
+
 * State Space
 
   * Refactored JointStateSpace and MetaSkeletonStateSpace: [#278](https://github.com/personalrobotics/aikido/pull/278)

--- a/src/common/StepSequence.cpp
+++ b/src/common/StepSequence.cpp
@@ -59,27 +59,12 @@ StepSequence::const_iterator StepSequence::end()
 int StepSequence::getMaxSteps() const
 {
   int numSteps = (mEndPoint - mStartPoint) / mStepSize;
-  if (!mIncludeEndpoints)
+
+  if (std::abs(mStartPoint + mStepSize * numSteps - mEndPoint) > 1e-7)
   {
-    if (std::abs(mStartPoint + mStepSize * numSteps - mEndPoint) < 1e-7)
-      return numSteps;
-    else
-      // Return numSteps + 1 for the start
-      return numSteps + 1;
+    numSteps++;
   }
-  else
-  {
-    if (std::abs(mStartPoint + mStepSize * numSteps - mEndPoint) < 1e-7)
-    {
-      // Return numSteps + 1 for the start (endpt already included)
-      return numSteps + 1;
-    }
-    else
-    {
-      // Return numSteps + 1 for the start + 1 for the end
-      return numSteps + 2;
-    }
-  }
+  return numSteps + mIncludeEndpoints;
 }
 
 //==============================================================================

--- a/src/common/StepSequence.cpp
+++ b/src/common/StepSequence.cpp
@@ -61,8 +61,11 @@ int StepSequence::getMaxSteps() const
   int numSteps = (mEndPoint - mStartPoint) / mStepSize;
   if (!mIncludeEndpoints)
   {
-    // Return numSteps + 1 for the start
-    return numSteps + 1;
+    if (fabs(mStartPoint + mStepSize * numSteps - mEndPoint) < 1e-7)
+      return numSteps;
+    else
+      // Return numSteps + 1 for the start
+      return numSteps + 1;
   }
   else
   {

--- a/src/common/StepSequence.cpp
+++ b/src/common/StepSequence.cpp
@@ -61,7 +61,7 @@ int StepSequence::getMaxSteps() const
   int numSteps = (mEndPoint - mStartPoint) / mStepSize;
   if (!mIncludeEndpoints)
   {
-    if (fabs(mStartPoint + mStepSize * numSteps - mEndPoint) < 1e-7)
+    if (std::abs(mStartPoint + mStepSize * numSteps - mEndPoint) < 1e-7)
       return numSteps;
     else
       // Return numSteps + 1 for the start
@@ -69,7 +69,7 @@ int StepSequence::getMaxSteps() const
   }
   else
   {
-    if (fabs(mStartPoint + mStepSize * numSteps - mEndPoint) < 1e-7)
+    if (std::abs(mStartPoint + mStepSize * numSteps - mEndPoint) < 1e-7)
     {
       // Return numSteps + 1 for the start (endpt already included)
       return numSteps + 1;

--- a/tests/common/test_StepSequence.cpp
+++ b/tests/common/test_StepSequence.cpp
@@ -72,6 +72,15 @@ TEST(StepSequence, IteratorStop)
   }
 
   EXPECT_EQ(5, count);
+
+  std::size_t count2 = 0;
+  StepSequence seq2(0.2, false);
+  for (double v : seq2)
+  {
+    DART_UNUSED(v);
+    count2++;
+  }
+  EXPECT_EQ(5, count2);
 }
 
 TEST(StepSequence, IteratorStopAlternateRange)
@@ -93,7 +102,7 @@ TEST(StepSequence, MaxSteps)
   EXPECT_EQ(6, seq1.getMaxSteps());
 
   StepSequence seq2(0.2, false);
-  EXPECT_EQ(6, seq2.getMaxSteps());
+  EXPECT_EQ(5, seq2.getMaxSteps());
 
   StepSequence seq3(0.3, true);
   EXPECT_EQ(5, seq3.getMaxSteps());
@@ -108,11 +117,11 @@ TEST(StepSequence, MaxStepsAlternateRanges)
   EXPECT_EQ(21, seq1.getMaxSteps());
 
   StepSequence seq2(0.2, false, 3, 7);
-  EXPECT_EQ(21, seq2.getMaxSteps());
+  EXPECT_EQ(20, seq2.getMaxSteps());
 
   StepSequence seq3(0.3, true, 2, 4);
   EXPECT_EQ(8, seq3.getMaxSteps());
 
   StepSequence seq4(0.3, false, 2, 5);
-  EXPECT_EQ(11, seq4.getMaxSteps());
+  EXPECT_EQ(10, seq4.getMaxSteps());
 }


### PR DESCRIPTION
In current `aikido`, unexpected exception is thrown in some cases.
`StepSequence seq(0.2, false); for (double v : seq) { DART_UNUSED(v); count++; }`
An exception will be throw
>unknown file: Failure
>C++ exception with description "Indexed maximum intenger." thrown in the test body.
Expected sequence shall be `(0.0, 0.2, 0.4, 0.6, 0.8)`; but `getMaxSteps()` returns 6.
Thus an exception is triggered in `operator []`.

In this PR,
 `StepSequence seq(0.2, true)` returns `(0.0, 0.2, 0.4, 0.6, 0.8, 1.0)` and `getMaxSteps()` returns 6.
 `StepSequence seq(0.2, false)` returns `(0.0, 0.2, 0.4, 0.6, 0.8)` and `getMaxSteps()` returns 5.
Unit tests are updated accordingly.

- [x] Document new methods and classes (N/A)
- [x] Format code with `make format`

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md` (N/A)
- [x] Add unit test(s) for this change
