### PR TITLE
Add flags to Saver classes to specify what to save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
   * Refactored JointStateSpace and MetaSkeletonStateSpace: [#278](https://github.com/personalrobotics/aikido/pull/278)
   * Added methods for checking compatibility between DART objects and state spaces: [#315](https://github.com/personalrobotics/aikido/pull/315)
+  * Added flags to MetaSkeletonStateSaver to specify what to save: [#339](https://github.com/personalrobotics/aikido/pull/339)
 
 * Control
 
@@ -21,6 +22,7 @@
 
   * Added parabolic timing for linear spline [#302](https://github.com/personalrobotics/aikido/pull/302), [#324](https://github.com/personalrobotics/aikido/pull/324)
   * Fixed step sequence iteration in VPF: [#303](https://github.com/personalrobotics/aikido/pull/303)
+  * Added flags to WorldStateSaver to specify what to save: [#339](https://github.com/personalrobotics/aikido/pull/339)
 
 ### 0.2.0 (2018-01-09)
 

--- a/include/aikido/planner/WorldStateSaver.hpp
+++ b/include/aikido/planner/WorldStateSaver.hpp
@@ -21,7 +21,7 @@ public:
   ///
   /// \param[in] world World to save state from and restore to.
   /// \param[in] options Options to specify what should be saved
-  explicit WorldStateSaver(const World* world, int options = CONFIGURATIONS);
+  explicit WorldStateSaver(World* world, int options = CONFIGURATIONS);
 
   virtual ~WorldStateSaver();
 

--- a/include/aikido/planner/WorldStateSaver.hpp
+++ b/include/aikido/planner/WorldStateSaver.hpp
@@ -6,16 +6,16 @@
 namespace aikido {
 namespace planner {
 
-/// Options to specify what WorldStateSaver should save.
-enum WorldStateSaverOptions
-{
-  CONFIGURATIONS = 1 << 0,
-};
-
 /// RAII class to save and restore a World's state.
 class WorldStateSaver
 {
 public:
+  /// Options to specify what WorldStateSaver should save.
+  enum Options
+  {
+    CONFIGURATIONS = 1 << 0,
+  };
+
   /// Construct a WorldStateSaver and save the current state of the \c World.
   /// This state will be restored when WorldStateSaver is destructed.
   ///

--- a/include/aikido/planner/WorldStateSaver.hpp
+++ b/include/aikido/planner/WorldStateSaver.hpp
@@ -1,25 +1,38 @@
 #ifndef AIKIDO_PLANNER_WORLDSTATESAVER_HPP_
 #define AIKIDO_PLANNER_WORLDSTATESAVER_HPP_
-#include "World.hpp"
+
+#include "aikido/planner/World.hpp"
 
 namespace aikido {
 namespace planner {
+
+/// Options to specify what WorldStateSaver should save.
+enum WorldStateSaverOptions
+{
+  CONFIGURATIONS = 1 << 0,
+};
 
 /// RAII class to save and restore a World's state.
 class WorldStateSaver
 {
 public:
-  /// Construct a WorldStateSaver and save the current state of the
-  /// \c World. This state will be restored when
-  /// WorldStateSaver is destructed.
+  /// Construct a WorldStateSaver and save the current state of the \c World.
+  /// This state will be restored when WorldStateSaver is destructed.
   ///
-  /// \param _world World to save state from and restore to.
-  explicit WorldStateSaver(World* const _world);
+  /// \param world World to save state from and restore to.
+  /// \param options Options to specify what should be saved
+  explicit WorldStateSaver(World* const world, int options = CONFIGURATIONS);
 
   virtual ~WorldStateSaver();
 
 private:
+  /// World to save the state of
   World* mWorld;
+
+  /// Options to specify what should be saved
+  int mOptions;
+
+  /// Saved state
   World::State mWorldState;
 };
 

--- a/include/aikido/planner/WorldStateSaver.hpp
+++ b/include/aikido/planner/WorldStateSaver.hpp
@@ -19,9 +19,9 @@ public:
   /// Construct a WorldStateSaver and save the current state of the \c World.
   /// This state will be restored when WorldStateSaver is destructed.
   ///
-  /// \param world World to save state from and restore to.
-  /// \param options Options to specify what should be saved
-  explicit WorldStateSaver(World* const world, int options = CONFIGURATIONS);
+  /// \param[in] world World to save state from and restore to.
+  /// \param[in] options Options to specify what should be saved
+  explicit WorldStateSaver(const World* world, int options = CONFIGURATIONS);
 
   virtual ~WorldStateSaver();
 

--- a/include/aikido/statespace/dart/MetaSkeletonStateSaver.hpp
+++ b/include/aikido/statespace/dart/MetaSkeletonStateSaver.hpp
@@ -23,8 +23,8 @@ public:
   /// MetaSkeleton. This state will be restored when MetaSkeletonStateSaver is
   /// destructed.
   ///
-  /// \param metaskeleton MetaSkeleton to save/restore
-  /// \param options Options to specify what should be saved
+  /// \param[in] metaskeleton MetaSkeleton to save/restore
+  /// \param[in] options Options to specify what should be saved
   explicit MetaSkeletonStateSaver(
       ::dart::dynamics::MetaSkeletonPtr metaskeleton,
       int options = POSITIONS | POSITION_LIMITS);

--- a/include/aikido/statespace/dart/MetaSkeletonStateSaver.hpp
+++ b/include/aikido/statespace/dart/MetaSkeletonStateSaver.hpp
@@ -7,6 +7,13 @@ namespace aikido {
 namespace statespace {
 namespace dart {
 
+/// Options to specify what MetaSkeletonStateSaver should save.
+enum MetaSkeletonStateSaverOptions
+{
+  POSITIONS = 1 << 0,
+  POSITION_LIMITS = 1 << 1,
+};
+
 /// RAII class to save and restore a MetaSkeleton's state.
 /// FIXME: currently only saves position and joint limits.
 class MetaSkeletonStateSaver
@@ -16,9 +23,11 @@ public:
   /// MetaSkeleton. This state will be restored when MetaSkeletonStateSaver is
   /// destructed.
   ///
-  /// \param _metaskeleton MetaSkeleton to save/restore
+  /// \param metaskeleton MetaSkeleton to save/restore
+  /// \param options Options to specify what should be saved
   explicit MetaSkeletonStateSaver(
-      ::dart::dynamics::MetaSkeletonPtr _metaskeleton);
+      ::dart::dynamics::MetaSkeletonPtr metaskeleton,
+      int options = POSITIONS | POSITION_LIMITS);
 
   virtual ~MetaSkeletonStateSaver();
 
@@ -30,9 +39,19 @@ public:
   MetaSkeletonStateSaver& operator=(MetaSkeletonStateSaver&&) = default;
 
 private:
+  /// MetaSkeleton to save the state of
   ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
+
+  /// Options to specify what should be saved
+  int mOptions;
+
+  /// Saved positions
   Eigen::VectorXd mPositions;
+
+  /// Saved position lower limits
   Eigen::VectorXd mPositionLowerLimits;
+
+  /// Saved position upper limits
   Eigen::VectorXd mPositionUpperLimits;
 };
 

--- a/include/aikido/statespace/dart/MetaSkeletonStateSaver.hpp
+++ b/include/aikido/statespace/dart/MetaSkeletonStateSaver.hpp
@@ -7,18 +7,18 @@ namespace aikido {
 namespace statespace {
 namespace dart {
 
-/// Options to specify what MetaSkeletonStateSaver should save.
-enum MetaSkeletonStateSaverOptions
-{
-  POSITIONS = 1 << 0,
-  POSITION_LIMITS = 1 << 1,
-};
-
 /// RAII class to save and restore a MetaSkeleton's state.
 /// FIXME: currently only saves position and joint limits.
 class MetaSkeletonStateSaver
 {
 public:
+  /// Options to specify what MetaSkeletonStateSaver should save.
+  enum Options
+  {
+    POSITIONS = 1 << 0,
+    POSITION_LIMITS = 1 << 1,
+  };
+
   /// Construct a MetaSkeletonStateSaver and save the current state of the \c
   /// MetaSkeleton. This state will be restored when MetaSkeletonStateSaver is
   /// destructed.

--- a/src/planner/WorldStateSaver.cpp
+++ b/src/planner/WorldStateSaver.cpp
@@ -1,19 +1,22 @@
-#include <aikido/planner/WorldStateSaver.hpp>
+#include "aikido/planner/WorldStateSaver.hpp"
 
 namespace aikido {
 namespace planner {
 
-WorldStateSaver::WorldStateSaver(World* const world) : mWorld{world}
+WorldStateSaver::WorldStateSaver(World* const world, int options)
+  : mWorld{world}, mOptions{options}
 {
   if (!world)
     throw std::invalid_argument("World must not be nullptr.");
 
-  mWorldState = mWorld->getState();
+  if (mOptions & WorldStateSaverOptions::CONFIGURATIONS)
+    mWorldState = mWorld->getState();
 }
 
 WorldStateSaver::~WorldStateSaver()
 {
-  mWorld->setState(mWorldState);
+  if (mOptions & WorldStateSaverOptions::CONFIGURATIONS)
+    mWorld->setState(mWorldState);
 }
 
 } // namespace planner

--- a/src/planner/WorldStateSaver.cpp
+++ b/src/planner/WorldStateSaver.cpp
@@ -3,10 +3,10 @@
 namespace aikido {
 namespace planner {
 
-WorldStateSaver::WorldStateSaver(World* const world, int options)
-  : mWorld{world}, mOptions{options}
+WorldStateSaver::WorldStateSaver(World* world, int options)
+  : mWorld{std::move(world)}, mOptions{options}
 {
-  if (!world)
+  if (!mWorld)
     throw std::invalid_argument("World must not be nullptr.");
 
   if (mOptions & Options::CONFIGURATIONS)

--- a/src/planner/WorldStateSaver.cpp
+++ b/src/planner/WorldStateSaver.cpp
@@ -9,13 +9,13 @@ WorldStateSaver::WorldStateSaver(World* const world, int options)
   if (!world)
     throw std::invalid_argument("World must not be nullptr.");
 
-  if (mOptions & WorldStateSaverOptions::CONFIGURATIONS)
+  if (mOptions & Options::CONFIGURATIONS)
     mWorldState = mWorld->getState();
 }
 
 WorldStateSaver::~WorldStateSaver()
 {
-  if (mOptions & WorldStateSaverOptions::CONFIGURATIONS)
+  if (mOptions & Options::CONFIGURATIONS)
     mWorld->setState(mWorldState);
 }
 

--- a/src/planner/vectorfield/VectorFieldPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldPlanner.cpp
@@ -161,7 +161,8 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
   // TODO: Check compatibility between MetaSkeleton and MetaSkeletonStateSpace
 
   // Save the current state of the space
-  auto saver = MetaSkeletonStateSaver(metaskeleton);
+  auto saver = MetaSkeletonStateSaver(
+      metaskeleton, MetaSkeletonStateSaver::Options::POSITIONS);
   DART_UNUSED(saver);
 
   auto vectorfield = std::make_shared<MoveEndEffectorOffsetVectorField>(
@@ -212,7 +213,8 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorPose(
   // TODO: Check compatibility between MetaSkeleton and MetaSkeletonStateSpace
 
   // Save the current state of the space
-  auto saver = MetaSkeletonStateSaver(metaskeleton);
+  auto saver = MetaSkeletonStateSaver(
+      metaskeleton, MetaSkeletonStateSaver::Options::POSITIONS);
   DART_UNUSED(saver);
 
   auto vectorfield = std::make_shared<MoveEndEffectorPoseVectorField>(

--- a/src/rviz/TrajectoryMarker.cpp
+++ b/src/rviz/TrajectoryMarker.cpp
@@ -198,6 +198,7 @@ void TrajectoryMarker::update()
 void TrajectoryMarker::updatePoints()
 {
   using visualization_msgs::Marker;
+  using aikido::statespace::dart::MetaSkeletonStateSaver;
 
   if (!mNeedPointsUpdate)
     return;
@@ -218,7 +219,8 @@ void TrajectoryMarker::updatePoints()
       = std::dynamic_pointer_cast<statespace::dart::MetaSkeletonStateSpace>(
           statespace);
 
-  auto saver = statespace::dart::MetaSkeletonStateSaver(mSkeleton);
+  auto saver = MetaSkeletonStateSaver(
+      mSkeleton, MetaSkeletonStateSaver::Options::POSITIONS);
   DART_UNUSED(saver);
 
   auto state = metaSkeletonSs->createState();

--- a/src/statespace/dart/MetaSkeletonStateSaver.cpp
+++ b/src/statespace/dart/MetaSkeletonStateSaver.cpp
@@ -1,5 +1,5 @@
+#include "aikido/statespace/dart/MetaSkeletonStateSaver.hpp"
 #include <iostream>
-#include <aikido/statespace/dart/MetaSkeletonStateSaver.hpp>
 
 namespace aikido {
 namespace statespace {
@@ -7,40 +7,52 @@ namespace dart {
 
 //==============================================================================
 MetaSkeletonStateSaver::MetaSkeletonStateSaver(
-    ::dart::dynamics::MetaSkeletonPtr _metaskeleton)
-  : mMetaSkeleton(std::move(_metaskeleton))
-  , mPositions(mMetaSkeleton->getPositions())
-  , mPositionLowerLimits(mMetaSkeleton->getPositionLowerLimits())
-  , mPositionUpperLimits(mMetaSkeleton->getPositionUpperLimits())
+    ::dart::dynamics::MetaSkeletonPtr metaskeleton, int options)
+  : mMetaSkeleton(std::move(metaskeleton)), mOptions(std::move(options))
 {
-  // Do nothing
+  if (mOptions & MetaSkeletonStateSaverOptions::POSITIONS)
+    mPositions = mMetaSkeleton->getPositions();
+
+  if (mOptions & MetaSkeletonStateSaverOptions::POSITION_LIMITS)
+  {
+    mPositionLowerLimits = mMetaSkeleton->getPositionLowerLimits();
+    mPositionUpperLimits = mMetaSkeleton->getPositionUpperLimits();
+  }
 }
 
 //==============================================================================
 MetaSkeletonStateSaver::~MetaSkeletonStateSaver()
 {
-  if (static_cast<std::size_t>(mPositions.size())
-      != mMetaSkeleton->getNumDofs())
+  if (mOptions & MetaSkeletonStateSaverOptions::POSITIONS)
   {
-    std::cerr << "[MetaSkeletonStateSaver] The number of DOFs in the "
-              << "MetaSkeleton does not match the saved position.";
-  }
-  if (static_cast<std::size_t>(mPositionLowerLimits.size())
-      != mMetaSkeleton->getNumDofs())
-  {
-    std::cerr << "[MetaSkeletonStateSaver] The number of DOFs in the "
-              << "MetaSkeleton does not match the saved joint lower limits.";
-  }
-  if (static_cast<std::size_t>(mPositionUpperLimits.size())
-      != mMetaSkeleton->getNumDofs())
-  {
-    std::cerr << "[MetaSkeletonStateSaver] The number of DOFs in the "
-              << "MetaSkeleton does not match the saved joint upper limits.";
+    if (static_cast<std::size_t>(mPositions.size())
+        != mMetaSkeleton->getNumDofs())
+    {
+      std::cerr << "[MetaSkeletonStateSaver] The number of DOFs in the "
+                << "MetaSkeleton does not match the saved position.";
+    }
+
+    mMetaSkeleton->setPositions(mPositions);
   }
 
-  mMetaSkeleton->setPositions(mPositions);
-  mMetaSkeleton->setPositionLowerLimits(mPositionLowerLimits);
-  mMetaSkeleton->setPositionUpperLimits(mPositionUpperLimits);
+  if (mOptions & MetaSkeletonStateSaverOptions::POSITION_LIMITS)
+  {
+    if (static_cast<std::size_t>(mPositionLowerLimits.size())
+        != mMetaSkeleton->getNumDofs())
+    {
+      std::cerr << "[MetaSkeletonStateSaver] The number of DOFs in the "
+                << "MetaSkeleton does not match the saved joint lower limits.";
+    }
+    if (static_cast<std::size_t>(mPositionUpperLimits.size())
+        != mMetaSkeleton->getNumDofs())
+    {
+      std::cerr << "[MetaSkeletonStateSaver] The number of DOFs in the "
+                << "MetaSkeleton does not match the saved joint upper limits.";
+    }
+
+    mMetaSkeleton->setPositionLowerLimits(mPositionLowerLimits);
+    mMetaSkeleton->setPositionUpperLimits(mPositionUpperLimits);
+  }
 }
 
 } // namespace dart

--- a/src/statespace/dart/MetaSkeletonStateSaver.cpp
+++ b/src/statespace/dart/MetaSkeletonStateSaver.cpp
@@ -10,10 +10,10 @@ MetaSkeletonStateSaver::MetaSkeletonStateSaver(
     ::dart::dynamics::MetaSkeletonPtr metaskeleton, int options)
   : mMetaSkeleton(std::move(metaskeleton)), mOptions(std::move(options))
 {
-  if (mOptions & MetaSkeletonStateSaverOptions::POSITIONS)
+  if (mOptions & Options::POSITIONS)
     mPositions = mMetaSkeleton->getPositions();
 
-  if (mOptions & MetaSkeletonStateSaverOptions::POSITION_LIMITS)
+  if (mOptions & Options::POSITION_LIMITS)
   {
     mPositionLowerLimits = mMetaSkeleton->getPositionLowerLimits();
     mPositionUpperLimits = mMetaSkeleton->getPositionUpperLimits();
@@ -23,7 +23,7 @@ MetaSkeletonStateSaver::MetaSkeletonStateSaver(
 //==============================================================================
 MetaSkeletonStateSaver::~MetaSkeletonStateSaver()
 {
-  if (mOptions & MetaSkeletonStateSaverOptions::POSITIONS)
+  if (mOptions & Options::POSITIONS)
   {
     if (static_cast<std::size_t>(mPositions.size())
         != mMetaSkeleton->getNumDofs())
@@ -35,7 +35,7 @@ MetaSkeletonStateSaver::~MetaSkeletonStateSaver()
     mMetaSkeleton->setPositions(mPositions);
   }
 
-  if (mOptions & MetaSkeletonStateSaverOptions::POSITION_LIMITS)
+  if (mOptions & Options::POSITION_LIMITS)
   {
     if (static_cast<std::size_t>(mPositionLowerLimits.size())
         != mMetaSkeleton->getNumDofs())

--- a/tests/statespace/dart/test_MetaSkeletonStateSaver.cpp
+++ b/tests/statespace/dart/test_MetaSkeletonStateSaver.cpp
@@ -5,7 +5,6 @@
 using dart::dynamics::Skeleton;
 using dart::dynamics::RevoluteJoint;
 using aikido::statespace::dart::MetaSkeletonStateSaver;
-using aikido::statespace::dart::MetaSkeletonStateSaverOptions;
 
 class MetaSkeletonStateSaverTest : public testing::Test
 {
@@ -80,7 +79,7 @@ TEST_F(MetaSkeletonStateSaverTest, Flags_PositionsOnly)
 
   {
     auto saver = MetaSkeletonStateSaver(
-        mSkeleton, MetaSkeletonStateSaverOptions::POSITIONS);
+        mSkeleton, MetaSkeletonStateSaver::Options::POSITIONS);
     DART_UNUSED(saver);
 
     mSkeleton->setPositionLowerLimit(0, 1.);
@@ -105,7 +104,7 @@ TEST_F(MetaSkeletonStateSaverTest, Flags_PositionLimitsOnly)
 
   {
     auto saver = MetaSkeletonStateSaver(
-        mSkeleton, MetaSkeletonStateSaverOptions::POSITION_LIMITS);
+        mSkeleton, MetaSkeletonStateSaver::Options::POSITION_LIMITS);
     DART_UNUSED(saver);
 
     mSkeleton->setPositionLowerLimit(0, 1.);


### PR DESCRIPTION
Resolves #276. Resolves #293.

This implementation might not be ideal because the "options" can be arbitrary ints, rather than combinations of the options that we actually enumerate. If that's a problem, maybe something like [this](http://blog.bitwigglers.org/using-enum-classes-as-type-safe-bitmasks/) would be better?

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
