### PR TITLE
[WIP] Refactor planner API

### DIFF
--- a/include/aikido/constraint/Testable.hpp
+++ b/include/aikido/constraint/Testable.hpp
@@ -37,6 +37,7 @@ public:
 };
 
 using TestablePtr = std::shared_ptr<Testable>;
+using ConstTestablePtr = std::shared_ptr<const Testable>;
 
 } // namespace constraint
 } // namespace aikido

--- a/include/aikido/planner/ConcretePlanner.hpp
+++ b/include/aikido/planner/ConcretePlanner.hpp
@@ -1,0 +1,56 @@
+#ifndef AIKIDO_PLANNER_CONCRETEPLANNER_HPP_
+#define AIKIDO_PLANNER_CONCRETEPLANNER_HPP_
+
+#include <functional>
+#include <unordered_map>
+#include "aikido/planner/Planner.hpp"
+#include "aikido/planner/Problem.hpp"
+#include "aikido/trajectory/Trajectory.hpp"
+
+namespace aikido {
+namespace planner {
+
+class ConcretePlanner : public Planner
+{
+public:
+  /// Constructor
+  ConcretePlanner() = default;
+
+  /// Destructor
+  virtual ~ConcretePlanner() = default;
+
+  // Documentation inherited.
+  bool canSolve(const Problem* problem) const override;
+
+  // Documentation inherited.
+  std::unordered_set<std::string> getSolvableProblems() const override;
+
+  // Documentation inherited.
+  trajectory::TrajectoryPtr solve(
+      const Problem* problem, Problem::Result* result = nullptr) override;
+
+protected:
+  using PlanningFunction = std::function<trajectory::TrajectoryPtr(
+      const Problem*, Problem::Result*)>;
+  using PlanningFunctionMap = std::unordered_map<std::string, PlanningFunction>;
+
+  /// Returns planning function map.
+  ///
+  /// The concrete planner classes should contain a static map and return it by
+  /// overriding this function.
+  virtual PlanningFunctionMap& getPlanningFunctionMap() = 0;
+
+  /// Returns planning function map.
+  const PlanningFunctionMap& getPlanningFunctionMap() const;
+
+  /// Registers planning function to this planner.
+  template <class ProblemT, typename T, typename R, typename... Args>
+  void registerPlanningFunction(R (T::*func)(Args...));
+};
+
+} // namespace planner
+} // namespace aikido
+
+#include "aikido/planner/detail/ConcretePlanner-impl.hpp"
+
+#endif // AIKIDO_PLANNER_CONCRETEPLANNER_HPP_

