### PR TITLE
Use forward declaration of smart pointers

### DIFF
--- a/include/aikido/common/smart_pointer.hpp
+++ b/include/aikido/common/smart_pointer.hpp
@@ -1,0 +1,21 @@
+#ifndef AIKIDO_COMMON_SMARTPOINTER_HPP_
+#define AIKIDO_COMMON_SMARTPOINTER_HPP_
+
+#include <dart/common/SmartPointer.hpp>
+
+// clang-format off
+#define AIKIDO_COMMON_DECLARE_SMART_POINTERS(X)                                \
+  DART_COMMON_MAKE_SHARED_WEAK(X)                                              \
+  using Unique ## X ## Ptr      = std::unique_ptr< X >;                        \
+  using UniqueConst ## X ## Ptr = std::unique_ptr< const X >;
+// clang-format on
+
+namespace aikido {
+namespace common {
+
+// Declare here the smart pointers of aikido::common objects
+
+} // namespace common
+} // namespace aikido
+
+#endif // AIKIDO_COMMON_SMARTPOINTER_HPP_

--- a/include/aikido/constraint/CartesianProductProjectable.hpp
+++ b/include/aikido/constraint/CartesianProductProjectable.hpp
@@ -1,6 +1,7 @@
 #ifndef AIKIDO_CONSTRAINT_CARTESIANPRODUCTPROJECTABLE_HPP_
 #define AIKIDO_CONSTRAINT_CARTESIANPRODUCTPROJECTABLE_HPP_
 
+#include "aikido/constraint/smart_pointer.hpp"
 #include "../statespace/CartesianProduct.hpp"
 #include "Projectable.hpp"
 

--- a/include/aikido/constraint/CartesianProductTestable.hpp
+++ b/include/aikido/constraint/CartesianProductTestable.hpp
@@ -2,6 +2,7 @@
 #define AIKIDO_CONSTRAINT_TESTABLESUBSPACE_HPP_
 
 #include <vector>
+#include "aikido/constraint/smart_pointer.hpp"
 #include "../statespace/CartesianProduct.hpp"
 #include "Testable.hpp"
 

--- a/include/aikido/constraint/CollisionFree.hpp
+++ b/include/aikido/constraint/CollisionFree.hpp
@@ -90,8 +90,6 @@ private:
   std::vector<std::shared_ptr<CollisionGroup>> mGroupsToSelfCheck;
 };
 
-using CollisionFreePtr = std::shared_ptr<CollisionFree>;
-
 } // namespace constraint
 } // namespace aikido
 

--- a/include/aikido/constraint/CyclicSampleable.hpp
+++ b/include/aikido/constraint/CyclicSampleable.hpp
@@ -1,6 +1,7 @@
 #ifndef AIKIDO_CONSTRAINT_CYCLICSAMPLEABLE_HPP_
 #define AIKIDO_CONSTRAINT_CYCLICSAMPLEABLE_HPP_
 
+#include "aikido/constraint/smart_pointer.hpp"
 #include "Sampleable.hpp"
 
 namespace aikido {

--- a/include/aikido/constraint/Differentiable.hpp
+++ b/include/aikido/constraint/Differentiable.hpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <Eigen/Dense>
+#include "aikido/statespace/smart_pointer.hpp"
 #include "../statespace/StateSpace.hpp"
 
 namespace aikido {
@@ -66,8 +67,6 @@ public:
       Eigen::VectorXd& _val,
       Eigen::MatrixXd& _jac) const;
 };
-
-using DifferentiablePtr = std::shared_ptr<Differentiable>;
 
 } // namespace constraint
 } // namespace aikido

--- a/include/aikido/constraint/DifferentiableIntersection.hpp
+++ b/include/aikido/constraint/DifferentiableIntersection.hpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <Eigen/Dense>
+#include "aikido/constraint/smart_pointer.hpp"
 #include "../statespace/StateSpace.hpp"
 #include "Differentiable.hpp"
 

--- a/include/aikido/constraint/DifferentiableSubspace.hpp
+++ b/include/aikido/constraint/DifferentiableSubspace.hpp
@@ -1,6 +1,7 @@
 #ifndef AIKIDO_CONSTRAINT_DIFFERENTIABLESUBSPACE_HPP_
 #define AIKIDO_CONSTRAINT_DIFFERENTIABLESUBSPACE_HPP_
 
