### PR TITLE
[WIP] Add style guide for template class

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -102,7 +102,7 @@ class TemplatedExampleClass
 {
 public:
   /// Brief description.
-  void exampleMethod();
+  T exampleMethod();
 };
 
 } // namespace example
@@ -128,9 +128,9 @@ namespace example {
 
 //==============================================================================
 template <typename T>
-TemplatedExampleClass<T>::exampleMethod()
+T TemplatedExampleClass<T>::exampleMethod()
 {
-  // Do something.
+  return T();
 }
 
 } // namespace example

--- a/STYLE.md
+++ b/STYLE.md
@@ -95,6 +95,16 @@ private:
   std::unique_ptr<util::RNG> mExampleMember; // Member variables are prefixed with "m"
 };
 
+/// This is a template class description.
+/// \tparam T This is an example template parameter description.
+template <typename T>
+class TemplatedExampleClass
+{
+public:
+  /// Brief description.
+  void exampleMethod();
+};
+
 } // namespace example
 } // namespace aikido
 
@@ -105,6 +115,28 @@ private:
 #include "aikido/component_name/detail/ExampleClass-impl.hpp"
 
 #endif // AIKIDO_EXAMPLE_EXAMPLECLASS_HPP_
+```
+
+```c++
+#ifndef AIKIDO_EXAMPLE_DETAIL_EXAMPLECLASS_IMPL_HPP_
+#define AIKIDO_EXAMPLE_DETAIL_EXAMPLECLASS_IMPL_HPP_
+
+#include "aikido/example/ExampleClass.hpp"
+
+namespace aikido {
+namespace example {
+
+//==============================================================================
+template <typename T>
+TemplatedExampleClass<T>::exampleMethod()
+{
+  // Do something.
+}
+
+} // namespace example
+} // namespace aikido
+
+#endif // AIKIDO_EXAMPLE_DETAIL_EXAMPLECLASS_IMPL_HPP_
 ```
 
 ### Source Style


### PR DESCRIPTION
The major motivation of this PR is to make using `\tparam` for template argument as an explicit convention of AIKIDO, but it would be also worth to have guide for template classes.