--- a/include/aikido/planner/FirstSupportedMetaPlanner.hpp
+++ b/include/aikido/planner/FirstSupportedMetaPlanner.hpp
@@ -1,0 +1,20 @@
+#ifndef AIKIDO_PLANNER_FIRSTSUPPORTEDMETAPLANNER_HPP_
+#define AIKIDO_PLANNER_FIRSTSUPPORTEDMETAPLANNER_HPP_
+
+#include "aikido/planner/MetaPlanner.hpp"
+
+namespace aikido {
+namespace planner {
+
+class FirstSupportedMetaPlanner : public MetaPlanner
+{
+public:
+  // Documentation inherited.
+  trajectory::TrajectoryPtr solve(
+      const Problem* problem, Problem::Result* result = nullptr) override;
+};
+
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_FIRSTSUPPORTEDMETAPLANNER_HPP_

--- a/include/aikido/planner/MetaPlanner.hpp
+++ b/include/aikido/planner/MetaPlanner.hpp
@@ -1,0 +1,50 @@
+#ifndef AIKIDO_PLANNER_METAPLANNER_HPP_
+#define AIKIDO_PLANNER_METAPLANNER_HPP_
+
+#include <unordered_set>
+#include <vector>
+#include "aikido/planner/Planner.hpp"
+
+namespace aikido {
+namespace planner {
+
+class MetaPlanner : public Planner
+{
+public:
+  /// Constructor.
+  explicit MetaPlanner(const std::vector<PlannerPtr>& planners);
+
+  /// Adds planner.
+  void addPlanner(PlannerPtr planner);
+
+  /// Returns true if this MetaPlanner contains \c planner.
+  bool hasPlanner(const Planner* planner);
+
+  /// Returns all the planners in this MetaPlanner.
+  const std::vector<PlannerPtr>& getPlanners() const;
+
+  /// Returns planner given \c index.
+  ///
+  /// \throw If index is equal to or greater than the number of planners in this
+  /// MetaPlanner.
+  PlannerPtr getPlanner(std::size_t index);
+
+  // Documentation inherited.
+  bool canSolve(const Problem* problem) const override;
+
+  // Documentation inherited.
+  std::unordered_set<std::string> getSolvableProblems() const override;
+
+  /// Returns set of planners that can solve \c problem.
+  std::unordered_set<PlannerPtr> getPlannersCanSolve(
+      const Problem* problem) const;
+
+protected:
+  /// Planners
+  std::vector<PlannerPtr> mPlanners;
+};
+
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_METAPLANNER_HPP_

--- a/include/aikido/planner/PlanToConfiguration.hpp
+++ b/include/aikido/planner/PlanToConfiguration.hpp
@@ -1,0 +1,85 @@
+#ifndef AIKIDO_PLANNER_PLANTOCONFIGURATION_HPP_
+#define AIKIDO_PLANNER_PLANTOCONFIGURATION_HPP_
+
+#include "aikido/constraint/Testable.hpp"
+#include "aikido/planner/Problem.hpp"
+#include "aikido/statespace/StateSpace.hpp"
+#include "aikido/trajectory/Interpolated.hpp"
+
+namespace aikido {
+namespace planner {
+
+/// Planning problem to plan to a single goal configuration.
+///
+/// Plan a trajectory from start state to goal state by using an interpolator to
+/// interpolate between them.
+class PlanToConfiguration : public Problem
+{
+public:
+  class Result;
+
+  /// Constructor.
+  ///
+  /// \param stateSpace State space.
+  /// \param startState Start state.
+  /// \param goalState Goal state.
+  /// \param interpolator Interpolator used to produce the output trajectory.
+  /// \param constraint Trajectory-wide constraint that must be satisfied.
+  /// \throw If \c stateSpace is not compatible to \c constraint's state space.
+  PlanToConfiguration(
+      statespace::StateSpacePtr stateSpace,
+      const statespace::StateSpace::State* startState,
+      const statespace::StateSpace::State* goalState,
+      statespace::InterpolatorPtr interpolator,
+      constraint::TestablePtr constraint);
+
+  /// Returns the name of the planner problem.
+  const std::string& getName() const override;
+  static const std::string& getStaticName();
+
+  /// Returns the start state.
+  const statespace::StateSpace::State* getStartState() const;
+
+  /// Returns the goal state.
+  const statespace::StateSpace::State* getGoalState() const;
+
+  /// Returns the interpolator used to produce the output trajectory.
+  statespace::InterpolatorPtr getInterpolator();
+
+  /// Returns the interpolator used to produce the output trajectory.
+  statespace::InterpolatorPtr getInterpolator() const;
+  // TODO: Should return ConstInterpolatorPtr when resolving const correctness
+  // issues.
+
+  /// Returns the constraint that must be satisfied throughout the trajectory.
+  constraint::TestablePtr getConstraint();
+
+  /// Returns the constraint that must be satisfied throughout the trajectory.
+  constraint::TestablePtr getConstraint() const;
+  // TODO: Should return ConstInterpolatorPtr when resolving const correctness
+  // issues.
+
+protected:
+  /// Start state.
+  const statespace::StateSpace::State* mStartState;
+
+  /// Goal state.
+  const statespace::StateSpace::State* mGoalState;
+
+  /// Interpolator used to produce the output trajectory.
+  statespace::InterpolatorPtr mInterpolator;
+
+  /// Trajectory-wide constraint that must be satisfied.
+  constraint::TestablePtr mConstraint;
+};
+
+class PlanToConfiguration::Result : public Problem::Result
+{
+public:
+protected:
+};
+
+} // namespace planner
+} // namespace aikido
+
+#endif

--- a/include/aikido/planner/PlanToConfigurations.hpp
+++ b/include/aikido/planner/PlanToConfigurations.hpp
@@ -1,0 +1,81 @@
+#ifndef AIKIDO_PLANNER_PLANTOCONFIGURATIONS_HPP_
+#define AIKIDO_PLANNER_PLANTOCONFIGURATIONS_HPP_
+
+#include "aikido/constraint/Testable.hpp"
+#include "aikido/planner/Problem.hpp"
+#include "aikido/statespace/StateSpace.hpp"
+#include "aikido/statespace/Interpolator.hpp"
+
+namespace aikido {
+namespace planner {
+
+/// Planning problem to plan to a multiple goal configurations.
+///
+/// Plan a trajectory from start state to any of the goal states using an
+/// interpolator to interpolate between the states.
+class PlanToConfigurations : public Problem
+{
+public:
+  class Result;
+
+  /// Constructor.
+  ///
+  /// \param stateSpace State space.
+  /// \param startState Start state.
+  /// \param goalStates Goal states.
+  /// \param interpolator Interpolator used to produce the output trajectory.
+  /// \param constraint Trajectory-wide constraint that must be satisfied.
+  /// \throw If \c stateSpace is not compatible to \c constraint's state space.
+  PlanToConfigurations(
+      statespace::StateSpacePtr stateSpace,
+      const statespace::StateSpace::State* startState,
+      const std::vector<statespace::StateSpace::State*> goalStates,
+      statespace::InterpolatorPtr interpolator,
+      constraint::TestablePtr constraint);
+
+  /// Returns the name of the planner problem.
+  const std::string& getName() const override;
+  static const std::string& getStaticName();
+
+  /// Returns the start state.
+  const statespace::StateSpace::State* getStartState() const;
+
+  /// Returns the vector of goal states.
+  const std::vector<statespace::StateSpace::State*> getGoalStates() const;
+
+  /// Returns the interpolator used to produce the output trajectory.
+  statespace::InterpolatorPtr getInterpolator();
+
+  /// Returns the interpolator used to produce the output trajectory.
+  statespace::ConstInterpolatorPtr getInterpolator() const;
+
+  /// Returns the constraint that must be satisfied throughout the trajectory.
+  constraint::TestablePtr getConstraint();
+
+  /// Returns the constraint that must be satisfied throughout the trajectory.
+  constraint::ConstTestablePtr getConstraint() const;
+
+protected:
+  /// Start state.
+  const statespace::StateSpace::State* mStartState;
+
+  /// Goal States.
+  const std::vector<statespace::StateSpace::State*> mGoalStates;
+
+  /// Interpolator used to produce the output trajectory.
+  statespace::InterpolatorPtr mInterpolator;
+
+  /// Trajectory-wide constrained that must be satisfied.
+  constraint::TestablePtr mConstraint;
+};
+
+class PlanToConfigurations::Result : public Problem::Result
+{
+public:
+protected:
+};
+
+} // namespace planner
+} // namespace aikido
+
+#endif

--- a/include/aikido/planner/PlanToEndEffectorOffset.hpp
+++ b/include/aikido/planner/PlanToEndEffectorOffset.hpp
@@ -1,0 +1,93 @@
+#ifndef AIKIDO_PLANNER_PLANTOENDEFFECTOROFFSET_HPP_
+#define AIKIDO_PLANNER_PLANTOENDEFFECTOROFFSET_HPP_
+
+#include <dart/dart.hpp>
+#include "aikido/planner/Problem.hpp"
+#include "aikido/statespace/StateSpace.hpp"
+#include "aikido/trajectory/Interpolated.hpp"
+#include "aikido/constraint/Testable.hpp"
+
+namespace aikido {
+namespace planner {
+
+/// Planning problem to plan to desired en-effector offset with fixed
+/// orientation
+class PlanToEndEffectorOffset : public Problem
+{
+public:
+  class Result;
+
+  /// Constructor.
+  ///
+  /// \param stateSpace State space.
+  /// \param bodyNode Body Node or robot for which the path is to be planned.
+  /// \param startState Start state.
+  /// \param goalState Goal state.
+  /// \param direction Direction of motion [unit vector in the world frame].
+  /// \param distance Distance to move, in meters.
+  /// \param interpolator Interpolator used to produce the output trajectory.
+  /// \param constraint Trajectory-wide constraint that must be satisfied.
+  /// \throw If \c stateSpace is not compatible to \c constraint's state space.
+  PlanToEndEffectorOffset(
+      statespace::StateSpacePtr stateSpace,
+      dart::dynamics::BodyNodePtr bodyNode,
+      const statespace::StateSpace::State* startState,
+      const Eigen::Vector3d& direction,
+      const double& distance,
+      statespace::InterpolatorPtr interpolator,
+      constraint::TestablePtr constraint);
+
+  /// Returns the name of the planner problem.
+  const std::string& getName() const override;
+  static const std::string& getStaticName();
+
+  /// Returns the body node or robot for which the path is to be planned.
+  dart::dynamics::BodyNodePtr getBodyNode();
+
+  /// Returns the start state.
+  const statespace::StateSpace::State* getStartState() const;
+
+  /// Returns the direction of motion specified in the world frame.
+  const Eigen::Vector3d& getDirection() const;
+
+  /// Returns the distance to move in the specified direction [meters]
+  const double& getDistance() const;
+
+  /// Returns the interpolator used to produce the output trajectory.
+  statespace::InterpolatorPtr getInterpolator();
+  statespace::ConstInterpolatorPtr getInterpolator() const;
+
+  /// Returns the constraint that must be satisfied throughout the trajectory.
+  constraint::TestablePtr getConstraint();
+  constraint::ConstTestablePtr getConstraint() const;
+
+protected:
+  /// Body Node or Robot.
+  dart::dynamics::BodyNodePtr mBodyNode;
+
+  /// Start state.
+  const statespace::StateSpace::State* mStartState;
+
+  /// Direction of motion.
+  const Eigen::Vector3d mDirection;
+
+  /// Distance to move in the direction specified.
+  const double mDistance;
+
+  /// Interpolator used to produce the output trajectory.
+  statespace::InterpolatorPtr mInterpolator;
+
+  /// Trajectory-wide constraint that must be satisfied.
+  constraint::TestablePtr mConstraint;
+};
+
+class PlanToEndEffectorOffset::Result : public Problem::Result
+{
+public:
+protected:
+};
+
+} // namespace planner
+} // namespace aikido
+
+#endif

--- a/include/aikido/planner/PlanToEndEffectorPose.hpp
+++ b/include/aikido/planner/PlanToEndEffectorPose.hpp
@@ -1,0 +1,86 @@
+#ifndef AIKIDO_PLANNER_PLANTOENDEFFECTORPOSE_HPP_
+#define AIKIDO_PLANNER_PLANTOENDEFFECTORPOSE_HPP_
+
+#include <dart/dart.hpp>
+#include "aikido/planner/Problem.hpp"
+#include "aikido/statespace/StateSpace.hpp"
+#include "aikido/trajectory/Interpolated.hpp"
+#include "aikido/constraint/Testable.hpp"
+
+namespace aikido {
+namespace planner {
+
+/// Planning problem to plan to a given end effector pose.
+///
+/// Plan a trajectory from start state to goal state by using an interpolator to
+/// interpolate between them.
+class PlanToEndEffectorPose : public Problem
+{
+public:
+  class Result;
+
+  /// Constructor.
+  ///
+  /// \param stateSpace State space.
+  /// \param bodyNode Body Node or Robot for which the path is to be planned.
+  /// \param startState Start state.
+  /// \param goalPose Goal pose.
+  /// \param interpolator Interpolator used to produce the output trajectory.
+  /// \param constraint Trajectory-wide constraint that must be satisfied.
+  /// \throw If \c stateSpace is not compatible to \c constraint's state space.
+  PlanToEndEffectorPose(
+      statespace::StateSpacePtr stateSpace,
+      dart::dynamics::BodyNodePtr bodyNode,
+      const statespace::StateSpace::State* startState,
+      const Eigen::Isometry3d& goalPose,
+      statespace::InterpolatorPtr interpolator,
+      constraint::TestablePtr constraint);
+
+  /// Returns the name of the planner problem.
+  const std::string& getName() const override;
+  static const std::string& getStaticName();
+
+  /// Returns the body node or robot for which the path is to be planned.
+  dart::dynamics::BodyNodePtr getBodyNode();
+
+  /// Returns the start state.
+  const statespace::StateSpace::State* getStartState() const;
+
+  /// Returns the goal pose.
+  const Eigen::Isometry3d& getGoalPose() const;
+
+  /// Returns the interpolator used to produce the output trajectory.
+  statespace::InterpolatorPtr getInterpolator();
+  statespace::ConstInterpolatorPtr getInterpolator() const;
+
+  /// Returns the constraint that must be satisfied throughout the trajectory.
+  constraint::TestablePtr getConstraint();
+  constraint::ConstTestablePtr getConstraint() const;
+
+protected:
+  /// Body Node or Robot.
+  dart::dynamics::BodyNodePtr mBodyNode;
+
+  /// Start state.
+  const statespace::StateSpace::State* mStartState;
+
+  /// Goal pose.
+  const Eigen::Isometry3d mGoalPose;
+
+  /// Interpolator used to produce the output trajectory.
+  statespace::InterpolatorPtr mInterpolator;
+
+  /// Trajectory-wide constraint that must be satisfied.
+  constraint::TestablePtr mConstraint;
+};
+
+class PlanToEndEffectorPose::Result : public Problem::Result
+{
+public:
+protected:
+};
+
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_PLANTOENDEFFECTORPOSE_HPP_

--- a/include/aikido/planner/PlanToTSR.hpp
+++ b/include/aikido/planner/PlanToTSR.hpp
@@ -1,0 +1,80 @@
+#ifndef AIKIDO_PLANNER_PLANTOTSR_HPP_
+#define AIKIDO_PLANNER_PLANTOTSR_HPP_
+
+#include <dart/dart.hpp>
+#include "aikido/constraint/TSR.hpp"
+#include "aikido/planner/Problem.hpp"
+#include "aikido/statespace/StateSpace.hpp"
+#include "aikido/trajectory/Interpolated.hpp"
+
+namespace aikido {
+namespace planner {
+
+/// Planning problem to plan to given single Task Space Region (TSR).
+class PlanToTSR : public Problem
+{
+public:
+  class Result;
+
+  /// Constructor.
+  ///
+  /// \param stateSpace State space.
+  /// \param bodyNode Body Node or robot for which the path is to be planned.
+  /// \param startState Start state.
+  /// \param goalTSR Goal TSR.
+  /// \param interpolator Interpolator used to produce the output trajectory.
+  /// \param constraint Trajectory-wide constraint that must be satisfied.
+  /// \throw If \c stateSpace is not compatible to \c constraint's state space.
+  PlanToTSR(
+      statespace::StateSpacePtr stateSpace,
+      dart::dynamics::BodyNodePtr bodyNode,
+      const statespace::StateSpace::State* startState,
+      const constraint::TSRPtr goalTSR,
+      statespace::InterpolatorPtr interpolator,
+      constraint::TestablePtr constraint);
+
+  const std::string& getName() const override;
+
+  static const std::string& getStaticName();
+
+  dart::dynamics::BodyNodePtr getBodyNode();
+
+  const statespace::StateSpace::State* getStartState() const;
+
+  const constraint::TSRPtr getGoalTSR() const;
+
+  statespace::InterpolatorPtr getInterpolator();
+
+  statespace::ConstInterpolatorPtr getInterpolator() const;
+
+  constraint::TestablePtr getConstraint();
+
+  constraint::ConstTestablePtr getConstraint() const;
+
+protected:
+  /// Body Node or Robot
+  dart::dynamics::BodyNodePtr mBodyNode;
+
+  /// Start State
+  const statespace::StateSpace::State* mStartState;
+
+  /// Goal TSR
+  const constraint::TSRPtr mGoalTSR;
+
+  /// Interpolator used to produce the output trajectory.
+  statespace::InterpolatorPtr mInterpolator;
+
+  /// Trajectory-wide constraint that must be satisfied.
+  constraint::TestablePtr mConstraint;
+};
+
+class PlanToTSR::Result : public Problem::Result
+{
+public:
+protected:
+};
+
+} // namespace planner
+} // namespace aikido
+
+#endif

--- a/include/aikido/planner/Planner.hpp
+++ b/include/aikido/planner/Planner.hpp
@@ -1,0 +1,33 @@
+#ifndef AIKIDO_PLANNER_PLANNER_HPP_
+#define AIKIDO_PLANNER_PLANNER_HPP_
+
+#include <functional>
+#include <unordered_set>
+#include "aikido/planner/Problem.hpp"
+#include "aikido/trajectory/Trajectory.hpp"
+
+namespace aikido {
+namespace planner {
+
+/// Base class for a meta-planner
+class Planner
+{
+public:
+  /// Returns true if this planner can solve \c problem.
+  virtual bool canSolve(const Problem* problem) const = 0;
+
+  /// Returns all the problems that this planner can solve.
+  virtual std::unordered_set<std::string> getSolvableProblems() const = 0;
+
+  /// Solves \c problem returning the result to \c result.
+  virtual trajectory::TrajectoryPtr solve(
+      const Problem* problem, Problem::Result* result = nullptr)
+      = 0;
+};
+
+using PlannerPtr = std::shared_ptr<Planner>;
+
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_PLANNER_HPP_

--- a/include/aikido/planner/Problem.hpp
+++ b/include/aikido/planner/Problem.hpp
@@ -1,0 +1,54 @@
+#ifndef AIKIDO_PLANNER_PROBLEM_HPP_
+#define AIKIDO_PLANNER_PROBLEM_HPP_
+
+#include <string>
+#include "aikido/statespace/StateSpace.hpp"
+
+namespace aikido {
+namespace planner {
+
+/// Base class for various planning problems.
+class Problem
+{
+public:
+  class Result;
+
+  /// Constructor.
+  explicit Problem(statespace::StateSpacePtr stateSpace);
+
+  /// Destructor.
+  virtual ~Problem() = default;
+
+  /// Returns name.
+  virtual const std::string& getName() const = 0;
+
+  /// Returns const state space.
+  statespace::StateSpacePtr getStateSpace() const;
+
+protected:
+  /// State space associated with this problem.
+  statespace::StateSpacePtr mStateSpace;
+};
+
+/// Base class for planning result of various planning problems.
+class Problem::Result
+{
+public:
+  /// Destructor.
+  virtual ~Result() = default;
+
+  /// Sets message.
+  void setMessage(const std::string& message);
+
+  /// Returns message.
+  const std::string& getMessage() const;
+
+protected:
+  /// Message.
+  std::string mMessage;
+};
+
+} // namespace planner
+} // namespace aikido
+
+#endif

--- a/include/aikido/planner/RankedMetaPlanner.hpp
+++ b/include/aikido/planner/RankedMetaPlanner.hpp
@@ -1,0 +1,22 @@
+#ifndef AIKIDO_PLANNER_RANKEDMETAPLANNER_HPP_
+#define AIKIDO_PLANNER_RANKEDMETAPLANNER_HPP_
+
+#include "aikido/planner/MetaPlanner.hpp"
+
+namespace aikido {
+namespace planner {
+
+class RankedMetaPlanner : public MetaPlanner
+{
+public:
+  // Documentation inherited.
+  trajectory::TrajectoryPtr solve(
+      const Problem* problem, Problem::Result* result = nullptr) override;
+
+protected:
+};
+
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_RANKEDMETAPLANNER_HPP_

--- a/include/aikido/planner/SequenceMetaPlanner.hpp
+++ b/include/aikido/planner/SequenceMetaPlanner.hpp
@@ -1,0 +1,20 @@
+#ifndef AIKIDO_PLANNER_SEQUENCEMETAPLANNER_HPP_
+#define AIKIDO_PLANNER_SEQUENCEMETAPLANNER_HPP_
+
+#include "aikido/planner/MetaPlanner.hpp"
+
+namespace aikido {
+namespace planner {
+
+class SequenceMetaPlanner : public MetaPlanner
+{
+public:
+  // Documentation inherited.
+  trajectory::TrajectoryPtr solve(
+      const Problem* problem, Problem::Result* result = nullptr) override;
+};
+
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_SEQUENCEMETAPLANNER_HPP_

--- a/include/aikido/planner/SnapPlanner.hpp
+++ b/include/aikido/planner/SnapPlanner.hpp
@@ -1,37 +1,60 @@
-#ifndef AIKIDO_PLANNER_SNAP_PLANNER_HPP_
-#define AIKIDO_PLANNER_SNAP_PLANNER_HPP_
+#ifndef AIKIDO_PLANNER_SNAPPLANNER_HPP_
+#define AIKIDO_PLANNER_SNAPPLANNER_HPP_
 
-#include "../constraint/Testable.hpp"
-#include "../statespace/Interpolator.hpp"
-#include "../statespace/StateSpace.hpp"
-#include "../trajectory/Interpolated.hpp"
-#include "PlanningResult.hpp"
+#include "aikido/constraint/Testable.hpp"
+#include "aikido/planner/ConcretePlanner.hpp"
+#include "aikido/planner/PlanToConfiguration.hpp"
+#include "aikido/planner/PlanToConfigurations.hpp"
+#include "aikido/planner/PlanToTSR.hpp"
+#include "aikido/trajectory/Interpolated.hpp"
 
 namespace aikido {
 namespace planner {
 
-/// Plan a trajectory from \c startState to \c goalState by using
-/// \c interpolator to interpolate between them. The planner returns success if
-/// the resulting trajectory satisfies \c constraint at some resolution and
-/// failure (returning \c nullptr) otherwise. The reason for the failure is
-/// stored in the \c planningResult output parameter.
+/// Planner that checks the straight-line trajectory to the goal.
 ///
-/// \param stateSpace state space
-/// \param startState start state
-/// \param goalState goal state
-/// \param interpolator interpolator used to produce the output trajectory
-/// \param constraint trajectory-wide constraint that must be satisfied
-/// \param[out] planningResult information about success or failure
-/// \return trajectory or \c nullptr if planning failed
-trajectory::InterpolatedPtr planSnap(
-    const std::shared_ptr<statespace::StateSpace>& stateSpace,
-    const statespace::StateSpace::State* startState,
-    const statespace::StateSpace::State* goalState,
-    const std::shared_ptr<statespace::Interpolator>& interpolator,
-    const std::shared_ptr<constraint::Testable>& constraint,
-    planner::PlanningResult& planningResult);
+/// SnapPlanner is a utility planner class that collision checks the
+/// straight-line trajectory to the goal. If that trajectory is invalid, e.g.,
+/// due to an environment or self collision, the planner immediately returns
+/// \c nullptr.
+///
+/// SnapPlanner is intended to be used only as a "short circuit" to speed-up
+/// planning between nearby configurations. This planner is most commonly used
+/// as the first item in a Sequence meta-planner to avoid calling a motion
+/// planner when the trivial solution is valid.
+class SnapPlanner : public ConcretePlanner
+{
+public:
+  /// Constructor
+  SnapPlanner();
+
+  /// Solves PlanToConfiguration problem.
+  ///
+  /// The planner returns success if the resulting trajectory satisfies
+  /// constraint at some resolution and failure (returning \c nullptr)
+  /// otherwise. The reason for the failure is stored in the \c result output
+  /// parameter.
+  ///
+  /// \param problem Planning problem.
+  /// \param[out] result Information about success or failure.
+  /// \return Trajectory or \c nullptr if planning failed.
+  /// \throw If \c problem is not PlanToConfiguration.
+  /// \throw If \c result is not PlanToConfiguration::Result.
+  trajectory::InterpolatedPtr planToConfiguration(
+      const Problem* problem, Problem::Result* result = nullptr);
+
+protected:
+  // Documentation inherited.
+  PlanningFunctionMap& getPlanningFunctionMap() override;
+
+  /// Whether planning function map is set.
+  static bool mIsRegisteredPlanningFunctions;
+
+  /// Planning function map.
+  static PlanningFunctionMap mPlanningFunctionMap;
+};
 
 } // namespace planner
 } // namespace aikido
 
-#endif // AIKIDO_PLANNER_SNAP_PLANNER_HPP_
+#endif // AIKIDO_PLANNER_SNAPPLANNER_HPP_

--- a/include/aikido/planner/detail/ConcretePlanner-impl.hpp
+++ b/include/aikido/planner/detail/ConcretePlanner-impl.hpp
@@ -1,0 +1,26 @@
+#ifndef AIKIDO_PLANNER_DETAIL_CONCRETEPLANNER_IMPL_HPP_
+#define AIKIDO_PLANNER_DETAIL_CONCRETEPLANNER_IMPL_HPP_
+
+#include "aikido/planner/ConcretePlanner.hpp"
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+template <class ProblemT, typename T, typename R, typename... Args>
+void ConcretePlanner::registerPlanningFunction(R (T::*func)(Args...))
+{
+  auto& map = getPlanningFunctionMap();
+  auto bindedFunc = std::bind(
+      func,
+      static_cast<T*>(this),
+      std::placeholders::_1,  // problem
+      std::placeholders::_2); // result
+
+  map.insert(std::make_pair(ProblemT::getStaticName(), bindedFunc));
+}
+
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_DETAIL_CONCRETEPLANNER_IMPL_HPP_

--- a/include/aikido/statespace/Interpolator.hpp
+++ b/include/aikido/statespace/Interpolator.hpp
@@ -52,6 +52,7 @@ public:
 };
 
 using InterpolatorPtr = std::shared_ptr<Interpolator>;
+using ConstInterpolatorPtr = std::shared_ptr<const Interpolator>;
 
 } // namespace statespace
 } // namespace aikido

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -1,5 +1,17 @@
 set(sources
+  ConcretePlanner.cpp
+  FirstSupportedMetaPlanner.cpp
+  MetaPlanner.cpp
+  Planner.cpp
+  PlanToConfiguration.cpp
+  PlanToConfigurations.cpp
+  PlanToTSR.cpp
+  PlanToEndEffectorOffset.cpp
+  PlanToEndEffectorPose.cpp
+  Problem.cpp
+  RankedMetaPlanner.cpp
   SnapPlanner.cpp
+  SequenceMetaPlanner.cpp
   World.cpp
   WorldStateSaver.cpp)
 

--- a/src/planner/ConcretePlanner.cpp
+++ b/src/planner/ConcretePlanner.cpp
@@ -1,0 +1,73 @@
+#include "aikido/planner/ConcretePlanner.hpp"
+
+#include <cassert>
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+bool ConcretePlanner::canSolve(const Problem* problem) const
+{
+  auto& map = getPlanningFunctionMap();
+  const auto search = map.find(problem->getName());
+
+  if (search != map.end())
+    return true;
+  else
+    return false;
+}
+
+//==============================================================================
+std::unordered_set<std::string> ConcretePlanner::getSolvableProblems() const
+{
+  auto& map = getPlanningFunctionMap();
+
+  std::unordered_set<std::string> problems;
+  problems.reserve(map.size());
+
+  for (auto& item : map)
+    problems.insert(item.first);
+
+  return problems;
+}
+
+//==============================================================================
+trajectory::TrajectoryPtr ConcretePlanner::solve(
+    const Problem* problem, Problem::Result* result)
+{
+  if (!problem)
+  {
+    if (result)
+    {
+      // TODO(JS): not implemented
+    }
+
+    return nullptr;
+  }
+
+  auto& map = getPlanningFunctionMap();
+  const auto search = map.find(problem->getName());
+
+  if (search == map.end())
+  {
+    if (result)
+    {
+      // TODO(JS): not implemented
+    }
+
+    return nullptr;
+  }
+
+  assert(search->second);
+  return search->second(problem, result);
+}
+
+//==============================================================================
+const ConcretePlanner::PlanningFunctionMap&
+ConcretePlanner::getPlanningFunctionMap() const
+{
+  return const_cast<ConcretePlanner*>(this)->getPlanningFunctionMap();
+}
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/FirstSupportedMetaPlanner.cpp
+++ b/src/planner/FirstSupportedMetaPlanner.cpp
@@ -1,0 +1,24 @@
+#include "aikido/planner/FirstSupportedMetaPlanner.hpp"
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+trajectory::TrajectoryPtr FirstSupportedMetaPlanner::solve(
+    const Problem* problem, Problem::Result* result)
+{
+  for (const auto& planner : mPlanners)
+  {
+    if (!planner->canSolve(problem))
+      continue;
+
+    return planner->solve(problem, result);
+  }
+
+  // TODO: Set result "no supported planner".
+
+  return nullptr;
+}
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/MetaPlanner.cpp
+++ b/src/planner/MetaPlanner.cpp
@@ -1,0 +1,112 @@
+#include "aikido/planner/MetaPlanner.hpp"
+
+#include <algorithm>
+#include <dart/common/Console.hpp>
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+MetaPlanner::MetaPlanner(const std::vector<PlannerPtr>& planners)
+  : mPlanners(planners)
+{
+  // Do nothing
+}
+
+//==============================================================================
+void MetaPlanner::addPlanner(PlannerPtr planner)
+{
+  if (std::find(mPlanners.begin(), mPlanners.end(), planner) != mPlanners.end())
+  {
+    dtwarn << "[MetaPlanner::addPlanner] Attempts to add a planner that "
+              "already exists in this MetaPlanner.\n";
+    return;
+  }
+
+  mPlanners.emplace_back(std::move(planner));
+}
+
+//==============================================================================
+bool MetaPlanner::hasPlanner(const Planner* planner)
+{
+  if (std::find_if(
+          mPlanners.begin(),
+          mPlanners.end(),
+          [&planner](const PlannerPtr& val) -> bool {
+            return (val.get() == planner);
+          })
+      != mPlanners.end())
+  {
+    return true;
+  }
+
+  return false;
+}
+
+//==============================================================================
+const std::vector<PlannerPtr>& MetaPlanner::getPlanners() const
+{
+  return mPlanners;
+}
+
+//==============================================================================
+PlannerPtr MetaPlanner::getPlanner(std::size_t index)
+{
+  if (index > mPlanners.size())
+    throw std::invalid_argument("index is out of bound");
+
+  return mPlanners[index];
+}
+
+//==============================================================================
+bool MetaPlanner::canSolve(const Problem* problem) const
+{
+  for (const auto& planner : mPlanners)
+  {
+    if (planner->canSolve(problem))
+      return true;
+  }
+
+  return false;
+}
+
+//==============================================================================
+std::unordered_set<std::string> MetaPlanner::getSolvableProblems() const
+{
+  std::unordered_set<std::string> problems;
+
+  for (const auto& planner : mPlanners)
+  {
+    const auto& subProblems = planner->getSolvableProblems();
+    problems.insert(subProblems.begin(), subProblems.end());
+  }
+
+  return problems;
+}
+
+//==============================================================================
+std::unordered_set<PlannerPtr> MetaPlanner::getPlannersCanSolve(
+    const Problem* problem) const
+{
+  std::unordered_set<PlannerPtr> planners;
+
+  for (const auto& planner : mPlanners)
+  {
+    auto metaPlanner = std::dynamic_pointer_cast<MetaPlanner>(planner);
+    if (metaPlanner)
+    {
+      auto subPlanners = metaPlanner->getPlannersCanSolve(problem);
+      planners.insert(subPlanners.begin(), subPlanners.end());
+    }
+    else
+    {
+      if (planner->canSolve(problem))
+        planners.insert(planner);
+    }
+  }
+
+  return planners;
+}
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/PlanToConfiguration.cpp
+++ b/src/planner/PlanToConfiguration.cpp
@@ -1,0 +1,78 @@
+#include "aikido/planner/PlanToConfiguration.hpp"
+
+#include "aikido/constraint/Testable.hpp"
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+PlanToConfiguration::PlanToConfiguration(
+    statespace::StateSpacePtr stateSpace,
+    const statespace::StateSpace::State* startState,
+    const statespace::StateSpace::State* goalState,
+    statespace::InterpolatorPtr interpolator,
+    constraint::TestablePtr constraint)
+  : Problem(std::move(stateSpace))
+  , mStartState(startState)
+  , mGoalState(goalState)
+  , mInterpolator(std::move(interpolator))
+  , mConstraint(std::move(constraint))
+{
+  if (mStateSpace != mConstraint->getStateSpace())
+  {
+    throw std::invalid_argument(
+        "StateSpace of constraint not equal to StateSpace of planning space");
+  }
+}
+
+//==============================================================================
+const std::string& PlanToConfiguration::getName() const
+{
+  return getStaticName();
+}
+
+//==============================================================================
+const std::string& PlanToConfiguration::getStaticName()
+{
+  static std::string name("PlanToConfiguration");
+  return name;
+}
+
+//==============================================================================
+const statespace::StateSpace::State* PlanToConfiguration::getStartState() const
+{
+  return mStartState;
+}
+
+//==============================================================================
+const statespace::StateSpace::State* PlanToConfiguration::getGoalState() const
+{
+  return mGoalState;
+}
+
+//==============================================================================
+statespace::InterpolatorPtr PlanToConfiguration::getInterpolator()
+{
+  return mInterpolator;
+}
+
+//==============================================================================
+statespace::InterpolatorPtr PlanToConfiguration::getInterpolator() const
+{
+  return mInterpolator;
+}
+
+//==============================================================================
+constraint::TestablePtr PlanToConfiguration::getConstraint()
+{
+  return mConstraint;
+}
+
+//==============================================================================
+constraint::TestablePtr PlanToConfiguration::getConstraint() const
+{
+  return mConstraint;
+}
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/PlanToConfigurations.cpp
+++ b/src/planner/PlanToConfigurations.cpp
@@ -1,0 +1,79 @@
+#include "aikido/planner/PlanToConfigurations.hpp"
+
+#include "aikido/constraint/Testable.hpp"
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+PlanToConfigurations::PlanToConfigurations(
+    statespace::StateSpacePtr stateSpace,
+    const statespace::StateSpace::State* startState,
+    const std::vector<statespace::StateSpace::State*> goalStates,
+    statespace::InterpolatorPtr interpolator,
+    constraint::TestablePtr constraint)
+  : Problem(std::move(stateSpace))
+  , mStartState(startState)
+  , mGoalStates(goalStates)
+  , mInterpolator(std::move(interpolator))
+  , mConstraint(std::move(constraint))
+{
+  if (mStateSpace != mConstraint->getStateSpace())
+  {
+    throw std::invalid_argument(
+        "StateSpace of constraint not equal to StateSpace of planning space");
+  }
+}
+
+//==============================================================================
+const std::string& PlanToConfigurations::getName() const
+{
+  return getStaticName();
+}
+
+//==============================================================================
+const std::string& PlanToConfigurations::getStaticName()
+{
+  static std::string name("PlanToConfigurations");
+  return name;
+}
+
+//==============================================================================
+const statespace::StateSpace::State* PlanToConfigurations::getStartState() const
+{
+  return mStartState;
+}
+
+//==============================================================================
+const std::vector<statespace::StateSpace::State*>
+PlanToConfigurations::getGoalStates() const
+{
+  return mGoalStates;
+}
+
+//==============================================================================
+statespace::InterpolatorPtr PlanToConfigurations::getInterpolator()
+{
+  return mInterpolator;
+}
+
+//==============================================================================
+statespace::ConstInterpolatorPtr PlanToConfigurations::getInterpolator() const
+{
+  return mInterpolator;
+}
+
+//==============================================================================
+constraint::TestablePtr PlanToConfigurations::getConstraint()
+{
+  return mConstraint;
+}
+
+//==============================================================================
+constraint::ConstTestablePtr PlanToConfigurations::getConstraint() const
+{
+  return mConstraint;
+}
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/PlanToEndEffectorOffset.cpp
+++ b/src/planner/PlanToEndEffectorOffset.cpp
@@ -1,0 +1,96 @@
+#include "aikido/planner/PlanToEndEffectorOffset.hpp"
+
+#include "aikido/constraint/Testable.hpp"
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+PlanToEndEffectorOffset::PlanToEndEffectorOffset(
+    statespace::StateSpacePtr stateSpace,
+    dart::dynamics::BodyNodePtr bodyNode,
+    const statespace::StateSpace::State* startState,
+    const Eigen::Vector3d& direction,
+    const double& distance,
+    statespace::InterpolatorPtr interpolator,
+    constraint::TestablePtr constraint)
+  : Problem(std::move(stateSpace))
+  , mBodyNode(std::move(bodyNode))
+  , mStartState(startState)
+  , mDirection(direction)
+  , mDistance(distance)
+  , mInterpolator(std::move(interpolator))
+  , mConstraint(std::move(constraint))
+{
+  if (mStateSpace != mConstraint->getStateSpace())
+  {
+    throw std::invalid_argument(
+        "StateSpace of constraint not equal to StateSpace of planning space");
+  }
+}
+
+//==============================================================================
+const std::string& PlanToEndEffectorOffset::getName() const
+{
+  return getStaticName();
+}
+
+//==============================================================================
+const std::string& PlanToEndEffectorOffset::getStaticName()
+{
+  static std::string name("PlanToEndEffectorOffset");
+  return name;
+}
+
+//==============================================================================
+dart::dynamics::BodyNodePtr PlanToEndEffectorOffset::getBodyNode()
+{
+  return mBodyNode;
+}
+
+//==============================================================================
+const statespace::StateSpace::State* PlanToEndEffectorOffset::getStartState()
+    const
+{
+  return mStartState;
+}
+
+//==============================================================================
+const Eigen::Vector3d& PlanToEndEffectorOffset::getDirection() const
+{
+  return mDirection;
+}
+
+//==============================================================================
+const double& PlanToEndEffectorOffset::getDistance() const
+{
+  return mDistance;
+}
+
+//==============================================================================
+statespace::InterpolatorPtr PlanToEndEffectorOffset::getInterpolator()
+{
+  return mInterpolator;
+}
+
+//==============================================================================
+statespace::ConstInterpolatorPtr PlanToEndEffectorOffset::getInterpolator()
+    const
+{
+  return mInterpolator;
+}
+
+//==============================================================================
+constraint::TestablePtr PlanToEndEffectorOffset::getConstraint()
+{
+  return mConstraint;
+}
+
+//==============================================================================
+constraint::ConstTestablePtr PlanToEndEffectorOffset::getConstraint() const
+{
+  return mConstraint;
+}
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/PlanToEndEffectorPose.cpp
+++ b/src/planner/PlanToEndEffectorPose.cpp
@@ -1,0 +1,87 @@
+#include "aikido/planner/PlanToEndEffectorPose.hpp"
+
+#include "aikido/constraint/Testable.hpp"
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+PlanToEndEffectorPose::PlanToEndEffectorPose(
+    statespace::StateSpacePtr stateSpace,
+    dart::dynamics::BodyNodePtr bodyNode,
+    const statespace::StateSpace::State* startState,
+    const Eigen::Isometry3d& goalPose,
+    statespace::InterpolatorPtr interpolator,
+    constraint::TestablePtr constraint)
+  : Problem(std::move(stateSpace))
+  , mBodyNode(std::move(bodyNode))
+  , mStartState(startState)
+  , mGoalPose(goalPose)
+  , mInterpolator(std::move(interpolator))
+  , mConstraint(std::move(constraint))
+{
+  if (mStateSpace != mConstraint->getStateSpace())
+  {
+    throw std::invalid_argument(
+        "StateSpace of constraint not equal to StateSpace of planning space");
+  }
+}
+
+//==============================================================================
+const std::string& PlanToEndEffectorPose::getName() const
+{
+  return getStaticName();
+}
+
+//==============================================================================
+const std::string& PlanToEndEffectorPose::getStaticName()
+{
+  static std::string name("PlanToEndEffectorPose");
+  return name;
+}
+
+//==============================================================================
+dart::dynamics::BodyNodePtr PlanToEndEffectorPose::getBodyNode()
+{
+  return mBodyNode;
+}
+
+//==============================================================================
+const statespace::StateSpace::State* PlanToEndEffectorPose::getStartState()
+    const
+{
+  return mStartState;
+}
+
+//==============================================================================
+const Eigen::Isometry3d& PlanToEndEffectorPose::getGoalPose() const
+{
+  return mGoalPose;
+}
+
+//==============================================================================
+statespace::InterpolatorPtr PlanToEndEffectorPose::getInterpolator()
+{
+  return mInterpolator;
+}
+
+//==============================================================================
+statespace::ConstInterpolatorPtr PlanToEndEffectorPose::getInterpolator() const
+{
+  return mInterpolator;
+}
+
+//==============================================================================
+constraint::TestablePtr PlanToEndEffectorPose::getConstraint()
+{
+  return mConstraint;
+}
+
+//==============================================================================
+constraint::ConstTestablePtr PlanToEndEffectorPose::getConstraint() const
+{
+  return mConstraint;
+}
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/PlanToTSR.cpp
+++ b/src/planner/PlanToTSR.cpp
@@ -1,0 +1,86 @@
+#include "aikido/planner/PlanToTSR.hpp"
+
+#include "aikido/constraint/Testable.hpp"
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+PlanToTSR::PlanToTSR(
+    statespace::StateSpacePtr stateSpace,
+    dart::dynamics::BodyNodePtr bodyNode,
+    const statespace::StateSpace::State* startState,
+    const constraint::TSRPtr goalTSR,
+    statespace::InterpolatorPtr interpolator,
+    constraint::TestablePtr constraint)
+  : Problem(std::move(stateSpace))
+  , mBodyNode(std::move(bodyNode))
+  , mStartState(startState)
+  , mGoalTSR(goalTSR)
+  , mInterpolator(std::move(interpolator))
+  , mConstraint(std::move(constraint))
+{
+  if (mStateSpace != mConstraint->getStateSpace())
+  {
+    throw std::invalid_argument(
+        "StateSpace of constraint not equal to StateSpace of planning space");
+  }
+}
+
+//==============================================================================
+const std::string& PlanToTSR::getName() const
+{
+  return getStaticName();
+}
+
+//==============================================================================
+const std::string& PlanToTSR::getStaticName()
+{
+  static std::string name("PlanToTSR");
+  return name;
+}
+
+//==============================================================================
+dart::dynamics::BodyNodePtr PlanToTSR::getBodyNode()
+{
+  return mBodyNode;
+}
+
+//==============================================================================
+const statespace::StateSpace::State* PlanToTSR::getStartState() const
+{
+  return mStartState;
+}
+
+//==============================================================================
+const constraint::TSRPtr PlanToTSR::getGoalTSR() const
+{
+  return mGoalTSR;
+}
+
+//==============================================================================
+statespace::InterpolatorPtr PlanToTSR::getInterpolator()
+{
+  return mInterpolator;
+}
+
+//==============================================================================
+statespace::ConstInterpolatorPtr PlanToTSR::getInterpolator() const
+{
+  return mInterpolator;
+}
+
+//==============================================================================
+constraint::TestablePtr PlanToTSR::getConstraint()
+{
+  return mConstraint;
+}
+
+//==============================================================================
+constraint::ConstTestablePtr PlanToTSR::getConstraint() const
+{
+  return mConstraint;
+}
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/Planner.cpp
+++ b/src/planner/Planner.cpp
@@ -1,0 +1,9 @@
+#include "aikido/planner/Planner.hpp"
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/Problem.cpp
+++ b/src/planner/Problem.cpp
@@ -1,0 +1,32 @@
+#include "aikido/planner/Problem.hpp"
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+Problem::Problem(statespace::StateSpacePtr stateSpace)
+  : mStateSpace(std::move(stateSpace))
+{
+  // Do nothing
+}
+
+//==============================================================================
+statespace::StateSpacePtr Problem::getStateSpace() const
+{
+  return mStateSpace;
+}
+
+//==============================================================================
+void Problem::Result::setMessage(const std::string& message)
+{
+  mMessage = message;
+}
+
+//==============================================================================
+const std::string& Problem::Result::getMessage() const
+{
+  return mMessage;
+}
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/RankedMetaPlanner.cpp
+++ b/src/planner/RankedMetaPlanner.cpp
@@ -1,0 +1,16 @@
+#include "aikido/planner/RankedMetaPlanner.hpp"
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+trajectory::TrajectoryPtr RankedMetaPlanner::solve(
+    const Problem* /*problem*/, Problem::Result* /*result*/)
+{
+  // Not implemented
+
+  return nullptr;
+}
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/SequenceMetaPlanner.cpp
+++ b/src/planner/SequenceMetaPlanner.cpp
@@ -1,0 +1,21 @@
+#include "aikido/planner/SequenceMetaPlanner.hpp"
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+trajectory::TrajectoryPtr SequenceMetaPlanner::solve(
+    const Problem* problem, Problem::Result* result)
+{
+  for (const auto& planner : mPlanners)
+  {
+    auto trajectory = planner->solve(problem, result);
+    if (trajectory)
+      return trajectory;
+  }
+
+  return nullptr;
+}
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/SnapPlanner.cpp
+++ b/src/planner/SnapPlanner.cpp
@@ -1,45 +1,78 @@
-#include <aikido/common/VanDerCorput.hpp>
-#include <aikido/constraint/Testable.hpp>
-#include <aikido/planner/PlanningResult.hpp>
-#include <aikido/planner/SnapPlanner.hpp>
-#include <aikido/statespace/Interpolator.hpp>
-#include <aikido/statespace/StateSpace.hpp>
-#include <aikido/trajectory/Interpolated.hpp>
+#include "aikido/planner/SnapPlanner.hpp"
+
+#include "aikido/common/VanDerCorput.hpp"
+#include "aikido/constraint/Testable.hpp"
+#include "aikido/statespace/StateSpace.hpp"
 
 namespace aikido {
 namespace planner {
 
-trajectory::InterpolatedPtr planSnap(
-    const std::shared_ptr<aikido::statespace::StateSpace>& stateSpace,
-    const aikido::statespace::StateSpace::State* startState,
-    const aikido::statespace::StateSpace::State* goalState,
-    const std::shared_ptr<aikido::statespace::Interpolator>& interpolator,
-    const std::shared_ptr<aikido::constraint::Testable>& constraint,
-    aikido::planner::PlanningResult& planningResult)
+//==============================================================================
+SnapPlanner::PlanningFunctionMap SnapPlanner::mPlanningFunctionMap;
+bool SnapPlanner::mIsRegisteredPlanningFunctions = false;
+
+//==============================================================================
+SnapPlanner::SnapPlanner()
 {
-  if (stateSpace != constraint->getStateSpace())
+  if (!mIsRegisteredPlanningFunctions)
+  {
+    registerPlanningFunction<PlanToConfiguration>(
+        &SnapPlanner::planToConfiguration);
+
+    mIsRegisteredPlanningFunctions = true;
+  }
+}
+
+//==============================================================================
+trajectory::InterpolatedPtr SnapPlanner::planToConfiguration(
+    const Problem* problem, Problem::Result* result)
+{
+  if (!problem)
+    return nullptr;
+
+  const auto* castedProblem = dynamic_cast<const PlanToConfiguration*>(problem);
+  if (!castedProblem)
+    throw std::invalid_argument("problem is not PlanToConfiguration type");
+
+  auto* castedResult = dynamic_cast<PlanToConfiguration::Result*>(result);
+  if (result && !castedResult)
   {
     throw std::invalid_argument(
-        "StateSpace of constraint not equal to StateSpace of planning space");
+        "result is not PlanToConfiguration::Result type");
   }
-  aikido::common::VanDerCorput vdc{1, true, true, 0.02}; // TODO junk resolution
+
+  auto stateSpace = castedProblem->getStateSpace();
+  auto interpolator = castedProblem->getInterpolator();
   auto returnTraj
       = std::make_shared<trajectory::Interpolated>(stateSpace, interpolator);
   auto testState = stateSpace->createState();
+  auto startState = castedProblem->getStartState();
+  auto goalState = castedProblem->getGoalState();
+  auto constraint = castedProblem->getConstraint();
 
+  aikido::common::VanDerCorput vdc{1, true, true, 0.02}; // TODO junk resolution
   for (const auto alpha : vdc)
   {
     interpolator->interpolate(startState, goalState, alpha, testState);
     if (!constraint->isSatisfied(testState))
     {
-      planningResult.message = "Collision detected";
+      if (castedResult)
+        result->setMessage("Collision detected");
+
       return nullptr;
     }
   }
 
   returnTraj->addWaypoint(0, startState);
   returnTraj->addWaypoint(1, goalState);
+
   return returnTraj;
+}
+
+//==============================================================================
+SnapPlanner::PlanningFunctionMap& SnapPlanner::getPlanningFunctionMap()
+{
+  return mPlanningFunctionMap;
 }
 
 } // namespace planner


### PR DESCRIPTION
This is a WIP PR to initiate discussion on introducing planner API.

**Summary**
* Add planner classes
  * `Planner`: Base class
  * `ConcretePlanner : Planner`: Base class for non-meta planners (e.g., `SnapPlanner`). Open to better name.
  * `MetaPlanner`
* Add problem classes (_method_ in `prpy`): This is to encapsulate different sets of parameters per planning problems.

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