+#include "aikido/constraint/smart_pointer.hpp"
 #include "../statespace/CartesianProduct.hpp"
 #include "Differentiable.hpp"
 

--- a/include/aikido/constraint/FrameDifferentiable.hpp
+++ b/include/aikido/constraint/FrameDifferentiable.hpp
@@ -2,6 +2,7 @@
 #define AIKIDO_CONSTRAINT_FRAMEDIFFERENTIABLE_HPP_
 
 #include <dart/dynamics/dynamics.hpp>
+#include "aikido/constraint/smart_pointer.hpp"
 #include "../statespace/dart/MetaSkeletonStateSpace.hpp"
 #include "Differentiable.hpp"
 

--- a/include/aikido/constraint/FramePairDifferentiable.hpp
+++ b/include/aikido/constraint/FramePairDifferentiable.hpp
@@ -3,6 +3,8 @@
 
 #include <Eigen/Dense>
 #include <dart/dynamics/dynamics.hpp>
+#include "aikido/constraint/smart_pointer.hpp"
+#include "aikido/statespace/smart_pointer.hpp"
 #include "../statespace/dart/MetaSkeletonStateSpace.hpp"
 #include "Differentiable.hpp"
 

--- a/include/aikido/constraint/FrameTestable.hpp
+++ b/include/aikido/constraint/FrameTestable.hpp
@@ -2,6 +2,7 @@
 #define AIKIDO_CONSTRAINT_FRAMETESTABLE_HPP_
 
 #include <dart/dynamics/dynamics.hpp>
+#include "aikido/constraint/smart_pointer.hpp"
 #include "../statespace/SE3.hpp"
 #include "../statespace/dart/MetaSkeletonStateSpace.hpp"
 #include "Testable.hpp"

--- a/include/aikido/constraint/InverseKinematicsSampleable.hpp
+++ b/include/aikido/constraint/InverseKinematicsSampleable.hpp
@@ -2,6 +2,7 @@
 #define AIKIDO_CONSTRAINT_INVERSEKINEMATICSSAMPLEABLEABLE_HPP_
 
 #include <dart/dynamics/dynamics.hpp>
+#include "aikido/constraint/smart_pointer.hpp"
 #include "../statespace/dart/MetaSkeletonStateSpace.hpp"
 #include "Sampleable.hpp"
 

--- a/include/aikido/constraint/NewtonsMethodProjectable.hpp
+++ b/include/aikido/constraint/NewtonsMethodProjectable.hpp
@@ -2,6 +2,7 @@
 #define AIKIDO_CONSTRAINT_NEWTONSMETHODPROJECTABLE_HPP_
 
 #include <Eigen/Dense>
+#include "aikido/constraint/smart_pointer.hpp"
 #include "Differentiable.hpp"
 #include "Projectable.hpp"
 

--- a/include/aikido/constraint/Projectable.hpp
+++ b/include/aikido/constraint/Projectable.hpp
@@ -2,6 +2,7 @@
 #define AIKIDO_CONSTRAINT_PROJECTABLE_H
 
 #include <Eigen/Dense>
+#include "aikido/statespace/smart_pointer.hpp"
 #include "../statespace/StateSpace.hpp"
 
 namespace aikido {
@@ -28,8 +29,6 @@ public:
   /// \param _s state to be projected and mutated.
   virtual bool project(statespace::StateSpace::State* _s) const;
 };
-
-using ProjectablePtr = std::shared_ptr<Projectable>;
 
 } // namespace constraint
 } // namespace aikido

--- a/include/aikido/constraint/RejectionSampleable.hpp
+++ b/include/aikido/constraint/RejectionSampleable.hpp
@@ -1,6 +1,7 @@
 #ifndef AIKIDO_CONSTRAINT_REJECTIONSAMPLEABLE_HPP_
 #define AIKIDO_CONSTRAINT_REJECTIONSAMPLEABLE_HPP_
 
+#include "aikido/constraint/smart_pointer.hpp"
 #include "../statespace/StateSpace.hpp"
 #include "Sampleable.hpp"
 #include "Testable.hpp"

--- a/include/aikido/constraint/Sampleable.hpp
+++ b/include/aikido/constraint/Sampleable.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <boost/optional.hpp>
 
+#include "aikido/statespace/smart_pointer.hpp"
 #include "../common/RNG.hpp"
 #include "../statespace/StateSpace.hpp"
 
