### PR TITLE
Clean up planner_ompl CMakeLists.txt.

### DIFF
--- a/src/planner/ompl/CMakeLists.txt
+++ b/src/planner/ompl/CMakeLists.txt
@@ -1,13 +1,8 @@
-#============================================================================== # Dependencies
+#==============================================================================
+# Dependencies
 #
 find_package(OMPL QUIET)
-if(OMPL_FOUND)
-  message(STATUS "Looking for OMPL - version ${OMPL_VERSION} found")
-else()
-  message(STATUS
-    "Looking for OMPL - NOT found, skipping planner_ompl component")
-  return()
-endif()
+aikido_check_package(OMPL "planner_ompl" "OMPL")
 
 #==============================================================================
 # Libraries


### PR DESCRIPTION
It seems that this `CMakeLists.txt` hasn't been updated since we introduced the `aikido_check_package` macro, so there was some redundancy here.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
