### PR TITLE
Stop using DART's smart pointer macro.

### DIFF
--- a/include/aikido/common/pointers.hpp
+++ b/include/aikido/common/pointers.hpp
@@ -1,7 +1,7 @@
 #ifndef AIKIDO_COMMON_POINTERS_HPP_
 #define AIKIDO_COMMON_POINTERS_HPP_
 
-#include <dart/common/SmartPointer.hpp>
+#include <memory>
 
 // clang-format off
 
@@ -19,7 +19,11 @@
 //   } // namespace aikido
 //  
 #define AIKIDO_DECLARE_POINTERS(X)                                             \
-  DART_COMMON_MAKE_SHARED_WEAK(X)                                              \
+  class X ;                                                                    \
+  using X ## Ptr                = std::shared_ptr< X >;                        \
+  using Const ## X ## Ptr       = std::shared_ptr< const X >;                  \
+  using Weak ## X ## Ptr        = std::weak_ptr< X >;                          \
+  using WeakConst ## X ## Ptr   = std::weak_ptr< const X >;                    \
   using Unique ## X ## Ptr      = std::unique_ptr< X >;                        \
   using UniqueConst ## X ## Ptr = std::unique_ptr< const X >;
 


### PR DESCRIPTION
This should help with #333 since we won't need DART's source code to generate the full macro expansion. In addition, we'll be generating more consistent documentation since DART defines shared/weak pointers with `typedef`, and we were defining unique pointers with `using`.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