@@ -57,8 +58,6 @@ public:
   /// Returns whether getNumSamples() > 0.
   virtual bool canSample() const = 0;
 };
-
-using SampleablePtr = std::shared_ptr<Sampleable>;
 
 } // namespace constraint
 } // namespace aikido

--- a/include/aikido/constraint/TSR.hpp
+++ b/include/aikido/constraint/TSR.hpp
@@ -148,8 +148,6 @@ private:
   std::shared_ptr<statespace::SE3> mStateSpace;
 };
 
-using TSRPtr = std::shared_ptr<TSR>;
-
 } // namespace constraint
 } // namespace aikido
 

--- a/include/aikido/constraint/Testable.hpp
+++ b/include/aikido/constraint/Testable.hpp
@@ -2,6 +2,7 @@
 #define AIKIDO_CONSTRAINT_TESTABLE_HPP_
 
 #include <memory>
+#include "aikido/statespace/smart_pointer.hpp"
 #include "../statespace/StateSpace.hpp"
 #include "DefaultTestableOutcome.hpp"
 
@@ -35,8 +36,6 @@ public:
   /// to isSatisfied (and casts, etc do not explode).
   virtual std::unique_ptr<TestableOutcome> createOutcome() const = 0;
 };
-
-using TestablePtr = std::shared_ptr<Testable>;
 
 } // namespace constraint
 } // namespace aikido

--- a/include/aikido/constraint/TestableIntersection.hpp
+++ b/include/aikido/constraint/TestableIntersection.hpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <vector>
+#include "aikido/constraint/smart_pointer.hpp"
 #include "Testable.hpp"
 
 namespace aikido {
@@ -44,8 +45,6 @@ private:
 
   void testConstraintStateSpaceOrThrow(const TestablePtr& constraint);
 };
-
-using TestableIntersectionPtr = std::shared_ptr<TestableIntersection>;
 
 } // namespace constraint
 } // namespace aikido

--- a/include/aikido/constraint/smart_pointer.hpp
+++ b/include/aikido/constraint/smart_pointer.hpp
@@ -1,0 +1,14 @@
+#ifndef AIKIDO_CONSTRAINT_SMARTPOINTER_HPP_
+#define AIKIDO_CONSTRAINT_SMARTPOINTER_HPP_
+
+#include "aikido/common/smart_pointer.hpp"
+
+namespace aikido {
+namespace constraint {
+
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(Testable)
+
+} // namespace constraint
+} // namespace aikido
+
+#endif // AIKIDO_STATESPACE_SMARTPOINTER_HPP_

--- a/include/aikido/constraint/smart_pointer.hpp
+++ b/include/aikido/constraint/smart_pointer.hpp
@@ -6,7 +6,10 @@
 namespace aikido {
 namespace constraint {
 
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(Differentiable)
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(Projectable)
 AIKIDO_COMMON_DECLARE_SMART_POINTERS(Testable)
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(Sampleable)
 
 } // namespace constraint
 } // namespace aikido

--- a/include/aikido/control/PositionCommandExecutor.hpp
+++ b/include/aikido/control/PositionCommandExecutor.hpp
@@ -26,8 +26,6 @@ public:
   virtual void step() = 0;
 };
 
-using PositionCommandExecutorPtr = std::shared_ptr<PositionCommandExecutor>;
-
 } // namespace control
 } // namespace aikido
 

--- a/include/aikido/control/TrajectoryExecutor.hpp
+++ b/include/aikido/control/TrajectoryExecutor.hpp
@@ -2,7 +2,7 @@
 #define AIKIDO_CONTROL_TRAJECTORYEXECUTOR_HPP_
 
 #include <future>
-#include <aikido/trajectory/Trajectory.hpp>
+#include "aikido/trajectory/smart_pointer.hpp"
 
 namespace aikido {
 namespace control {
@@ -29,8 +29,6 @@ public:
   /// simulation.
   virtual void abort() = 0;
 };
-
-using TrajectoryExecutorPtr = std::shared_ptr<TrajectoryExecutor>;
 
 } // namespace control
 } // namespace aikido

--- a/include/aikido/control/TrajectoryResult.hpp
+++ b/include/aikido/control/TrajectoryResult.hpp
@@ -12,8 +12,6 @@ public:
   virtual ~TrajectoryResult() = default;
 };
 
