### PR TITLE
Configure Travis CI to automatically deploy docs from master

### DIFF
--- a/.ci/before_install_linux.sh
+++ b/.ci/before_install_linux.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Install documentation dependencies
+sudo -n apt-get -qqy install --no-install-recommends doxygen
+
 # Install test fixture dependencies.
 mkdir -p "${HOME}/workspace/src"
 cd "${HOME}/workspace"

--- a/.ci/before_install_linux.sh
+++ b/.ci/before_install_linux.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# Install documentation dependencies
-sudo -n apt-get -qqy install --no-install-recommends doxygen
-
 # Install test fixture dependencies.
 mkdir -p "${HOME}/workspace/src"
 cd "${HOME}/workspace"

--- a/.ci/build_docs.sh
+++ b/.ci/build_docs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ev
+set -e
 
 # Build documentation
 ./scripts/internal-run.sh catkin build --no-status --no-deps -p 1 -i --make-args docs -- aikido > /dev/null

--- a/.ci/build_docs.sh
+++ b/.ci/build_docs.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -ev
+
+# Build documentation
+./scripts/internal-run.sh catkin build --no-status --no-deps -p 1 -i --make-args docs -- aikido > /dev/null
+
+# Organize into "master" subdirectory
+mkdir -p "${HOME}/gh-pages"
+mv "${HOME}/workspace/build/aikido/doxygen" "${HOME}/gh-pages/master"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,20 @@ script:
 
 after_script:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ./scripts/view-all-results.sh test_results; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then . "${TRAVIS_BUILD_DIR}/.ci/build_docs.sh"; fi
 
 after_failure:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then cat ./build/aikido/Testing/Temporary/LastTest.log; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then cat ./build/aikido/Testing/Temporary/LastTestsFailed.log; fi
   - if [ "${TRAVIS_OS_NAME}" = "osx"   ]; then cat Testing/Temporary/LastTest.log; fi
   - if [ "${TRAVIS_OS_NAME}" = "osx"   ]; then cat Testing/Temporary/LastTestsFailed.log; fi
+
+deploy:
+  github-token: $GITHUB_TOKEN
+  provider: pages
+  skip-cleanup: true
+  local-dir: "${HOME}/gh-pages"
+  keep-history: false
+  verbose: true
+  on:
+    branch: master


### PR DESCRIPTION
This is related to #68, although we should figure out how to deploy docs from tags before closing that issue.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