-using TrajectoryResultPtr = std::shared_ptr<TrajectoryResult>;
-
 } // namespace control
 } // namespace aikido
 

--- a/include/aikido/control/ros/Conversions.hpp
+++ b/include/aikido/control/ros/Conversions.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <sensor_msgs/JointState.h>
 #include <trajectory_msgs/JointTrajectory.h>
+#include "aikido/trajectory/smart_pointer.hpp"
 #include <aikido/statespace/dart/MetaSkeletonStateSpace.hpp>
 #include <aikido/trajectory/Spline.hpp>
 

--- a/include/aikido/distance/CartesianProductWeighted.hpp
+++ b/include/aikido/distance/CartesianProductWeighted.hpp
@@ -1,6 +1,7 @@
 #ifndef AIKIDO_DISTANCE_CARTESIANPRODUCTWEIGHTED_HPP_
 #define AIKIDO_DISTANCE_CARTESIANPRODUCTWEIGHTED_HPP_
 
+#include "aikido/distance/smart_pointer.hpp"
 #include "../statespace/CartesianProduct.hpp"
 #include "DistanceMetric.hpp"
 

--- a/include/aikido/distance/DistanceMetric.hpp
+++ b/include/aikido/distance/DistanceMetric.hpp
@@ -1,6 +1,7 @@
 #ifndef AIKIDO_DISTANCE_DISTANCEMETRIC_HPP_
 #define AIKIDO_DISTANCE_DISTANCEMETRIC_HPP_
 
+#include "aikido/statespace/smart_pointer.hpp"
 #include "../statespace/StateSpace.hpp"
 
 namespace aikido {
@@ -26,8 +27,6 @@ public:
       const statespace::StateSpace::State* _state1,
       const statespace::StateSpace::State* _state2) const = 0;
 };
-
-using DistanceMetricPtr = std::shared_ptr<DistanceMetric>;
 
 } // namespace distance
 } // namespace aikido

--- a/include/aikido/distance/smart_pointer.hpp
+++ b/include/aikido/distance/smart_pointer.hpp
@@ -1,0 +1,14 @@
+#ifndef AIKIDO_DISTANCE_SMARTPOINTER_HPP_
+#define AIKIDO_DISTANCE_SMARTPOINTER_HPP_
+
+#include "aikido/common/smart_pointer.hpp"
+
+namespace aikido {
+namespace distance {
+
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(DistanceMetric)
+
+} // namespace distance
+} // namespace aikido
+
+#endif // AIKIDO_DISTANCE_SMARTPOINTER_HPP_

--- a/include/aikido/perception/PerceptionModule.hpp
+++ b/include/aikido/perception/PerceptionModule.hpp
@@ -1,7 +1,7 @@
 #ifndef AIKIDO_PERCEPTION_PERCEPTIONMODULE_HPP_
 #define AIKIDO_PERCEPTION_PERCEPTIONMODULE_HPP_
 
-#include <aikido/planner/World.hpp>
+#include "aikido/planner/smart_pointer.hpp"
 
 namespace aikido {
 namespace perception {

--- a/include/aikido/planner/SnapPlanner.hpp
+++ b/include/aikido/planner/SnapPlanner.hpp
@@ -1,6 +1,7 @@
 #ifndef AIKIDO_PLANNER_SNAP_PLANNER_HPP_
 #define AIKIDO_PLANNER_SNAP_PLANNER_HPP_
 
+#include "aikido/trajectory/smart_pointer.hpp"
 #include "../constraint/Testable.hpp"
 #include "../statespace/Interpolator.hpp"
 #include "../statespace/StateSpace.hpp"

--- a/include/aikido/planner/TrajectoryPostProcessor.hpp
+++ b/include/aikido/planner/TrajectoryPostProcessor.hpp
@@ -2,8 +2,8 @@
 #define AIKIDO_PLANNER_TRAJECTORYPOSTPROCESSOR_HPP_
 
 #include "aikido/common/RNG.hpp"
-#include "aikido/trajectory/Interpolated.hpp"
 #include "aikido/trajectory/Spline.hpp"
+#include "aikido/trajectory/smart_pointer.hpp"
 
 namespace aikido {
 namespace planner {

--- a/include/aikido/planner/World.hpp
+++ b/include/aikido/planner/World.hpp
@@ -107,8 +107,6 @@ protected:
   dart::common::NameManager<dart::dynamics::SkeletonPtr> mSkeletonNameManager;
 };
 
-using WorldPtr = std::shared_ptr<World>;
-
 } // namespace planner
 } // namespace aikido
 

--- a/include/aikido/planner/ompl/CRRT.hpp
+++ b/include/aikido/planner/ompl/CRRT.hpp
@@ -5,6 +5,7 @@
 #include <ompl/datastructures/NearestNeighbors.h>
 #include <ompl/geometric/planners/PlannerIncludes.h>
 
+#include "aikido/constraint/smart_pointer.hpp"
 #include "../../constraint/Projectable.hpp"
 #include "../../planner/ompl/BackwardCompatibility.hpp"
 

--- a/include/aikido/planner/ompl/GeometricStateSpace.hpp
+++ b/include/aikido/planner/ompl/GeometricStateSpace.hpp
@@ -2,6 +2,8 @@
 #define AIKIDO_OMPL_AIKIDOGEOMETRICSTATESPACE_HPP_
 
 #include <ompl/base/StateSpace.h>
+#include "aikido/constraint/smart_pointer.hpp"
+#include "aikido/distance/smart_pointer.hpp"
 #include "aikido/planner/ompl/BackwardCompatibility.hpp"
 #include "../../constraint/Projectable.hpp"
 #include "../../constraint/Sampleable.hpp"
@@ -145,8 +147,6 @@ private:
   constraint::TestablePtr mBoundsConstraint;
   constraint::ProjectablePtr mBoundsProjection;
 };
-
-using GeometricStateSpacePtr = std::shared_ptr<GeometricStateSpace>;
 
 } // namespace ompl
 } // namespace planner

--- a/include/aikido/planner/ompl/GoalRegion.hpp
+++ b/include/aikido/planner/ompl/GoalRegion.hpp
@@ -2,6 +2,7 @@
 #define AIKIDO_OMPL_GOALREGION_HPP_
 
 #include <ompl/base/goals/GoalSampleableRegion.h>
+#include "aikido/constraint/smart_pointer.hpp"
 #include "../../constraint/Sampleable.hpp"
 #include "../../constraint/Testable.hpp"
 

--- a/include/aikido/planner/ompl/Planner.hpp
+++ b/include/aikido/planner/ompl/Planner.hpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <utility> // std::pair
 
+#include "aikido/trajectory/smart_pointer.hpp"
 #include "../../constraint/Projectable.hpp"
 #include "../../constraint/Sampleable.hpp"
 #include "../../constraint/Testable.hpp"

--- a/include/aikido/planner/parabolic/ParabolicSmoother.hpp
+++ b/include/aikido/planner/parabolic/ParabolicSmoother.hpp
@@ -3,6 +3,7 @@
 
 #include <Eigen/Dense>
 #include "aikido/constraint/Testable.hpp"
+#include "aikido/constraint/smart_pointer.hpp"
 #include "aikido/planner/TrajectoryPostProcessor.hpp"
 #include "aikido/trajectory/Interpolated.hpp"
 #include "aikido/trajectory/Spline.hpp"

--- a/include/aikido/planner/smart_pointer.hpp
+++ b/include/aikido/planner/smart_pointer.hpp
@@ -1,0 +1,14 @@
+#ifndef AIKIDO_PLANNER_SMARTPOINTER_HPP_
+#define AIKIDO_PLANNER_SMARTPOINTER_HPP_
+
+#include "aikido/common/smart_pointer.hpp"
+
+namespace aikido {
+namespace planner {
+
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(Planner)
+
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_SMARTPOINTER_HPP_

--- a/include/aikido/planner/smart_pointer.hpp
+++ b/include/aikido/planner/smart_pointer.hpp
@@ -7,6 +7,7 @@ namespace aikido {
 namespace planner {
 
 AIKIDO_COMMON_DECLARE_SMART_POINTERS(Planner)
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(World)
 
 } // namespace planner
 } // namespace aikido

--- a/include/aikido/planner/vectorfield/BodyNodePoseVectorField.hpp
+++ b/include/aikido/planner/vectorfield/BodyNodePoseVectorField.hpp
@@ -119,8 +119,6 @@ protected:
   bool mEnforceJointVelocityLimits;
 };
 
-using BodyNodePoseVectorFieldPtr = std::shared_ptr<BodyNodePoseVectorField>;
-
 } // namespace vectorfield
 } // namespace planner
 } // namespace aikido

--- a/include/aikido/planner/vectorfield/VectorField.hpp
+++ b/include/aikido/planner/vectorfield/VectorField.hpp
@@ -69,8 +69,6 @@ protected:
   aikido::statespace::StateSpacePtr mStateSpace;
 };
 
-using VectorFieldPtr = std::shared_ptr<VectorField>;
-
 } // namespace vectorfield
 } // namespace planner
 } // namespace aikido

--- a/include/aikido/planner/vectorfield/VectorFieldPlanner.hpp
+++ b/include/aikido/planner/vectorfield/VectorFieldPlanner.hpp
@@ -1,6 +1,7 @@
 #ifndef AIKIDO_PLANNER_VECTORFIELD_VECTORFIELDPLANNER_HPP_
 #define AIKIDO_PLANNER_VECTORFIELD_VECTORFIELDPLANNER_HPP_
 
+#include "aikido/constraint/smart_pointer.hpp"
 #include <aikido/constraint/Testable.hpp>
 #include <aikido/planner/PlanningResult.hpp>
 #include <aikido/planner/vectorfield/VectorField.hpp>

--- a/include/aikido/robot/smart_pointer.hpp
+++ b/include/aikido/robot/smart_pointer.hpp
@@ -1,0 +1,16 @@
+#ifndef AIKIDO_ROBOT_SMARTPOINTER_HPP_
+#define AIKIDO_ROBOT_SMARTPOINTER_HPP_
+
+#include "aikido/common/smart_pointer.hpp"
+
+namespace aikido {
+namespace common {
+
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(Manipulator)
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(MobileBase)
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(Robot)
+
+} // namespace rviz
+} // namespace aikido
+
+#endif // AIKIDO_ROBOT_SMARTPOINTER_HPP_

--- a/include/aikido/rviz/InteractiveMarkerViewer.hpp
+++ b/include/aikido/rviz/InteractiveMarkerViewer.hpp
@@ -11,6 +11,7 @@
 #include <interactive_markers/interactive_marker_server.h>
 #include <ros/ros.h>
 
+#include "aikido/trajectory/smart_pointer.hpp"
 #include <aikido/constraint/TSR.hpp>
 #include <aikido/rviz/SmartPointers.hpp>
 #include <aikido/rviz/TSRMarker.hpp>

--- a/include/aikido/rviz/TrajectoryMarker.hpp
+++ b/include/aikido/rviz/TrajectoryMarker.hpp
@@ -5,6 +5,7 @@
 #include <interactive_markers/interactive_marker_server.h>
 #include <visualization_msgs/InteractiveMarker.h>
 #include "aikido/trajectory/Trajectory.hpp"
+#include "aikido/trajectory/smart_pointer.hpp"
 
 namespace aikido {
 namespace rviz {

--- a/include/aikido/rviz/WorldInteractiveMarkerViewer.hpp
+++ b/include/aikido/rviz/WorldInteractiveMarkerViewer.hpp
@@ -2,6 +2,7 @@
 #define AIKIDO_RVIZ_WORLDINTERACTIVEMARKERVIEWER_HPP_
 
 #include <map>
+#include "aikido/planner/smart_pointer.hpp"
 #include <aikido/planner/World.hpp>
 #include <aikido/rviz/InteractiveMarkerViewer.hpp>
 #include <aikido/rviz/SmartPointers.hpp>

--- a/include/aikido/statespace/CartesianProduct.hpp
+++ b/include/aikido/statespace/CartesianProduct.hpp
@@ -1,6 +1,7 @@
 #ifndef AIKIDO_STATESPACE_COMPOUNDSTATESPACE_HPP_
 #define AIKIDO_STATESPACE_COMPOUNDSTATESPACE_HPP_
 #include <vector>
+#include "aikido/statespace/smart_pointer.hpp"
 #include "ScopedState.hpp"
 #include "StateSpace.hpp"
 

--- a/include/aikido/statespace/Interpolator.hpp
+++ b/include/aikido/statespace/Interpolator.hpp
@@ -2,6 +2,7 @@
 #define AIKIDO_STATESPACE_INTERPOLATOR_HPP_
 
 #include <memory>
+#include "aikido/statespace/smart_pointer.hpp"
 #include "../statespace/StateSpace.hpp"
 
 namespace aikido {
@@ -50,8 +51,6 @@ public:
       double _alpha,
       Eigen::VectorXd& _tangentVector) const = 0;
 };
-
-using InterpolatorPtr = std::shared_ptr<Interpolator>;
 
 } // namespace statespace
 } // namespace aikido

--- a/include/aikido/statespace/StateSpace.hpp
+++ b/include/aikido/statespace/StateSpace.hpp
@@ -166,9 +166,6 @@ public:
   virtual void print(const State* _state, std::ostream& _os) const = 0;
 };
 
-using StateSpacePtr = std::shared_ptr<StateSpace>;
-using ConstStateSpacePtr = std::shared_ptr<const StateSpace>;
-
 } // namespace statespace
 } // namespace aikido
 

--- a/include/aikido/statespace/dart/MetaSkeletonStateSpace.hpp
+++ b/include/aikido/statespace/dart/MetaSkeletonStateSpace.hpp
@@ -163,10 +163,6 @@ private:
   Properties mProperties;
 };
 
-using MetaSkeletonStateSpacePtr = std::shared_ptr<MetaSkeletonStateSpace>;
-using ConstMetaSkeletonStateSpacePtr
-    = std::shared_ptr<const MetaSkeletonStateSpace>;
-
 } // namespace dart
 } // namespace statespace
 } // namespace aikido

--- a/include/aikido/statespace/smart_pointer.hpp
+++ b/include/aikido/statespace/smart_pointer.hpp
@@ -1,0 +1,15 @@
+#ifndef AIKIDO_STATESPACE_SMARTPOINTER_HPP_
+#define AIKIDO_STATESPACE_SMARTPOINTER_HPP_
+
+#include "aikido/common/smart_pointer.hpp"
+
+namespace aikido {
+namespace statespace {
+
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(Interpolator)
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(StateSpace)
+
+} // namespace statespace
+} // namespace aikido
+
+#endif // AIKIDO_STATESPACE_SMARTPOINTER_HPP_

--- a/include/aikido/statespace/smart_pointer.hpp
+++ b/include/aikido/statespace/smart_pointer.hpp
@@ -9,6 +9,13 @@ namespace statespace {
 AIKIDO_COMMON_DECLARE_SMART_POINTERS(Interpolator)
 AIKIDO_COMMON_DECLARE_SMART_POINTERS(StateSpace)
 
+namespace dart {
+
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(JointStateSpace)
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(MetaSkeletonStateSpace)
+
+} // namespace dart
+
 } // namespace statespace
 } // namespace aikido
 

--- a/include/aikido/trajectory/Interpolated.hpp
+++ b/include/aikido/trajectory/Interpolated.hpp
@@ -94,8 +94,6 @@ private:
   std::vector<Waypoint> mWaypoints;
 };
 
-using InterpolatedPtr = std::shared_ptr<Interpolated>;
-
 } // namespace trajectory
 } // namespace aikido
 

--- a/include/aikido/trajectory/Trajectory.hpp
+++ b/include/aikido/trajectory/Trajectory.hpp
@@ -2,6 +2,7 @@
 #define AIKIDO_TRAJECTORY_TRAJECTORY_HPP_
 
 #include <Eigen/Core>
+#include "aikido/statespace/smart_pointer.hpp"
 #include <aikido/trajectory/TrajectoryMetadata.hpp>
 #include "../statespace/StateSpace.hpp"
 
@@ -71,9 +72,6 @@ public:
   /// Trajectory metadata
   TrajectoryMetadata metadata;
 };
-
-using TrajectoryPtr = std::shared_ptr<Trajectory>;
-using ConstTrajectoryPtr = std::shared_ptr<const Trajectory>;
 
 } // namespace trajectory
 } // namespace aikido

--- a/include/aikido/trajectory/smart_pointer.hpp
+++ b/include/aikido/trajectory/smart_pointer.hpp
@@ -1,0 +1,15 @@
+#ifndef AIKIDO_TRAJECTORY_SMARTPOINTER_HPP_
+#define AIKIDO_TRAJECTORY_SMARTPOINTER_HPP_
+
+#include "aikido/common/smart_pointer.hpp"
+
+namespace aikido {
+namespace trajectory {
+
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(Spline)
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(Interpolated)
+
+} // namespace trajectory
+} // namespace aikido
+
+#endif // AIKIDO_TRAJECTORY_SMARTPOINTER_HPP_

--- a/include/aikido/trajectory/smart_pointer.hpp
+++ b/include/aikido/trajectory/smart_pointer.hpp
@@ -6,6 +6,7 @@
 namespace aikido {
 namespace trajectory {
 
+AIKIDO_COMMON_DECLARE_SMART_POINTERS(Trajectory)
 AIKIDO_COMMON_DECLARE_SMART_POINTERS(Spline)
 AIKIDO_COMMON_DECLARE_SMART_POINTERS(Interpolated)
 

--- a/src/control/ros/Conversions.cpp
+++ b/src/control/ros/Conversions.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <unordered_set>
 #include <dart/dynamics/Joint.hpp>
+#include "aikido/trajectory/smart_pointer.hpp"
 #include <aikido/common/Spline.hpp>
 #include <aikido/common/StepSequence.hpp>
 #include <aikido/control/ros/Conversions.hpp>

--- a/src/perception/AprilTagsModule.cpp
+++ b/src/perception/AprilTagsModule.cpp
@@ -13,6 +13,7 @@
 #include <tf/LinearMath/Vector3.h>
 #include <visualization_msgs/Marker.h>
 #include <visualization_msgs/MarkerArray.h>
+#include "aikido/planner/World.hpp"
 #include <aikido/perception/shape_conversions.hpp>
 
 namespace aikido {

--- a/src/perception/RcnnPoseModule.cpp
+++ b/src/perception/RcnnPoseModule.cpp
@@ -6,6 +6,7 @@
 #include <ros/topic.h>
 #include <visualization_msgs/Marker.h>
 #include <visualization_msgs/MarkerArray.h>
+#include "aikido/planner/World.hpp"
 #include <aikido/io/CatkinResourceRetriever.hpp>
 #include <aikido/perception/shape_conversions.hpp>
 

--- a/src/planner/parabolic/HauserParabolicSmootherHelpers.hpp
+++ b/src/planner/parabolic/HauserParabolicSmootherHelpers.hpp
@@ -6,6 +6,7 @@
 #include "aikido/trajectory/Spline.hpp"
 #include "aikido/constraint/Testable.hpp"
 #include "DynamicPath.h"
+#include "aikido/constraint/smart_pointer.hpp"
 
 namespace aikido {
 namespace planner {

--- a/src/statespace/dart/MetaSkeletonStateSpace.cpp
+++ b/src/statespace/dart/MetaSkeletonStateSpace.cpp
@@ -14,8 +14,6 @@ namespace {
 using ::dart::dynamics::MetaSkeleton;
 using ::dart::dynamics::INVALID_INDEX;
 
-using JointStateSpacePtr = std::shared_ptr<JointStateSpace>;
-
 //==============================================================================
 template <class Input, class Output>
 std::vector<Output> convertVectorType(const std::vector<Input>& input)

--- a/tests/constraint/test_Differentiable.cpp
+++ b/tests/constraint/test_Differentiable.cpp
@@ -2,6 +2,7 @@
 #include "../eigen_tests.hpp"
 
 #include <aikido/constraint/Differentiable.hpp>
+#include <aikido/constraint/smart_pointer.hpp>
 #include "PolynomialConstraint.hpp"
 
 using aikido::constraint::DifferentiablePtr;

--- a/tests/constraint/test_SampleableSubspace.cpp
+++ b/tests/constraint/test_SampleableSubspace.cpp
@@ -2,6 +2,7 @@
 #include <aikido/common/RNG.hpp>
 #include <aikido/constraint/CartesianProductSampleable.hpp>
 #include <aikido/constraint/Sampleable.hpp>
+#include <aikido/constraint/smart_pointer.hpp>
 #include <aikido/constraint/uniform/RnBoxConstraint.hpp>
 #include <aikido/constraint/uniform/SO2UniformSampler.hpp>
 #include <aikido/statespace/Rn.hpp>

--- a/tests/planner/test_World.cpp
+++ b/tests/planner/test_World.cpp
@@ -2,6 +2,7 @@
 #include <dart/dynamics/dynamics.hpp>
 #include <gtest/gtest.h>
 #include <aikido/planner/World.hpp>
+#include <aikido/planner/smart_pointer.hpp>
 
 using std::shared_ptr;
 using std::make_shared;


### PR DESCRIPTION
This PR moves the declaration of smart pointers to separate headers to avoid the circular dependencies.

***

**Before creating a pull request**

- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
