### PR TITLE
Clean up constraint namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
   * Fixed CollisionGroup bugs in Hand executors: [#299](https://github.com/personalrobotics/aikido/pull/299)
   * Rewrote executors for faster-than-realtime simulation: [#316](https://github.com/personalrobotics/aikido/pull/316)
+  * Introduced uniform and dart namespaces: [#342](https://github.com/personalrobotics/aikido/pull/342)
 
 * Planner
 

--- a/include/aikido/constraint.hpp
+++ b/include/aikido/constraint.hpp
@@ -25,3 +25,27 @@
 #include "constraint/uniform/SE2BoxConstraint.hpp"
 #include "constraint/uniform/SO2UniformSampler.hpp"
 #include "constraint/uniform/SO3UniformSampler.hpp"
+
+namespace aikido {
+namespace constraint {
+
+// Add aliases for long class names here.
+
+using R0BoxConstraint = uniform::R0BoxConstraint;
+using R1BoxConstraint = uniform::R1BoxConstraint;
+using R2BoxConstraint = uniform::R2BoxConstraint;
+using R3BoxConstraint = uniform::R3BoxConstraint;
+using R6BoxConstraint = uniform::R6BoxConstraint;
+using RnBoxConstraint = uniform::RnBoxConstraint;
+using R0ConstantSampler = uniform::R0ConstantSampler;
+using R1ConstantSampler = uniform::R1ConstantSampler;
+using R2ConstantSampler = uniform::R2ConstantSampler;
+using R3ConstantSampler = uniform::R3ConstantSampler;
+using R6ConstantSampler = uniform::R6ConstantSampler;
+using RnConstantSampler = uniform::RnConstantSampler;
+using SO2UniformSampler = uniform::SO2UniformSampler;
+using SO3UniformSampler = uniform::SO3UniformSampler;
+using SE2BoxConstraint = uniform::SE2BoxConstraint;
+
+} // namespace constraint
+} // namespace aikido

--- a/include/aikido/constraint.hpp
+++ b/include/aikido/constraint.hpp
@@ -31,33 +31,33 @@ namespace constraint {
 
 // Add aliases for long class names here.
 
-using R0BoxConstraint = uniform::R0BoxConstraint;
-using R1BoxConstraint = uniform::R1BoxConstraint;
-using R2BoxConstraint = uniform::R2BoxConstraint;
-using R3BoxConstraint = uniform::R3BoxConstraint;
-using R6BoxConstraint = uniform::R6BoxConstraint;
-using RnBoxConstraint = uniform::RnBoxConstraint;
-using R0ConstantSampler = uniform::R0ConstantSampler;
-using R1ConstantSampler = uniform::R1ConstantSampler;
-using R2ConstantSampler = uniform::R2ConstantSampler;
-using R3ConstantSampler = uniform::R3ConstantSampler;
-using R6ConstantSampler = uniform::R6ConstantSampler;
-using RnConstantSampler = uniform::RnConstantSampler;
-using SO2UniformSampler = uniform::SO2UniformSampler;
-using SO3UniformSampler = uniform::SO3UniformSampler;
-using SE2BoxConstraint = uniform::SE2BoxConstraint;
+using uniform::R0BoxConstraint;
+using uniform::R1BoxConstraint;
+using uniform::R2BoxConstraint;
+using uniform::R3BoxConstraint;
+using uniform::R6BoxConstraint;
+using uniform::RnBoxConstraint;
+using uniform::R0ConstantSampler;
+using uniform::R1ConstantSampler;
+using uniform::R2ConstantSampler;
+using uniform::R3ConstantSampler;
+using uniform::R6ConstantSampler;
+using uniform::RnConstantSampler;
+using uniform::SO2UniformSampler;
+using uniform::SO3UniformSampler;
+using uniform::SE2BoxConstraint;
 
-using CollisionFree = dart::CollisionFree;
-using CollisionFreeOutcome = dart::CollisionFreeOutcome;
-using FrameDifferentiable = dart::FrameDifferentiable;
-using FramePairDifferentiable = dart::FramePairDifferentiable;
-using FrameTestable = dart::FrameTestable;
-using InverseKinematicsSampleable = dart::InverseKinematicsSampleable;
-using TSR = dart::TSR;
-using createDifferentiableBounds = dart::createDifferentiableBounds;
-using createProjectableBounds = dart::createProjectableBounds;
-using createTestableBounds = dart::createTestableBounds;
-using createSampleableBounds = dart::createSampleableBounds;
+using dart::CollisionFree;
+using dart::CollisionFreeOutcome;
+using dart::FrameDifferentiable;
+using dart::FramePairDifferentiable;
+using dart::FrameTestable;
+using dart::InverseKinematicsSampleable;
+using dart::TSR;
+using dart::createDifferentiableBounds;
+using dart::createProjectableBounds;
+using dart::createTestableBounds;
+using dart::createSampleableBounds;
 
 } // namespace constraint
 } // namespace aikido

--- a/include/aikido/constraint.hpp
+++ b/include/aikido/constraint.hpp
@@ -1,25 +1,25 @@
 #include "constraint/CartesianProductProjectable.hpp"
 #include "constraint/CartesianProductSampleable.hpp"
 #include "constraint/CartesianProductTestable.hpp"
-#include "constraint/CollisionFree.hpp"
 #include "constraint/CyclicSampleable.hpp"
 #include "constraint/Differentiable.hpp"
 #include "constraint/DifferentiableIntersection.hpp"
 #include "constraint/DifferentiableSubspace.hpp"
 #include "constraint/FiniteSampleable.hpp"
-#include "constraint/FrameDifferentiable.hpp"
-#include "constraint/FramePairDifferentiable.hpp"
-#include "constraint/FrameTestable.hpp"
-#include "constraint/InverseKinematicsSampleable.hpp"
-#include "constraint/JointStateSpaceHelpers.hpp"
 #include "constraint/NewtonsMethodProjectable.hpp"
 #include "constraint/Projectable.hpp"
 #include "constraint/RejectionSampleable.hpp"
 #include "constraint/Sampleable.hpp"
 #include "constraint/Satisfied.hpp"
-#include "constraint/TSR.hpp"
 #include "constraint/Testable.hpp"
 #include "constraint/TestableIntersection.hpp"
+#include "constraint/dart/CollisionFree.hpp"
+#include "constraint/dart/FrameDifferentiable.hpp"
+#include "constraint/dart/FramePairDifferentiable.hpp"
+#include "constraint/dart/FrameTestable.hpp"
+#include "constraint/dart/InverseKinematicsSampleable.hpp"
+#include "constraint/dart/JointStateSpaceHelpers.hpp"
+#include "constraint/dart/TSR.hpp"
 #include "constraint/uniform/RnBoxConstraint.hpp"
 #include "constraint/uniform/RnConstantSampler.hpp"
 #include "constraint/uniform/SE2BoxConstraint.hpp"
@@ -46,6 +46,18 @@ using RnConstantSampler = uniform::RnConstantSampler;
 using SO2UniformSampler = uniform::SO2UniformSampler;
 using SO3UniformSampler = uniform::SO3UniformSampler;
 using SE2BoxConstraint = uniform::SE2BoxConstraint;
+
+using CollisionFree = dart::CollisionFree;
+using CollisionFreeOutcome = dart::CollisionFreeOutcome;
+using FrameDifferentiable = dart::FrameDifferentiable;
+using FramePairDifferentiable = dart::FramePairDifferentiable;
+using FrameTestable = dart::FrameTestable;
+using InverseKinematicsSampleable = dart::InverseKinematicsSampleable;
+using TSR = dart::TSR;
+using createDifferentiableBounds = dart::createDifferentiableBounds;
+using createProjectableBounds = dart::createProjectableBounds;
+using createTestableBounds = dart::createTestableBounds;
+using createSampleableBounds = dart::createSampleableBounds;
 
 } // namespace constraint
 } // namespace aikido

--- a/include/aikido/constraint/dart/CollisionFree.hpp
+++ b/include/aikido/constraint/dart/CollisionFree.hpp
@@ -1,5 +1,5 @@
-#ifndef AIKIDO_CONSTRAINT_COLLISIONFREE_HPP_
-#define AIKIDO_CONSTRAINT_COLLISIONFREE_HPP_
+#ifndef AIKIDO_CONSTRAINT_DART_COLLISIONFREE_HPP_
+#define AIKIDO_CONSTRAINT_DART_COLLISIONFREE_HPP_
 
 #include <memory>
 #include <tuple>
@@ -9,12 +9,13 @@
 #include <dart/collision/CollisionGroup.hpp>
 #include <dart/collision/CollisionOption.hpp>
 #include "aikido/common/pointers.hpp"
-#include "../statespace/dart/MetaSkeletonStateSpace.hpp"
-#include "CollisionFreeOutcome.hpp"
-#include "Testable.hpp"
+#include "aikido/constraint/Testable.hpp"
+#include "aikido/constraint/dart/CollisionFreeOutcome.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
 AIKIDO_DECLARE_POINTERS(CollisionFree)
 
@@ -35,13 +36,13 @@ public:
   /// \param _collisionOptions options passed to \c _collisionDetector
   CollisionFree(
       statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
-      dart::dynamics::MetaSkeletonPtr _metaskeleton,
-      std::shared_ptr<dart::collision::CollisionDetector> _collisionDetector,
-      dart::collision::CollisionOption _collisionOptions
-      = dart::collision::CollisionOption(
+      ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
+      std::shared_ptr<::dart::collision::CollisionDetector> _collisionDetector,
+      ::dart::collision::CollisionOption _collisionOptions
+      = ::dart::collision::CollisionOption(
           false,
           1,
-          std::make_shared<dart::collision::BodyNodeCollisionFilter>()));
+          std::make_shared<::dart::collision::BodyNodeCollisionFilter>()));
 
   // Documentation inherited.
   statespace::StateSpacePtr getStateSpace() const override;
@@ -62,38 +63,40 @@ public:
   /// \param group1 First collision group.
   /// \param group2 Second collision group.
   void addPairwiseCheck(
-      std::shared_ptr<dart::collision::CollisionGroup> _group1,
-      std::shared_ptr<dart::collision::CollisionGroup> _group2);
+      std::shared_ptr<::dart::collision::CollisionGroup> _group1,
+      std::shared_ptr<::dart::collision::CollisionGroup> _group2);
 
   /// Remove collision check between group1 and group2.
   /// \param group1 First collision group.
   /// \param group2 Second collision group.
   void removePairwiseCheck(
-      std::shared_ptr<dart::collision::CollisionGroup> _group1,
-      std::shared_ptr<dart::collision::CollisionGroup> _group2);
+      std::shared_ptr<::dart::collision::CollisionGroup> _group1,
+      std::shared_ptr<::dart::collision::CollisionGroup> _group2);
 
   /// Checks collision within group.
   /// \param group Collision group.
-  void addSelfCheck(std::shared_ptr<dart::collision::CollisionGroup> _group);
+  void addSelfCheck(std::shared_ptr<::dart::collision::CollisionGroup> _group);
 
   /// Remove self-collision check within group.
   /// \param group Collision group.
-  void removeSelfCheck(std::shared_ptr<dart::collision::CollisionGroup> _group);
+  void removeSelfCheck(
+      std::shared_ptr<::dart::collision::CollisionGroup> _group);
 
 private:
-  using CollisionGroup = dart::collision::CollisionGroup;
+  using CollisionGroup = ::dart::collision::CollisionGroup;
 
   aikido::statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
-  dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
-  std::shared_ptr<dart::collision::CollisionDetector> mCollisionDetector;
-  dart::collision::CollisionOption mCollisionOptions;
+  ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
+  std::shared_ptr<::dart::collision::CollisionDetector> mCollisionDetector;
+  ::dart::collision::CollisionOption mCollisionOptions;
   std::vector<std::pair<std::shared_ptr<CollisionGroup>,
                         std::shared_ptr<CollisionGroup>>>
       mGroupsToPairwiseCheck;
   std::vector<std::shared_ptr<CollisionGroup>> mGroupsToSelfCheck;
 };
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido
 
-#endif // AIKIDO_CONSTRAINT_COLLISIONFREE_HPP_
+#endif // AIKIDO_CONSTRAINT_DART_COLLISIONFREE_HPP_

--- a/include/aikido/constraint/dart/CollisionFreeOutcome.hpp
+++ b/include/aikido/constraint/dart/CollisionFreeOutcome.hpp
@@ -1,16 +1,17 @@
-#ifndef AIKIDO_CONSTRAINT_COLLISIONFREEOUTCOME_HPP_
-#define AIKIDO_CONSTRAINT_COLLISIONFREEOUTCOME_HPP_
+#ifndef AIKIDO_CONSTRAINT_DART_COLLISIONFREEOUTCOME_HPP_
+#define AIKIDO_CONSTRAINT_DART_COLLISIONFREEOUTCOME_HPP_
 
 #include <vector>
-#include "TestableOutcome.hpp"
-#include "dart/collision/CollisionObject.hpp"
-#include "dart/collision/Contact.hpp"
-#include "dart/dynamics/BodyNode.hpp"
-#include "dart/dynamics/ShapeFrame.hpp"
-#include "dart/dynamics/ShapeNode.hpp"
+#include <dart/collision/CollisionObject.hpp>
+#include <dart/collision/Contact.hpp>
+#include <dart/dynamics/BodyNode.hpp>
+#include <dart/dynamics/ShapeFrame.hpp>
+#include <dart/dynamics/ShapeNode.hpp>
+#include "aikido/constraint/TestableOutcome.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
 /// TestableOutcome derivative class intended as (optional) input to isSatisfied
 /// method in CollisionFree class.
@@ -34,28 +35,29 @@ public:
 
   /// Return a copy of the vector storing the Contact objects from pairwise
   /// collisions.
-  std::vector<dart::collision::Contact> getPairwiseContacts() const;
+  std::vector<::dart::collision::Contact> getPairwiseContacts() const;
 
   /// Return a copy of the vector storing the Contact objects from self
   /// collisions.
-  std::vector<dart::collision::Contact> getSelfContacts() const;
+  std::vector<::dart::collision::Contact> getSelfContacts() const;
 
   /// Gets the name of a CollisionObject. The name returned is that of the
   /// corresponding BodyNode (if possible). If not, the name of the ShapeFrame
   /// is returned instead. This is a helper for toString().
   /// \param[in] object object pointer to CollisionObject we want the name of.
   std::string getCollisionObjectName(
-      const dart::collision::CollisionObject* object) const;
+      const ::dart::collision::CollisionObject* object) const;
 
 protected:
   /// Holds Contact objects from pairwise collisions.
-  std::vector<dart::collision::Contact> mPairwiseContacts;
+  std::vector<::dart::collision::Contact> mPairwiseContacts;
 
   /// Holds Contact objects from self collisions.
-  std::vector<dart::collision::Contact> mSelfContacts;
+  std::vector<::dart::collision::Contact> mSelfContacts;
 };
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido
 
-#endif // AIKIDO_CONSTRAINT_COLLISIONFREEOUTCOME_HPP_
+#endif // AIKIDO_CONSTRAINT_DART_COLLISIONFREEOUTCOME_HPP_

--- a/include/aikido/constraint/dart/FrameDifferentiable.hpp
+++ b/include/aikido/constraint/dart/FrameDifferentiable.hpp
@@ -1,14 +1,15 @@
-#ifndef AIKIDO_CONSTRAINT_FRAMEDIFFERENTIABLE_HPP_
-#define AIKIDO_CONSTRAINT_FRAMEDIFFERENTIABLE_HPP_
+#ifndef AIKIDO_CONSTRAINT_DART_FRAMEDIFFERENTIABLE_HPP_
+#define AIKIDO_CONSTRAINT_DART_FRAMEDIFFERENTIABLE_HPP_
 
 #include <dart/dynamics/dynamics.hpp>
-#include "../statespace/dart/MetaSkeletonStateSpace.hpp"
-#include "Differentiable.hpp"
+#include "aikido/constraint/Differentiable.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
 
 #include <Eigen/Dense>
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
 /// A pose constraint on _jacobianNode's transform
 /// w.r.t. MetaSkeletonState of _jacobianNode.
@@ -28,8 +29,8 @@ public:
   ///        in SE3.
   FrameDifferentiable(
       statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
-      dart::dynamics::MetaSkeletonPtr _metaskeleton,
-      dart::dynamics::ConstJacobianNodePtr _jacobianNode,
+      ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
+      ::dart::dynamics::ConstJacobianNodePtr _jacobianNode,
       DifferentiablePtr _poseConstraint);
 
   // Documentation inherited.
@@ -65,12 +66,13 @@ public:
 
 private:
   statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
-  dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
-  dart::dynamics::ConstJacobianNodePtr mJacobianNode;
+  ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
+  ::dart::dynamics::ConstJacobianNodePtr mJacobianNode;
   DifferentiablePtr mPoseConstraint;
 };
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido
 
-#endif // AIKIDO_CONSTRAINT_FRAMEDIFFERENTIABLE_HPP_
+#endif // AIKIDO_CONSTRAINT_DART_FRAMEDIFFERENTIABLE_HPP_

--- a/include/aikido/constraint/dart/FramePairDifferentiable.hpp
+++ b/include/aikido/constraint/dart/FramePairDifferentiable.hpp
@@ -1,13 +1,14 @@
-#ifndef AIKIDO_CONSTRAINT_FRAMEPAIRDIFFERENTIABLE_HPP_
-#define AIKIDO_CONSTRAINT_FRAMEPAIRDIFFERENTIABLE_HPP_
+#ifndef AIKIDO_CONSTRAINT_DART_FRAMEPAIRDIFFERENTIABLE_HPP_
+#define AIKIDO_CONSTRAINT_DART_FRAMEPAIRDIFFERENTIABLE_HPP_
 
 #include <Eigen/Dense>
 #include <dart/dynamics/dynamics.hpp>
-#include "../statespace/dart/MetaSkeletonStateSpace.hpp"
-#include "Differentiable.hpp"
+#include "aikido/constraint/Differentiable.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
 /// A differentiable constraint which constrains relative transform
 /// of jacobianNodeTarget w.r.t. jacobianNodeBase.
@@ -29,9 +30,9 @@ public:
   ///        w.r.t. _jacobianNodeBase.
   FramePairDifferentiable(
       statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
-      dart::dynamics::MetaSkeletonPtr _metaskeleton,
-      dart::dynamics::ConstJacobianNodePtr _jacobianNodeTarget,
-      dart::dynamics::ConstJacobianNodePtr _jacobianNodeBase,
+      ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
+      ::dart::dynamics::ConstJacobianNodePtr _jacobianNodeTarget,
+      ::dart::dynamics::ConstJacobianNodePtr _jacobianNodeBase,
       DifferentiablePtr _relPoseConstraint);
 
   // Documentation inherited.
@@ -60,13 +61,14 @@ public:
 
 private:
   statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
-  dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
-  dart::dynamics::ConstJacobianNodePtr mJacobianNode1;
-  dart::dynamics::ConstJacobianNodePtr mJacobianNode2;
+  ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
+  ::dart::dynamics::ConstJacobianNodePtr mJacobianNode1;
+  ::dart::dynamics::ConstJacobianNodePtr mJacobianNode2;
   DifferentiablePtr mRelPoseConstraint;
 };
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido
 
-#endif // AIKIDO_CONSTRAINT_FRAMEPAIRDIFFERENTIABLE_HPP_
+#endif // AIKIDO_CONSTRAINT_DART_FRAMEPAIRDIFFERENTIABLE_HPP_

--- a/include/aikido/constraint/dart/FrameTestable.hpp
+++ b/include/aikido/constraint/dart/FrameTestable.hpp
@@ -1,13 +1,14 @@
-#ifndef AIKIDO_CONSTRAINT_FRAMETESTABLE_HPP_
-#define AIKIDO_CONSTRAINT_FRAMETESTABLE_HPP_
+#ifndef AIKIDO_CONSTRAINT_DART_FRAMETESTABLE_HPP_
+#define AIKIDO_CONSTRAINT_DART_FRAMETESTABLE_HPP_
 
 #include <dart/dynamics/dynamics.hpp>
-#include "../statespace/SE3.hpp"
-#include "../statespace/dart/MetaSkeletonStateSpace.hpp"
-#include "Testable.hpp"
+#include "aikido/constraint/Testable.hpp"
+#include "aikido/statespace/SE3.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
 /// Transforms a SE(3) Testable into a MetaSkeleton-Testable by
 /// performing forward kinematics on a configuration (metaskeleton state)
@@ -22,8 +23,8 @@ public:
   /// \param _poseConstraint A testable constraint on _frame.
   FrameTestable(
       statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
-      dart::dynamics::MetaSkeletonPtr _metaskeleton,
-      dart::dynamics::ConstJacobianNodePtr _frame,
+      ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
+      ::dart::dynamics::ConstJacobianNodePtr _frame,
       TestablePtr _poseConstraint);
 
   /// Check if the constraint is satisfied by performing forward
@@ -48,13 +49,14 @@ public:
 
 private:
   statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
-  dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
-  dart::dynamics::ConstJacobianNodePtr mFrame;
+  ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
+  ::dart::dynamics::ConstJacobianNodePtr mFrame;
   TestablePtr mPoseConstraint;
   std::shared_ptr<statespace::SE3> mPoseStateSpace;
 };
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido
 
-#endif // AIKIDO_CONSTRAINT_FRAMETESTABLE_HPP_
+#endif // AIKIDO_CONSTRAINT_DART_FRAMETESTABLE_HPP_

--- a/include/aikido/constraint/dart/InverseKinematicsSampleable.hpp
+++ b/include/aikido/constraint/dart/InverseKinematicsSampleable.hpp
@@ -1,12 +1,13 @@
-#ifndef AIKIDO_CONSTRAINT_INVERSEKINEMATICSSAMPLEABLEABLE_HPP_
-#define AIKIDO_CONSTRAINT_INVERSEKINEMATICSSAMPLEABLEABLE_HPP_
+#ifndef AIKIDO_CONSTRAINT_DART_INVERSEKINEMATICSSAMPLEABLE_HPP_
+#define AIKIDO_CONSTRAINT_DART_INVERSEKINEMATICSSAMPLEABLE_HPP_
 
 #include <dart/dynamics/dynamics.hpp>
-#include "../statespace/dart/MetaSkeletonStateSpace.hpp"
-#include "Sampleable.hpp"
+#include "aikido/constraint/Sampleable.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
 /// Transforms a SE3-Sampleable into a MetaSkeleton-Sampleable
 /// that samples a configuration of a metaskeleton.
@@ -31,10 +32,10 @@ public:
   ///        to retry sampling and finding an inverse kinematics solution.
   InverseKinematicsSampleable(
       statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
-      dart::dynamics::MetaSkeletonPtr _metaskeleton,
+      ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
       SampleablePtr _poseConstraint,
       SampleablePtr _seedConstraint,
-      dart::dynamics::InverseKinematicsPtr _inverseKinematics,
+      ::dart::dynamics::InverseKinematicsPtr _inverseKinematics,
       int _maxNumTrials);
 
   virtual ~InverseKinematicsSampleable() = default;
@@ -47,14 +48,15 @@ public:
 
 private:
   statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
-  dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
+  ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
   SampleablePtr mPoseConstraint;
   SampleablePtr mSeedConstraint;
-  dart::dynamics::InverseKinematicsPtr mInverseKinematics;
+  ::dart::dynamics::InverseKinematicsPtr mInverseKinematics;
   int mMaxNumTrials;
 };
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido
 
-#endif // AIKIDO_CONSTRAINT_INVERSEKINEMATICSSAMPLEABLE_HPP_
+#endif // AIKIDO_CONSTRAINT_DART_INVERSEKINEMATICSSAMPLEABLE_HPP_

--- a/include/aikido/constraint/dart/JointStateSpaceHelpers.hpp
+++ b/include/aikido/constraint/dart/JointStateSpaceHelpers.hpp
@@ -1,15 +1,16 @@
-#ifndef AIKIDO_CONSTRAINT_DART_HPP_
-#define AIKIDO_CONSTRAINT_DART_HPP_
+#ifndef AIKIDO_CONSTRAINT_DART_JOINTSTATESPACEHELPERS_HPP_
+#define AIKIDO_CONSTRAINT_DART_JOINTSTATESPACEHELPERS_HPP_
 
-#include "../statespace/dart/JointStateSpace.hpp"
-#include "../statespace/dart/MetaSkeletonStateSpace.hpp"
-#include "Differentiable.hpp"
-#include "Projectable.hpp"
-#include "Sampleable.hpp"
-#include "Testable.hpp"
+#include "aikido/constraint/Differentiable.hpp"
+#include "aikido/constraint/Projectable.hpp"
+#include "aikido/constraint/Sampleable.hpp"
+#include "aikido/constraint/Testable.hpp"
+#include "aikido/statespace/dart/JointStateSpace.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
 /// Create differentiable bounds that can be applied to the given StateSpace
 /// \param _stateSpace The StateSpace where the Differentiable will be applied
@@ -107,9 +108,10 @@ std::unique_ptr<Sampleable> createSampleableBounds(
     statespace::dart::MetaSkeletonStateSpacePtr _metaSkeleton,
     std::unique_ptr<common::RNG> _rng);
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido
 
 #include "detail/JointStateSpaceHelpers-impl.hpp"
 
-#endif // ifndef AIKIDO_CONSTRAINT_DART_HPP_
+#endif // AIKIDO_CONSTRAINT_DART_JOINTSTATESPACEHELPERS_HPP_

--- a/include/aikido/constraint/dart/TSR.hpp
+++ b/include/aikido/constraint/dart/TSR.hpp
@@ -1,16 +1,17 @@
-#ifndef AIKIDO_CONSTRAINT_TSR_HPP_
-#define AIKIDO_CONSTRAINT_TSR_HPP_
+#ifndef AIKIDO_CONSTRAINT_DART_TSR_HPP_
+#define AIKIDO_CONSTRAINT_DART_TSR_HPP_
 
 #include <Eigen/Dense>
 #include <dart/math/MathTypes.hpp>
-#include "../statespace/SE3.hpp"
-#include "Differentiable.hpp"
-#include "Projectable.hpp"
-#include "Sampleable.hpp"
-#include "Testable.hpp"
+#include "aikido/constraint/Differentiable.hpp"
+#include "aikido/constraint/Projectable.hpp"
+#include "aikido/constraint/Sampleable.hpp"
+#include "aikido/constraint/Testable.hpp"
+#include "aikido/statespace/SE3.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
 AIKIDO_DECLARE_POINTERS(TSR)
 
@@ -150,7 +151,8 @@ private:
   std::shared_ptr<statespace::SE3> mStateSpace;
 };
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido
 
-#endif // AIKIDO_CONSTRAINT_TSR_HPP_
+#endif // AIKIDO_CONSTRAINT_DART_TSR_HPP_

--- a/include/aikido/constraint/dart/detail/JointStateSpaceHelpers-impl.hpp
+++ b/include/aikido/constraint/dart/detail/JointStateSpaceHelpers-impl.hpp
@@ -16,7 +16,10 @@
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 namespace detail {
+
+using ::dart::common::make_unique;
 
 //==============================================================================
 using JointStateSpaceTypeList = common::type_list<statespace::dart::R0Joint,
@@ -65,7 +68,7 @@ std::unique_ptr<OutputConstraint> createBoxConstraint(
 
   if (properties.isPositionLimited())
   {
-    return dart::common::make_unique<uniform::RBoxConstraint<N>>(
+    return make_unique<uniform::RBoxConstraint<N>>(
         std::move(_stateSpace),
         std::move(_rng),
         properties.getPositionLowerLimits(),
@@ -73,7 +76,7 @@ std::unique_ptr<OutputConstraint> createBoxConstraint(
   }
   else
   {
-    return dart::common::make_unique<Satisfied>(std::move(_stateSpace));
+    return make_unique<Satisfied>(std::move(_stateSpace));
   }
 }
 
@@ -131,7 +134,7 @@ struct createSampleableFor_impl<statespace::dart::RJoint<N>>
 
     if (properties.isPositionLimited())
     {
-      return dart::common::make_unique<uniform::RBoxConstraint<N>>(
+      return make_unique<uniform::RBoxConstraint<N>>(
           std::move(_stateSpace),
           std::move(_rng),
           properties.getPositionLowerLimits(),
@@ -156,7 +159,7 @@ struct createDifferentiableFor_impl<statespace::dart::SO2Joint>
     if (_stateSpace->getProperties().isPositionLimited())
       throw std::invalid_argument("SO2Joint must not have limits.");
 
-    return dart::common::make_unique<Satisfied>(std::move(_stateSpace));
+    return make_unique<Satisfied>(std::move(_stateSpace));
   }
 };
 
@@ -172,7 +175,7 @@ struct createTestableFor_impl<statespace::dart::SO2Joint>
     if (_stateSpace->getProperties().isPositionLimited())
       throw std::invalid_argument("SO2Joint must not have limits.");
 
-    return dart::common::make_unique<Satisfied>(std::move(_stateSpace));
+    return make_unique<Satisfied>(std::move(_stateSpace));
   }
 };
 
@@ -188,7 +191,7 @@ struct createProjectableFor_impl<statespace::dart::SO2Joint>
     if (_stateSpace->getProperties().isPositionLimited())
       throw std::invalid_argument("SO2Joint must not have limits.");
 
-    return dart::common::make_unique<Satisfied>(std::move(_stateSpace));
+    return make_unique<Satisfied>(std::move(_stateSpace));
   }
 };
 
@@ -205,7 +208,7 @@ struct createSampleableFor_impl<statespace::dart::SO2Joint>
     if (_stateSpace->getProperties().isPositionLimited())
       throw std::invalid_argument("SO2Joint must not have limits.");
 
-    return dart::common::make_unique<uniform::SO2UniformSampler>(
+    return make_unique<uniform::SO2UniformSampler>(
         std::move(_stateSpace), std::move(_rng));
   }
 };
@@ -222,7 +225,7 @@ struct createDifferentiableFor_impl<statespace::dart::SO3Joint>
     if (_stateSpace->getProperties().isPositionLimited())
       throw std::invalid_argument("SO3Joint must not have limits.");
 
-    return dart::common::make_unique<Satisfied>(std::move(_stateSpace));
+    return make_unique<Satisfied>(std::move(_stateSpace));
   }
 };
 
@@ -238,7 +241,7 @@ struct createTestableFor_impl<statespace::dart::SO3Joint>
     if (_stateSpace->getProperties().isPositionLimited())
       throw std::invalid_argument("SO3Joint must not have limits.");
 
-    return dart::common::make_unique<Satisfied>(std::move(_stateSpace));
+    return make_unique<Satisfied>(std::move(_stateSpace));
   }
 };
 
@@ -254,7 +257,7 @@ struct createProjectableFor_impl<statespace::dart::SO3Joint>
     if (_stateSpace->getProperties().isPositionLimited())
       throw std::invalid_argument("SO3Joint must not have limits.");
 
-    return dart::common::make_unique<Satisfied>(std::move(_stateSpace));
+    return make_unique<Satisfied>(std::move(_stateSpace));
   }
 };
 
@@ -271,7 +274,7 @@ struct createSampleableFor_impl<statespace::dart::SO3Joint>
     if (_stateSpace->getProperties().isPositionLimited())
       throw std::invalid_argument("SO3Joint must not have limits.");
 
-    return dart::common::make_unique<uniform::SO3UniformSampler>(
+    return make_unique<uniform::SO3UniformSampler>(
         std::move(_stateSpace), std::move(_rng));
   }
 };
@@ -286,7 +289,7 @@ std::unique_ptr<OutputConstraint> createBoxConstraint(
 
   if (properties.isPositionLimited())
   {
-    return dart::common::make_unique<uniform::SE2BoxConstraint>(
+    return make_unique<uniform::SE2BoxConstraint>(
         std::move(_stateSpace),
         std::move(_rng),
         properties.getPositionLowerLimits().tail<2>(),
@@ -294,7 +297,7 @@ std::unique_ptr<OutputConstraint> createBoxConstraint(
   }
   else
   {
-    return dart::common::make_unique<Satisfied>(std::move(_stateSpace));
+    return make_unique<Satisfied>(std::move(_stateSpace));
   }
 }
 
@@ -376,7 +379,7 @@ struct createSampleableFor_impl<statespace::dart::SE2Joint>
     }
     else
     {
-      return dart::common::make_unique<uniform::SE2BoxConstraint>(
+      return make_unique<uniform::SE2BoxConstraint>(
           std::move(stateSpace),
           std::move(rng),
           properties.getPositionLowerLimits().tail<2>(),
@@ -445,7 +448,7 @@ std::unique_ptr<OutputConstraint> createBoxConstraint(
     std::shared_ptr<statespace::dart::WeldJoint> _stateSpace,
     std::unique_ptr<common::RNG> /*_rng*/)
 {
-  return dart::common::make_unique<Satisfied>(std::move(_stateSpace));
+  return make_unique<Satisfied>(std::move(_stateSpace));
 }
 
 //==============================================================================
@@ -500,7 +503,7 @@ struct createSampleableFor_impl<statespace::dart::WeldJoint>
     // A WeldJoint has zero DOFs
     Eigen::VectorXd positions = Eigen::Matrix<double, 0, 1>();
 
-    return dart::common::make_unique<uniform::R0ConstantSampler>(
+    return make_unique<uniform::R0ConstantSampler>(
         std::move(_stateSpace), positions);
   }
 };
@@ -542,5 +545,6 @@ std::unique_ptr<Sampleable> createSampleableBoundsFor(
       std::move(_stateSpace), std::move(_rng));
 }
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido

--- a/include/aikido/constraint/detail/JointStateSpaceHelpers-impl.hpp
+++ b/include/aikido/constraint/detail/JointStateSpaceHelpers-impl.hpp
@@ -1,18 +1,18 @@
 #include <sstream>
 #include <dart/common/StlHelpers.hpp>
-#include "../../common/metaprogramming.hpp"
-#include "../../statespace/dart/RnJoint.hpp"
-#include "../../statespace/dart/SE2Joint.hpp"
-#include "../../statespace/dart/SE3Joint.hpp"
-#include "../../statespace/dart/SO2Joint.hpp"
-#include "../../statespace/dart/SO3Joint.hpp"
-#include "../../statespace/dart/WeldJoint.hpp"
-#include "../Satisfied.hpp"
-#include "../uniform/RnBoxConstraint.hpp"
-#include "../uniform/RnConstantSampler.hpp"
-#include "../uniform/SE2BoxConstraint.hpp"
-#include "../uniform/SO2UniformSampler.hpp"
-#include "../uniform/SO3UniformSampler.hpp"
+#include "aikido/common/metaprogramming.hpp"
+#include "aikido/constraint/Satisfied.hpp"
+#include "aikido/constraint/uniform/RnBoxConstraint.hpp"
+#include "aikido/constraint/uniform/RnConstantSampler.hpp"
+#include "aikido/constraint/uniform/SE2BoxConstraint.hpp"
+#include "aikido/constraint/uniform/SO2UniformSampler.hpp"
+#include "aikido/constraint/uniform/SO3UniformSampler.hpp"
+#include "aikido/statespace/dart/RnJoint.hpp"
+#include "aikido/statespace/dart/SE2Joint.hpp"
+#include "aikido/statespace/dart/SE3Joint.hpp"
+#include "aikido/statespace/dart/SO2Joint.hpp"
+#include "aikido/statespace/dart/SO3Joint.hpp"
+#include "aikido/statespace/dart/WeldJoint.hpp"
 
 namespace aikido {
 namespace constraint {
@@ -65,7 +65,7 @@ std::unique_ptr<OutputConstraint> createBoxConstraint(
 
   if (properties.isPositionLimited())
   {
-    return dart::common::make_unique<RBoxConstraint<N>>(
+    return dart::common::make_unique<uniform::RBoxConstraint<N>>(
         std::move(_stateSpace),
         std::move(_rng),
         properties.getPositionLowerLimits(),
@@ -131,7 +131,7 @@ struct createSampleableFor_impl<statespace::dart::RJoint<N>>
 
     if (properties.isPositionLimited())
     {
-      return dart::common::make_unique<RBoxConstraint<N>>(
+      return dart::common::make_unique<uniform::RBoxConstraint<N>>(
           std::move(_stateSpace),
           std::move(_rng),
           properties.getPositionLowerLimits(),
@@ -205,7 +205,7 @@ struct createSampleableFor_impl<statespace::dart::SO2Joint>
     if (_stateSpace->getProperties().isPositionLimited())
       throw std::invalid_argument("SO2Joint must not have limits.");
 
-    return dart::common::make_unique<SO2UniformSampler>(
+    return dart::common::make_unique<uniform::SO2UniformSampler>(
         std::move(_stateSpace), std::move(_rng));
   }
 };
@@ -271,7 +271,7 @@ struct createSampleableFor_impl<statespace::dart::SO3Joint>
     if (_stateSpace->getProperties().isPositionLimited())
       throw std::invalid_argument("SO3Joint must not have limits.");
 
-    return dart::common::make_unique<SO3UniformSampler>(
+    return dart::common::make_unique<uniform::SO3UniformSampler>(
         std::move(_stateSpace), std::move(_rng));
   }
 };
@@ -286,7 +286,7 @@ std::unique_ptr<OutputConstraint> createBoxConstraint(
 
   if (properties.isPositionLimited())
   {
-    return dart::common::make_unique<SE2BoxConstraint>(
+    return dart::common::make_unique<uniform::SE2BoxConstraint>(
         std::move(_stateSpace),
         std::move(_rng),
         properties.getPositionLowerLimits().tail<2>(),
@@ -376,7 +376,7 @@ struct createSampleableFor_impl<statespace::dart::SE2Joint>
     }
     else
     {
-      return dart::common::make_unique<SE2BoxConstraint>(
+      return dart::common::make_unique<uniform::SE2BoxConstraint>(
           std::move(stateSpace),
           std::move(rng),
           properties.getPositionLowerLimits().tail<2>(),
@@ -500,7 +500,7 @@ struct createSampleableFor_impl<statespace::dart::WeldJoint>
     // A WeldJoint has zero DOFs
     Eigen::VectorXd positions = Eigen::Matrix<double, 0, 1>();
 
-    return dart::common::make_unique<R0ConstantSampler>(
+    return dart::common::make_unique<uniform::R0ConstantSampler>(
         std::move(_stateSpace), positions);
   }
 };

--- a/include/aikido/constraint/uniform/RnBoxConstraint.hpp
+++ b/include/aikido/constraint/uniform/RnBoxConstraint.hpp
@@ -1,13 +1,15 @@
-#ifndef AIKIDO_STATESPACE_RNBOXCONSTRAINT_HPP_
-#define AIKIDO_STATESPACE_RNBOXCONSTRAINT_HPP_
-#include "../../statespace/Rn.hpp"
-#include "../Differentiable.hpp"
-#include "../Projectable.hpp"
-#include "../Sampleable.hpp"
-#include "../Testable.hpp"
+#ifndef AIKIDO_CONSTRAINT_UNIFORM_RNBOXCONSTRAINT_HPP_
+#define AIKIDO_CONSTRAINT_UNIFORM_RNBOXCONSTRAINT_HPP_
+
+#include "aikido/constraint/Differentiable.hpp"
+#include "aikido/constraint/Projectable.hpp"
+#include "aikido/constraint/Sampleable.hpp"
+#include "aikido/constraint/Testable.hpp"
+#include "aikido/statespace/Rn.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace uniform {
 
 /// A BoxConstraint on RealVectorStates.
 /// For each dimension, this constraint has lowerLimit and upperLimit.
@@ -92,9 +94,10 @@ using R3BoxConstraint = RBoxConstraint<3>;
 using R6BoxConstraint = RBoxConstraint<6>;
 using RnBoxConstraint = RBoxConstraint<Eigen::Dynamic>;
 
+} // namespace uniform
 } // namespace constraint
 } // namespace aikido
 
 #include "aikido/constraint/uniform/detail/RnBoxConstraint-impl.hpp"
 
-#endif // AIKIDO_STATESPACE_REALVECTORSTATESPACESAMPLEABLECONSTRAINT_HPP_
+#endif // AIKIDO_CONSTRAINT_UNIFORM_RNBOXCONSTRAINT_HPP_

--- a/include/aikido/constraint/uniform/RnConstantSampler.hpp
+++ b/include/aikido/constraint/uniform/RnConstantSampler.hpp
@@ -1,10 +1,12 @@
-#ifndef AIKIDO_CONSTRAINT_RNCONSTANTSAMPLER_HPP_
-#define AIKIDO_CONSTRAINT_RNCONSTANTSAMPLER_HPP_
-#include "../../statespace/Rn.hpp"
-#include "../Sampleable.hpp"
+#ifndef AIKIDO_CONSTRAINT_UNIFORM_RNCONSTANTSAMPLER_HPP_
+#define AIKIDO_CONSTRAINT_UNIFORM_RNCONSTANTSAMPLER_HPP_
+
+#include "aikido/constraint/Sampleable.hpp"
+#include "aikido/statespace/Rn.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace uniform {
 
 /// ConstantSampler for RealVectorStates.
 /// Stub sampler for WeldJoint or any fixed constant state space.
@@ -42,9 +44,10 @@ using R3ConstantSampler = RConstantSampler<3>;
 using R6ConstantSampler = RConstantSampler<6>;
 using RnConstantSampler = RConstantSampler<Eigen::Dynamic>;
 
+} // namespace uniform
 } // namespace constraint
 } // namespace aikido
 
 #include "aikido/constraint/uniform/detail/RnConstantSampler-impl.hpp"
 
-#endif // AIKIDO_CONSTRAINT_RNCONSTANTSAMPLER_HPP_
+#endif // AIKIDO_CONSTRAINT_UNIFORM_RNCONSTANTSAMPLER_HPP_

--- a/include/aikido/constraint/uniform/SE2BoxConstraint.hpp
+++ b/include/aikido/constraint/uniform/SE2BoxConstraint.hpp
@@ -1,14 +1,15 @@
 #ifndef AIKIDO_CONSTRAINT_UNIFORM_SE2BOXCONSTRAINT_HPP_
 #define AIKIDO_CONSTRAINT_UNIFORM_SE2BOXCONSTRAINT_HPP_
 
-#include "../../statespace/SE2.hpp"
-#include "../Differentiable.hpp"
-#include "../Projectable.hpp"
-#include "../Sampleable.hpp"
-#include "../Testable.hpp"
+#include "aikido/constraint/Differentiable.hpp"
+#include "aikido/constraint/Projectable.hpp"
+#include "aikido/constraint/Sampleable.hpp"
+#include "aikido/constraint/Testable.hpp"
+#include "aikido/statespace/SE2.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace uniform {
 
 /// A BoxConstraint on SE2.
 ///
@@ -80,6 +81,7 @@ private:
   std::size_t mDimension;
 };
 
+} // namespace uniform
 } // namespace constraint
 } // namespace aikido
 

--- a/include/aikido/constraint/uniform/SO2UniformSampler.hpp
+++ b/include/aikido/constraint/uniform/SO2UniformSampler.hpp
@@ -1,11 +1,12 @@
 #ifndef AIKIDO_CONSTRAINT_UNIFORM_SO2UNIFORMSAMPLER_HPP_
 #define AIKIDO_CONSTRAINT_UNIFORM_SO2UNIFORMSAMPLER_HPP_
 
-#include "../../statespace/SO2.hpp"
-#include "../Sampleable.hpp"
+#include "aikido/constraint/Sampleable.hpp"
+#include "aikido/statespace/SO2.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace uniform {
 
 /// Uniform sampler for SO2States. Its SampleGenerators will sample
 /// uniformly from SO2, and the sequence of samples is
@@ -33,6 +34,7 @@ private:
   std::unique_ptr<common::RNG> mRng;
 };
 
+} // namespace uniform
 } // namespace constraint
 } // namespace aikido
 

--- a/include/aikido/constraint/uniform/SO3UniformSampler.hpp
+++ b/include/aikido/constraint/uniform/SO3UniformSampler.hpp
@@ -1,11 +1,12 @@
 #ifndef AIKIDO_CONSTRAINT_UNIFORM_SO3UNIFORMSAMPLER_HPP_
 #define AIKIDO_CONSTRAINT_UNIFORM_SO3UNIFORMSAMPLER_HPP_
 
-#include "../../statespace/SO3.hpp"
-#include "../Sampleable.hpp"
+#include "aikido/constraint/Sampleable.hpp"
+#include "aikido/statespace/SO3.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace uniform {
 
 /// Uniform sampler for SO3States. Its SampleGenerators will sample
 /// uniformly from SO3, and the sequence of samples is
@@ -33,6 +34,7 @@ private:
   std::unique_ptr<common::RNG> mRng;
 };
 
+} // namespace uniform
 } // namespace constraint
 } // namespace aikido
 

--- a/include/aikido/constraint/uniform/detail/RnBoxConstraint-impl.hpp
+++ b/include/aikido/constraint/uniform/detail/RnBoxConstraint-impl.hpp
@@ -1,9 +1,9 @@
-#include <aikido/constraint/uniform/RnBoxConstraint.hpp>
-
 #include <stdexcept>
+#include "aikido/constraint/uniform/RnBoxConstraint.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace uniform {
 
 using constraint::ConstraintType;
 
@@ -309,5 +309,6 @@ auto RBoxConstraint<N>::getUpperLimits() const -> const VectorNd&
   return mUpperLimits;
 }
 
-} // namespace statespace
+} // namespace uniform
+} // namespace constraint
 } // namespace aikido

--- a/include/aikido/constraint/uniform/detail/RnConstantSampler-impl.hpp
+++ b/include/aikido/constraint/uniform/detail/RnConstantSampler-impl.hpp
@@ -2,6 +2,9 @@
 #include <dart/dart.hpp>
 #include "aikido/constraint/uniform/RnConstantSampler.hpp"
 
+#undef dtwarn
+#define dtwarn (::dart::common::colorErr("Warning", __FILE__, __LINE__, 33))
+
 namespace aikido {
 namespace constraint {
 namespace uniform {
@@ -118,7 +121,7 @@ template <int N>
 std::unique_ptr<constraint::SampleGenerator>
 RConstantSampler<N>::createSampleGenerator() const
 {
-  return dart::common::make_unique<RnConstantSamplerSampleGenerator<N>>(
+  return ::dart::common::make_unique<RnConstantSamplerSampleGenerator<N>>(
       mSpace, mValue);
 }
 

--- a/include/aikido/constraint/uniform/detail/RnConstantSampler-impl.hpp
+++ b/include/aikido/constraint/uniform/detail/RnConstantSampler-impl.hpp
@@ -1,11 +1,10 @@
-#include <aikido/constraint/uniform/RnConstantSampler.hpp>
-
 #include <stdexcept>
-
 #include <dart/dart.hpp>
+#include "aikido/constraint/uniform/RnConstantSampler.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace uniform {
 
 //==============================================================================
 extern template class RConstantSampler<0>;
@@ -131,5 +130,6 @@ RConstantSampler<N>::getConstantValue() const
   return mValue;
 }
 
+} // namespace uniform
 } // namespace constraint
 } // namespace aikido

--- a/include/aikido/rviz/InteractiveMarkerViewer.hpp
+++ b/include/aikido/rviz/InteractiveMarkerViewer.hpp
@@ -11,7 +11,7 @@
 #include <interactive_markers/interactive_marker_server.h>
 #include <ros/ros.h>
 
-#include <aikido/constraint/TSR.hpp>
+#include <aikido/constraint/dart/TSR.hpp>
 #include <aikido/rviz/TSRMarker.hpp>
 #include <aikido/rviz/pointers.hpp>
 #include <aikido/trajectory/Trajectory.hpp>
@@ -51,7 +51,7 @@ public:
   /// \param basename Basename for markers
   /// \return TSRMarkerPtr contains sampled frames of TSR.
   TSRMarkerPtr addTSRMarker(
-      const aikido::constraint::TSR& tsr,
+      const aikido::constraint::dart::TSR& tsr,
       int nSamples = 10,
       const std::string& basename = "");
 

--- a/include/aikido/rviz/InteractiveMarkerViewer.hpp
+++ b/include/aikido/rviz/InteractiveMarkerViewer.hpp
@@ -51,7 +51,7 @@ public:
   /// \param basename Basename for markers
   /// \return TSRMarkerPtr contains sampled frames of TSR.
   TSRMarkerPtr addTSRMarker(
-      const aikido::constraint::dart::TSR& tsr,
+      const constraint::dart::TSR& tsr,
       int nSamples = 10,
       const std::string& basename = "");
 

--- a/src/constraint/CMakeLists.txt
+++ b/src/constraint/CMakeLists.txt
@@ -1,32 +1,32 @@
 set(sources
-  uniform/RnBoxConstraint.cpp
-  uniform/RnConstantSampler.cpp
-  uniform/SO2UniformSampler.cpp
-  uniform/SO3UniformSampler.cpp
-  uniform/SE2BoxConstraint.cpp
   CartesianProductProjectable.cpp
   CartesianProductSampleable.cpp
   CartesianProductTestable.cpp
-  CollisionFree.cpp
-  CollisionFreeOutcome.cpp
   CyclicSampleable.cpp
   DefaultTestableOutcome.cpp
   Differentiable.cpp
   DifferentiableIntersection.cpp
   DifferentiableSubspace.cpp
   FiniteSampleable.cpp
-  FrameTestable.cpp
-  FrameDifferentiable.cpp
-  FramePairDifferentiable.cpp
-  InverseKinematicsSampleable.cpp
-  JointStateSpaceHelpers.cpp
   NewtonsMethodProjectable.cpp
   Projectable.cpp
   RejectionSampleable.cpp
   Sampleable.cpp
   Satisfied.cpp
-  TSR.cpp
   TestableIntersection.cpp
+  uniform/RnBoxConstraint.cpp
+  uniform/RnConstantSampler.cpp
+  uniform/SO2UniformSampler.cpp
+  uniform/SO3UniformSampler.cpp
+  uniform/SE2BoxConstraint.cpp
+  dart/CollisionFree.cpp
+  dart/CollisionFreeOutcome.cpp
+  dart/FrameDifferentiable.cpp
+  dart/FramePairDifferentiable.cpp
+  dart/FrameTestable.cpp
+  dart/InverseKinematicsSampleable.cpp
+  dart/JointStateSpaceHelpers.cpp
+  dart/TSR.cpp
 )
 
 add_library("${PROJECT_NAME}_constraint" SHARED ${sources})

--- a/src/constraint/dart/CollisionFree.cpp
+++ b/src/constraint/dart/CollisionFree.cpp
@@ -1,14 +1,15 @@
-#include <aikido/constraint/CollisionFree.hpp>
+#include "aikido/constraint/dart/CollisionFree.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
 //==============================================================================
 CollisionFree::CollisionFree(
     statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
-    dart::dynamics::MetaSkeletonPtr _metaskeleton,
-    std::shared_ptr<dart::collision::CollisionDetector> _collisionDetector,
-    dart::collision::CollisionOption _collisionOptions)
+    ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
+    std::shared_ptr<::dart::collision::CollisionDetector> _collisionDetector,
+    ::dart::collision::CollisionOption _collisionOptions)
   : mMetaSkeletonStateSpace(std::move(_metaSkeletonStateSpace))
   , mMetaSkeleton(std::move(_metaskeleton))
   , mCollisionDetector(std::move(_collisionDetector))
@@ -49,7 +50,7 @@ bool CollisionFree::isSatisfied(
   mMetaSkeletonStateSpace->setState(mMetaSkeleton.get(), skelStatePtr);
 
   bool collision = false;
-  dart::collision::CollisionResult collisionResult;
+  ::dart::collision::CollisionResult collisionResult;
   for (const auto& groups : mGroupsToPairwiseCheck)
   {
     collision = mCollisionDetector->collide(
@@ -92,8 +93,8 @@ std::unique_ptr<TestableOutcome> CollisionFree::createOutcome() const
 
 //==============================================================================
 void CollisionFree::addPairwiseCheck(
-    std::shared_ptr<dart::collision::CollisionGroup> _group1,
-    std::shared_ptr<dart::collision::CollisionGroup> _group2)
+    std::shared_ptr<::dart::collision::CollisionGroup> _group1,
+    std::shared_ptr<::dart::collision::CollisionGroup> _group2)
 {
   if (_group1 < _group2)
     mGroupsToPairwiseCheck.emplace_back(std::move(_group1), std::move(_group2));
@@ -103,8 +104,8 @@ void CollisionFree::addPairwiseCheck(
 
 //==============================================================================
 void CollisionFree::removePairwiseCheck(
-    std::shared_ptr<dart::collision::CollisionGroup> _group1,
-    std::shared_ptr<dart::collision::CollisionGroup> _group2)
+    std::shared_ptr<::dart::collision::CollisionGroup> _group1,
+    std::shared_ptr<::dart::collision::CollisionGroup> _group2)
 {
   if (_group1 < _group2)
     mGroupsToPairwiseCheck.erase(
@@ -124,19 +125,20 @@ void CollisionFree::removePairwiseCheck(
 
 //==============================================================================
 void CollisionFree::addSelfCheck(
-    std::shared_ptr<dart::collision::CollisionGroup> _group)
+    std::shared_ptr<::dart::collision::CollisionGroup> _group)
 {
   mGroupsToSelfCheck.emplace_back(std::move(_group));
 }
 
 //==============================================================================
 void CollisionFree::removeSelfCheck(
-    std::shared_ptr<dart::collision::CollisionGroup> _group)
+    std::shared_ptr<::dart::collision::CollisionGroup> _group)
 {
   mGroupsToSelfCheck.erase(
       std::remove(mGroupsToSelfCheck.begin(), mGroupsToSelfCheck.end(), _group),
       mGroupsToSelfCheck.end());
 }
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido

--- a/src/constraint/dart/CollisionFreeOutcome.cpp
+++ b/src/constraint/dart/CollisionFreeOutcome.cpp
@@ -1,8 +1,9 @@
+#include "aikido/constraint/dart/CollisionFreeOutcome.hpp"
 #include <sstream>
-#include <aikido/constraint/CollisionFreeOutcome.hpp>
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
 //==============================================================================
 bool CollisionFreeOutcome::isSatisfied() const
@@ -41,14 +42,14 @@ void CollisionFreeOutcome::clear()
 }
 
 //==============================================================================
-std::vector<dart::collision::Contact>
+std::vector<::dart::collision::Contact>
 CollisionFreeOutcome::getPairwiseContacts() const
 {
   return mPairwiseContacts;
 }
 
 //==============================================================================
-std::vector<dart::collision::Contact> CollisionFreeOutcome::getSelfContacts()
+std::vector<::dart::collision::Contact> CollisionFreeOutcome::getSelfContacts()
     const
 {
   return mSelfContacts;
@@ -56,13 +57,13 @@ std::vector<dart::collision::Contact> CollisionFreeOutcome::getSelfContacts()
 
 //==============================================================================
 std::string CollisionFreeOutcome::getCollisionObjectName(
-    const dart::collision::CollisionObject* object) const
+    const ::dart::collision::CollisionObject* object) const
 {
-  const dart::dynamics::ShapeFrame* frame = object->getShapeFrame();
+  const ::dart::dynamics::ShapeFrame* frame = object->getShapeFrame();
 
   if (frame->isShapeNode())
   {
-    const dart::dynamics::ShapeNode* node = frame->asShapeNode();
+    const ::dart::dynamics::ShapeNode* node = frame->asShapeNode();
     return node->getBodyNodePtr()->getName();
   }
   else
@@ -71,5 +72,6 @@ std::string CollisionFreeOutcome::getCollisionObjectName(
   }
 }
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido

--- a/src/constraint/dart/FrameDifferentiable.cpp
+++ b/src/constraint/dart/FrameDifferentiable.cpp
@@ -1,14 +1,15 @@
-#include <aikido/constraint/FrameDifferentiable.hpp>
-#include <aikido/statespace/SE3.hpp>
+#include "aikido/constraint/dart/FrameDifferentiable.hpp"
+#include "aikido/statespace/SE3.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
 //==============================================================================
 FrameDifferentiable::FrameDifferentiable(
     statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
-    dart::dynamics::MetaSkeletonPtr _metaskeleton,
-    dart::dynamics::ConstJacobianNodePtr _jacobianNode,
+    ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
+    ::dart::dynamics::ConstJacobianNodePtr _jacobianNode,
     DifferentiablePtr _poseConstraint)
   : mMetaSkeletonStateSpace(std::move(_metaSkeletonStateSpace))
   , mMetaSkeleton(std::move(_metaskeleton))
@@ -127,5 +128,6 @@ statespace::StateSpacePtr FrameDifferentiable::getStateSpace() const
   return mMetaSkeletonStateSpace;
 }
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido

--- a/src/constraint/dart/FramePairDifferentiable.cpp
+++ b/src/constraint/dart/FramePairDifferentiable.cpp
@@ -1,15 +1,16 @@
-#include <aikido/constraint/FramePairDifferentiable.hpp>
-#include <aikido/statespace/SE3.hpp>
+#include "aikido/constraint/dart/FramePairDifferentiable.hpp"
+#include "aikido/statespace/SE3.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
 //==============================================================================
 FramePairDifferentiable::FramePairDifferentiable(
     statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
-    dart::dynamics::MetaSkeletonPtr _metaskeleton,
-    dart::dynamics::ConstJacobianNodePtr _jacobianNode1,
-    dart::dynamics::ConstJacobianNodePtr _jacobianNode2,
+    ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
+    ::dart::dynamics::ConstJacobianNodePtr _jacobianNode1,
+    ::dart::dynamics::ConstJacobianNodePtr _jacobianNode2,
     DifferentiablePtr _relPoseConstraint)
   : mMetaSkeletonStateSpace(std::move(_metaSkeletonStateSpace))
   , mMetaSkeleton(std::move(_metaskeleton))
@@ -149,5 +150,6 @@ statespace::StateSpacePtr FramePairDifferentiable::getStateSpace() const
   return mMetaSkeletonStateSpace;
 }
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido

--- a/src/constraint/dart/FrameTestable.cpp
+++ b/src/constraint/dart/FrameTestable.cpp
@@ -1,13 +1,14 @@
-#include <aikido/constraint/FrameTestable.hpp>
+#include "aikido/constraint/dart/FrameTestable.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
 //==============================================================================
 FrameTestable::FrameTestable(
     statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
-    dart::dynamics::MetaSkeletonPtr _metaskeleton,
-    dart::dynamics::ConstJacobianNodePtr _frame,
+    ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
+    ::dart::dynamics::ConstJacobianNodePtr _frame,
     TestablePtr _poseConstraint)
   : mMetaSkeletonStateSpace(std::move(_metaSkeletonStateSpace))
   , mMetaSkeleton(std::move(_metaskeleton))
@@ -65,5 +66,6 @@ std::shared_ptr<statespace::StateSpace> FrameTestable::getStateSpace() const
   return mMetaSkeletonStateSpace;
 }
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido

--- a/src/constraint/dart/InverseKinematicsSampleable.cpp
+++ b/src/constraint/dart/InverseKinematicsSampleable.cpp
@@ -1,15 +1,17 @@
-#include <aikido/constraint/InverseKinematicsSampleable.hpp>
+#include "aikido/constraint/dart/InverseKinematicsSampleable.hpp"
+#include "aikido/statespace/SE3.hpp"
 
-#include <aikido/statespace/SE3.hpp>
+#undef dtwarn
+#define dtwarn (::dart::common::colorErr("Warning", __FILE__, __LINE__, 33))
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
-using statespace::SE3;
 using statespace::dart::MetaSkeletonStateSpacePtr;
 using statespace::dart::MetaSkeletonStateSpace;
 using statespace::SE3;
-using dart::dynamics::INVALID_INDEX;
+using ::dart::dynamics::INVALID_INDEX;
 
 // For internal use only.
 class IkSampleGenerator : public SampleGenerator
@@ -39,16 +41,16 @@ private:
   // For internal use only.
   IkSampleGenerator(
       statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
-      dart::dynamics::MetaSkeletonPtr _metaskeleton,
-      dart::dynamics::InverseKinematicsPtr _inverseKinematics,
+      ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
+      ::dart::dynamics::InverseKinematicsPtr _inverseKinematics,
       std::unique_ptr<SampleGenerator> _poseSampler,
       std::unique_ptr<SampleGenerator> _seedSampler,
       int _maxNumTrials);
 
   statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
-  dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
+  ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
   std::shared_ptr<statespace::SE3> mPoseStateSpace;
-  dart::dynamics::InverseKinematicsPtr mInverseKinematics;
+  ::dart::dynamics::InverseKinematicsPtr mInverseKinematics;
   std::unique_ptr<SampleGenerator> mPoseSampler;
   std::unique_ptr<SampleGenerator> mSeedSampler;
   int mMaxNumTrials;
@@ -59,10 +61,10 @@ private:
 //==============================================================================
 InverseKinematicsSampleable::InverseKinematicsSampleable(
     MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
-    dart::dynamics::MetaSkeletonPtr _metaskeleton,
+    ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
     SampleablePtr _poseConstraint,
     SampleablePtr _seedConstraint,
-    dart::dynamics::InverseKinematicsPtr _inverseKinematics,
+    ::dart::dynamics::InverseKinematicsPtr _inverseKinematics,
     int _maxNumTrials)
   : mMetaSkeletonStateSpace(std::move(_metaSkeletonStateSpace))
   , mMetaSkeleton(std::move(_metaskeleton))
@@ -135,8 +137,8 @@ InverseKinematicsSampleable::createSampleGenerator() const
 //==============================================================================
 IkSampleGenerator::IkSampleGenerator(
     statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
-    dart::dynamics::MetaSkeletonPtr _metaskeleton,
-    dart::dynamics::InverseKinematicsPtr _inverseKinematics,
+    ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
+    ::dart::dynamics::InverseKinematicsPtr _inverseKinematics,
     std::unique_ptr<SampleGenerator> _poseSampler,
     std::unique_ptr<SampleGenerator> _seedSampler,
     int _maxNumTrials)
@@ -233,5 +235,6 @@ int IkSampleGenerator::getNumSamples() const
   return std::min(mSeedSampler->getNumSamples(), mPoseSampler->getNumSamples());
 }
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido

--- a/src/constraint/dart/JointStateSpaceHelpers.cpp
+++ b/src/constraint/dart/JointStateSpaceHelpers.cpp
@@ -1,17 +1,17 @@
-#include <aikido/constraint/JointStateSpaceHelpers.hpp>
-
+#include "aikido/constraint/dart/JointStateSpaceHelpers.hpp"
 #include <dart/common/StlHelpers.hpp>
-#include <aikido/constraint/CartesianProductProjectable.hpp>
-#include <aikido/constraint/CartesianProductSampleable.hpp>
-#include <aikido/constraint/CartesianProductTestable.hpp>
-#include <aikido/constraint/DifferentiableIntersection.hpp>
-#include <aikido/constraint/DifferentiableSubspace.hpp>
-#include <aikido/constraint/TestableIntersection.hpp>
+#include "aikido/constraint/CartesianProductProjectable.hpp"
+#include "aikido/constraint/CartesianProductSampleable.hpp"
+#include "aikido/constraint/CartesianProductTestable.hpp"
+#include "aikido/constraint/DifferentiableIntersection.hpp"
+#include "aikido/constraint/DifferentiableSubspace.hpp"
+#include "aikido/constraint/TestableIntersection.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
-using dart::common::make_unique;
+using ::dart::common::make_unique;
 
 //==============================================================================
 std::unique_ptr<Differentiable> createDifferentiableBounds(
@@ -154,5 +154,6 @@ std::unique_ptr<Sampleable> createSampleableBounds(
       std::move(_metaSkeleton), std::move(constraints));
 }
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido

--- a/src/constraint/dart/TSR.cpp
+++ b/src/constraint/dart/TSR.cpp
@@ -1,5 +1,4 @@
-#include <aikido/constraint/TSR.hpp>
-
+#include "aikido/constraint/dart/TSR.hpp"
 #include <cmath>
 #include <random>
 #include <stdexcept>
@@ -9,12 +8,16 @@
 #include <dart/common/StlHelpers.hpp>
 #include <dart/math/Geometry.hpp>
 
+#undef dtwarn
+#define dtwarn (::dart::common::colorErr("Warning", __FILE__, __LINE__, 33))
+
 using boost::format;
 using boost::str;
 using aikido::statespace::SE3;
 
 namespace aikido {
 namespace constraint {
+namespace dart {
 
 class TSRSampleGenerator : public SampleGenerator
 {
@@ -277,7 +280,7 @@ void TSR::getValue(
   Eigen::Isometry3d Tw_s = T0_w_inv * se3 * Tw_e_inv;
 
   Eigen::Vector3d translation = Tw_s.translation();
-  Eigen::Vector3d eulerOrig = dart::math::matrixToEulerZYX(Tw_s.linear());
+  Eigen::Vector3d eulerOrig = ::dart::math::matrixToEulerZYX(Tw_s.linear());
   Eigen::Vector3d eulerZYX = eulerOrig.reverse();
 
   _out.resize(6);
@@ -443,7 +446,7 @@ bool TSRSampleGenerator::sample(statespace::StateSpace::State* _state)
   Eigen::Isometry3d Tw_s;
   Tw_s.setIdentity();
   Tw_s.translation() = translation;
-  Tw_s.linear() = dart::math::eulerZYXToMatrix(angles.reverse());
+  Tw_s.linear() = ::dart::math::eulerZYXToMatrix(angles.reverse());
 
   Eigen::Isometry3d T0_s(mT0_w * Tw_s * mTw_e);
   mStateSpace->setIsometry(static_cast<SE3::State*>(_state), T0_s);
@@ -484,5 +487,6 @@ int TSRSampleGenerator::getNumSamples() const
   return NO_LIMIT;
 }
 
+} // namespace dart
 } // namespace constraint
 } // namespace aikido

--- a/src/constraint/uniform/RnBoxConstraint.cpp
+++ b/src/constraint/uniform/RnBoxConstraint.cpp
@@ -1,7 +1,8 @@
-#include <aikido/constraint/uniform/RnBoxConstraint.hpp>
+#include "aikido/constraint/uniform/RnBoxConstraint.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace uniform {
 
 template class RBoxConstraint<0>;
 
@@ -15,5 +16,6 @@ template class RBoxConstraint<6>;
 
 template class RBoxConstraint<Eigen::Dynamic>;
 
-} // namespace statespace
+} // namespace uniform
+} // namespace constraint
 } // namespace aikido

--- a/src/constraint/uniform/RnConstantSampler.cpp
+++ b/src/constraint/uniform/RnConstantSampler.cpp
@@ -1,7 +1,8 @@
-#include <aikido/constraint/uniform/RnConstantSampler.hpp>
+#include "aikido/constraint/uniform/RnConstantSampler.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace uniform {
 
 template class RConstantSampler<0>;
 
@@ -15,5 +16,6 @@ template class RConstantSampler<6>;
 
 template class RConstantSampler<Eigen::Dynamic>;
 
+} // namespace uniform
 } // namespace constraint
 } // namespace aikido

--- a/src/constraint/uniform/SE2BoxConstraint.cpp
+++ b/src/constraint/uniform/SE2BoxConstraint.cpp
@@ -1,11 +1,11 @@
-#include <aikido/constraint/uniform/SE2BoxConstraint.hpp>
-
+#include "aikido/constraint/uniform/SE2BoxConstraint.hpp"
 #include <stdexcept>
-#include <aikido/constraint/uniform/SO2UniformSampler.hpp>
-#include <aikido/statespace/SO2.hpp>
+#include "aikido/constraint/uniform/SO2UniformSampler.hpp"
+#include "aikido/statespace/SO2.hpp"
 
 namespace aikido {
 namespace constraint {
+namespace uniform {
 
 using constraint::ConstraintType;
 
@@ -222,5 +222,6 @@ Eigen::Vector2d SE2BoxConstraint::getUpperLimits() const
   return mUpperLimits.tail<2>();
 }
 
-} // namespace statespace
+} // namespace uniform
+} // namespace constraint
 } // namespace aikido

--- a/src/constraint/uniform/SO2UniformSampler.cpp
+++ b/src/constraint/uniform/SO2UniformSampler.cpp
@@ -1,8 +1,9 @@
+#include "aikido/constraint/uniform/SO2UniformSampler.hpp"
 #include <cmath>
-#include <aikido/constraint/uniform/SO2UniformSampler.hpp>
 
 namespace aikido {
 namespace constraint {
+namespace uniform {
 
 //==============================================================================
 class SO2UniformSampleGenerator : public constraint::SampleGenerator
@@ -92,5 +93,6 @@ SO2UniformSampler::createSampleGenerator() const
       new SO2UniformSampleGenerator(mSpace, mRng->clone()));
 }
 
-} // namespace statespace
+} // namespace uniform
+} // namespace constraint
 } // namespace aikido

--- a/src/constraint/uniform/SO3UniformSampler.cpp
+++ b/src/constraint/uniform/SO3UniformSampler.cpp
@@ -1,8 +1,9 @@
+#include "aikido/constraint/uniform/SO3UniformSampler.hpp"
 #include <cmath>
-#include <aikido/constraint/uniform/SO3UniformSampler.hpp>
 
 namespace aikido {
 namespace constraint {
+namespace uniform {
 
 //==============================================================================
 class SO3UniformSampleGenerator : public constraint::SampleGenerator
@@ -97,5 +98,6 @@ SO3UniformSampler::createSampleGenerator() const
       new SO3UniformSampleGenerator(mSpace, mRng->clone()));
 }
 
-} // namespace statespace
+} // namespace uniform
+} // namespace constraint
 } // namespace aikido

--- a/src/planner/ompl/dart.cpp
+++ b/src/planner/ompl/dart.cpp
@@ -1,4 +1,4 @@
-#include <aikido/constraint/JointStateSpaceHelpers.hpp>
+#include <aikido/constraint/dart/JointStateSpaceHelpers.hpp>
 #include <aikido/distance/defaults.hpp>
 #include <aikido/planner/ompl/Planner.hpp>
 #include <aikido/planner/ompl/dart.hpp>
@@ -21,13 +21,14 @@ namespace ompl {
 
   // State sampler
   auto sampler
-      = constraint::createSampleableBounds(_stateSpace, std::move(_rng));
+      = constraint::dart::createSampleableBounds(_stateSpace, std::move(_rng));
 
   // Bounds constraint
-  auto boundsConstraint = constraint::createTestableBounds(_stateSpace);
+  auto boundsConstraint = constraint::dart::createTestableBounds(_stateSpace);
 
   // Projectable constraint - project to statespace
-  auto boundsProjection = constraint::createProjectableBounds(_stateSpace);
+  auto boundsProjection
+      = constraint::dart::createProjectableBounds(_stateSpace);
 
   // Interpolator
   auto interpolator

--- a/src/planner/vectorfield/BodyNodePoseVectorField.cpp
+++ b/src/planner/vectorfield/BodyNodePoseVectorField.cpp
@@ -1,5 +1,4 @@
 #include <aikido/common/StepSequence.hpp>
-#include <aikido/constraint/JointStateSpaceHelpers.hpp>
 #include <aikido/planner/vectorfield/BodyNodePoseVectorField.hpp>
 #include <aikido/planner/vectorfield/VectorFieldUtil.hpp>
 #include "detail/VectorFieldPlannerExceptions.hpp"

--- a/src/planner/vectorfield/VectorFieldPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldPlanner.cpp
@@ -178,10 +178,10 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
       jointLimitTolerance);
 
   auto compoundConstraint
-      = std::make_shared<aikido::constraint::TestableIntersection>(stateSpace);
+      = std::make_shared<constraint::TestableIntersection>(stateSpace);
   compoundConstraint->addConstraint(constraint);
   compoundConstraint->addConstraint(
-      aikido::constraint::dart::createTestableBounds(stateSpace));
+      constraint::dart::createTestableBounds(stateSpace));
 
   auto startState
       = stateSpace->getScopedStateFromMetaSkeleton(metaskeleton.get());
@@ -231,7 +231,7 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorPose(
       = std::make_shared<aikido::constraint::TestableIntersection>(stateSpace);
   compoundConstraint->addConstraint(constraint);
   compoundConstraint->addConstraint(
-      aikido::constraint::dart::createTestableBounds(stateSpace));
+      constraint::dart::createTestableBounds(stateSpace));
 
   auto startState
       = stateSpace->getScopedStateFromMetaSkeleton(metaskeleton.get());

--- a/src/planner/vectorfield/VectorFieldPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldPlanner.cpp
@@ -1,6 +1,6 @@
 #include <boost/numeric/odeint.hpp>
-#include <aikido/constraint/JointStateSpaceHelpers.hpp>
 #include <aikido/constraint/TestableIntersection.hpp>
+#include <aikido/constraint/dart/JointStateSpaceHelpers.hpp>
 #include <aikido/planner/vectorfield/MoveEndEffectorOffsetVectorField.hpp>
 #include <aikido/planner/vectorfield/MoveEndEffectorPoseVectorField.hpp>
 #include <aikido/planner/vectorfield/VectorFieldPlanner.hpp>
@@ -181,7 +181,7 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
       = std::make_shared<aikido::constraint::TestableIntersection>(stateSpace);
   compoundConstraint->addConstraint(constraint);
   compoundConstraint->addConstraint(
-      aikido::constraint::createTestableBounds(stateSpace));
+      aikido::constraint::dart::createTestableBounds(stateSpace));
 
   auto startState
       = stateSpace->getScopedStateFromMetaSkeleton(metaskeleton.get());
@@ -231,7 +231,7 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorPose(
       = std::make_shared<aikido::constraint::TestableIntersection>(stateSpace);
   compoundConstraint->addConstraint(constraint);
   compoundConstraint->addConstraint(
-      aikido::constraint::createTestableBounds(stateSpace));
+      aikido::constraint::dart::createTestableBounds(stateSpace));
 
   auto startState
       = stateSpace->getScopedStateFromMetaSkeleton(metaskeleton.get());

--- a/src/rviz/InteractiveMarkerViewer.cpp
+++ b/src/rviz/InteractiveMarkerViewer.cpp
@@ -61,13 +61,10 @@ FrameMarkerPtr InteractiveMarkerViewer::addFrame(
 
 //==============================================================================
 TSRMarkerPtr InteractiveMarkerViewer::addTSRMarker(
-    const aikido::constraint::dart::TSR& tsr,
-    int nSamples,
-    const std::string& basename)
+    const constraint::dart::TSR& tsr, int nSamples, const std::string& basename)
 {
   using dart::dynamics::Frame;
   using dart::dynamics::SimpleFrame;
-  using aikido::constraint::dart::TSR;
 
   auto sampler = tsr.createSampleGenerator();
   auto state = tsr.getSE3()->createState();

--- a/src/rviz/InteractiveMarkerViewer.cpp
+++ b/src/rviz/InteractiveMarkerViewer.cpp
@@ -61,13 +61,13 @@ FrameMarkerPtr InteractiveMarkerViewer::addFrame(
 
 //==============================================================================
 TSRMarkerPtr InteractiveMarkerViewer::addTSRMarker(
-    const aikido::constraint::TSR& tsr,
+    const aikido::constraint::dart::TSR& tsr,
     int nSamples,
     const std::string& basename)
 {
   using dart::dynamics::Frame;
   using dart::dynamics::SimpleFrame;
-  using aikido::constraint::TSR;
+  using aikido::constraint::dart::TSR;
 
   auto sampler = tsr.createSampleGenerator();
   auto state = tsr.getSE3()->createState();

--- a/tests/constraint/test_CartesianProductProjectable.cpp
+++ b/tests/constraint/test_CartesianProductProjectable.cpp
@@ -10,8 +10,8 @@ using aikido::constraint::ProjectablePtr;
 using aikido::statespace::CartesianProduct;
 using aikido::statespace::R2;
 using aikido::statespace::R3;
-using aikido::constraint::R2BoxConstraint;
-using aikido::constraint::R3BoxConstraint;
+using aikido::constraint::uniform::R2BoxConstraint;
+using aikido::constraint::uniform::R3BoxConstraint;
 
 class CartesianProductProjectableTest : public testing::Test
 {

--- a/tests/constraint/test_CartesianProductTestable.cpp
+++ b/tests/constraint/test_CartesianProductTestable.cpp
@@ -14,7 +14,7 @@ using aikido::statespace::SO2;
 using aikido::statespace::R3;
 using aikido::constraint::TestablePtr;
 using aikido::constraint::Testable;
-using aikido::constraint::R3BoxConstraint;
+using aikido::constraint::uniform::R3BoxConstraint;
 
 class CartesianProductTestableTest : public testing::Test
 {

--- a/tests/constraint/test_CollisionFree.cpp
+++ b/tests/constraint/test_CollisionFree.cpp
@@ -1,6 +1,6 @@
 #include <dart/dart.hpp>
 #include <gtest/gtest.h>
-#include <aikido/constraint/CollisionFree.hpp>
+#include <aikido/constraint/dart/CollisionFree.hpp>
 #include <aikido/statespace/Rn.hpp>
 #include <aikido/statespace/SE3.hpp>
 #include <aikido/statespace/SO2.hpp>
@@ -8,8 +8,8 @@
 
 using aikido::statespace::dart::MetaSkeletonStateSpace;
 using aikido::statespace::dart::MetaSkeletonStateSpacePtr;
-using aikido::constraint::CollisionFree;
-using aikido::constraint::CollisionFreeOutcome;
+using aikido::constraint::dart::CollisionFree;
+using aikido::constraint::dart::CollisionFreeOutcome;
 using aikido::constraint::TestableOutcome;
 using aikido::statespace::SO2;
 using aikido::statespace::SE3;

--- a/tests/constraint/test_CyclicSampleable.cpp
+++ b/tests/constraint/test_CyclicSampleable.cpp
@@ -8,7 +8,7 @@
 #include <aikido/statespace/StateSpace.hpp>
 
 using aikido::statespace::SO2;
-using aikido::constraint::SO2UniformSampler;
+using aikido::constraint::uniform::SO2UniformSampler;
 using aikido::statespace::R1;
 using aikido::statespace::R2;
 using aikido::constraint::CyclicSampleable;

--- a/tests/constraint/test_DartHelpers.cpp
+++ b/tests/constraint/test_DartHelpers.cpp
@@ -1,8 +1,8 @@
 #include <dart/common/StlHelpers.hpp>
 #include <dart/dynamics/dynamics.hpp>
 #include <gtest/gtest.h>
-#include <aikido/constraint/JointStateSpaceHelpers.hpp>
 #include <aikido/constraint/Satisfied.hpp>
+#include <aikido/constraint/dart/JointStateSpaceHelpers.hpp>
 #include <aikido/statespace/dart/RnJoint.hpp>
 #include <aikido/statespace/dart/SO2Joint.hpp>
 #include <aikido/statespace/dart/SO3Joint.hpp>
@@ -24,10 +24,10 @@ using aikido::statespace::dart::SO2Joint;
 using aikido::statespace::dart::SO3Joint;
 using aikido::common::RNGWrapper;
 
-using aikido::constraint::createDifferentiableBoundsFor;
-using aikido::constraint::createProjectableBoundsFor;
-using aikido::constraint::createTestableBoundsFor;
-using aikido::constraint::createSampleableBoundsFor;
+using aikido::constraint::dart::createDifferentiableBoundsFor;
+using aikido::constraint::dart::createProjectableBoundsFor;
+using aikido::constraint::dart::createTestableBoundsFor;
+using aikido::constraint::dart::createSampleableBoundsFor;
 
 //==============================================================================
 class RnJointHelpersTests : public ::testing::Test

--- a/tests/constraint/test_DifferentiableIntersection.cpp
+++ b/tests/constraint/test_DifferentiableIntersection.cpp
@@ -2,12 +2,12 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 #include <aikido/constraint/DifferentiableIntersection.hpp>
-#include <aikido/constraint/TSR.hpp>
+#include <aikido/constraint/dart/TSR.hpp>
 #include <aikido/statespace/Rn.hpp>
 #include "PolynomialConstraint.hpp"
 
 using aikido::constraint::DifferentiableIntersection;
-using aikido::constraint::TSR;
+using aikido::constraint::dart::TSR;
 using aikido::constraint::DifferentiablePtr;
 
 using aikido::statespace::R1;

--- a/tests/constraint/test_FrameDifferentiable.cpp
+++ b/tests/constraint/test_FrameDifferentiable.cpp
@@ -1,7 +1,7 @@
 #include <aikido/common/RNG.hpp>
-#include <aikido/constraint/FrameDifferentiable.hpp>
 #include <aikido/constraint/Satisfied.hpp>
-#include <aikido/constraint/TSR.hpp>
+#include <aikido/constraint/dart/FrameDifferentiable.hpp>
+#include <aikido/constraint/dart/TSR.hpp>
 #include <aikido/statespace/Rn.hpp>
 #include <aikido/statespace/SE3.hpp>
 #include <aikido/statespace/SO2.hpp>
@@ -10,8 +10,8 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
-using aikido::constraint::FrameDifferentiable;
-using aikido::constraint::TSR;
+using aikido::constraint::dart::FrameDifferentiable;
+using aikido::constraint::dart::TSR;
 using aikido::statespace::SE3;
 using aikido::statespace::SO2;
 using aikido::statespace::dart::MetaSkeletonStateSpace;

--- a/tests/constraint/test_FramePairDifferentiable.cpp
+++ b/tests/constraint/test_FramePairDifferentiable.cpp
@@ -1,7 +1,7 @@
 #include <aikido/common/RNG.hpp>
-#include <aikido/constraint/FramePairDifferentiable.hpp>
 #include <aikido/constraint/Satisfied.hpp>
-#include <aikido/constraint/TSR.hpp>
+#include <aikido/constraint/dart/FramePairDifferentiable.hpp>
+#include <aikido/constraint/dart/TSR.hpp>
 #include <aikido/statespace/Rn.hpp>
 #include <aikido/statespace/SE3.hpp>
 #include <aikido/statespace/SO2.hpp>
@@ -10,8 +10,8 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
-using aikido::constraint::FramePairDifferentiable;
-using aikido::constraint::TSR;
+using aikido::constraint::dart::FramePairDifferentiable;
+using aikido::constraint::dart::TSR;
 using aikido::statespace::dart::MetaSkeletonStateSpace;
 using aikido::statespace::dart::MetaSkeletonStateSpacePtr;
 using aikido::statespace::SO2;

--- a/tests/constraint/test_FrameTestable.cpp
+++ b/tests/constraint/test_FrameTestable.cpp
@@ -1,11 +1,11 @@
 #include <gtest/gtest.h>
-#include <aikido/constraint/FrameTestable.hpp>
+#include <aikido/constraint/dart/FrameTestable.hpp>
 #include <aikido/statespace/SE3.hpp>
 #include <aikido/statespace/SO2.hpp>
 #include "MockConstraints.hpp"
 
 using aikido::constraint::DefaultTestableOutcome;
-using aikido::constraint::FrameTestable;
+using aikido::constraint::dart::FrameTestable;
 using aikido::constraint::Testable;
 using aikido::constraint::TestablePtr;
 using aikido::statespace::dart::MetaSkeletonStateSpace;

--- a/tests/constraint/test_InverseKinematicsSampleable.cpp
+++ b/tests/constraint/test_InverseKinematicsSampleable.cpp
@@ -4,8 +4,8 @@
 #include <aikido/common/RNG.hpp>
 #include <aikido/constraint/CyclicSampleable.hpp>
 #include <aikido/constraint/FiniteSampleable.hpp>
-#include <aikido/constraint/InverseKinematicsSampleable.hpp>
-#include <aikido/constraint/TSR.hpp>
+#include <aikido/constraint/dart/InverseKinematicsSampleable.hpp>
+#include <aikido/constraint/dart/TSR.hpp>
 #include <aikido/statespace/Rn.hpp>
 #include <aikido/statespace/SE3.hpp>
 #include <aikido/statespace/SO2.hpp>
@@ -14,13 +14,13 @@
 
 using aikido::statespace::R2;
 using aikido::constraint::FiniteSampleable;
-using aikido::constraint::InverseKinematicsSampleable;
+using aikido::constraint::dart::InverseKinematicsSampleable;
 using aikido::constraint::CyclicSampleable;
 using aikido::statespace::SE3;
 using aikido::statespace::SO2;
 using dart::dynamics::FreeJoint;
 using aikido::constraint::SampleGenerator;
-using aikido::constraint::TSR;
+using aikido::constraint::dart::TSR;
 using aikido::common::RNGWrapper;
 using aikido::common::RNG;
 using aikido::statespace::dart::MetaSkeletonStateSpace;

--- a/tests/constraint/test_NewtonsMethodProjectable.cpp
+++ b/tests/constraint/test_NewtonsMethodProjectable.cpp
@@ -1,6 +1,6 @@
 #include <aikido/constraint/NewtonsMethodProjectable.hpp>
 #include <aikido/constraint/Satisfied.hpp>
-#include <aikido/constraint/TSR.hpp>
+#include <aikido/constraint/dart/TSR.hpp>
 #include "PolynomialConstraint.hpp"
 
 #include <aikido/statespace/Rn.hpp>
@@ -10,7 +10,7 @@
 
 using aikido::constraint::NewtonsMethodProjectable;
 using aikido::constraint::Satisfied;
-using aikido::constraint::TSR;
+using aikido::constraint::dart::TSR;
 using aikido::statespace::R1;
 using aikido::statespace::R3;
 

--- a/tests/constraint/test_Projectable.cpp
+++ b/tests/constraint/test_Projectable.cpp
@@ -10,7 +10,7 @@ using aikido::constraint::CartesianProductProjectable;
 using aikido::constraint::ProjectablePtr;
 using aikido::statespace::CartesianProduct;
 using aikido::statespace::R3;
-using aikido::constraint::R3BoxConstraint;
+using aikido::constraint::uniform::R3BoxConstraint;
 
 TEST(Project, ProjectInPlaceDefault)
 {

--- a/tests/constraint/test_RnBoxConstraint.cpp
+++ b/tests/constraint/test_RnBoxConstraint.cpp
@@ -6,8 +6,8 @@
 
 using aikido::statespace::R2;
 using aikido::statespace::Rn;
-using aikido::constraint::R2BoxConstraint;
-using aikido::constraint::RnBoxConstraint;
+using aikido::constraint::uniform::R2BoxConstraint;
+using aikido::constraint::uniform::RnBoxConstraint;
 using aikido::constraint::ConstraintType;
 using aikido::constraint::SampleGenerator;
 using aikido::distance::R2Euclidean;

--- a/tests/constraint/test_RnConstantSampler.cpp
+++ b/tests/constraint/test_RnConstantSampler.cpp
@@ -12,7 +12,8 @@ void testConstructorThrowsForNullStateSpace()
 {
   EXPECT_THROW(
       {
-        constraint::RConstantSampler<N>(nullptr, Eigen::Matrix<double, N, 1>());
+        constraint::uniform::RConstantSampler<N>(
+            nullptr, Eigen::Matrix<double, N, 1>());
       },
       std::invalid_argument);
 }
@@ -37,7 +38,7 @@ void testConstructorThrowsForWrongSizeValue()
   {
     EXPECT_DEATH(
         {
-          constraint::RConstantSampler<N>(
+          constraint::uniform::RConstantSampler<N>(
               std::make_shared<statespace::R<N>>(),
               Eigen::VectorXd::Zero(N + 1));
         },
@@ -49,7 +50,7 @@ void testConstructorThrowsForWrongSizeValue()
   {
     EXPECT_THROW(
         {
-          constraint::RConstantSampler<N>(
+          constraint::uniform::RConstantSampler<N>(
               std::make_shared<statespace::R<N>>(3), Eigen::VectorXd::Zero(4));
         },
         std::invalid_argument);
@@ -77,8 +78,8 @@ void testSampleGenerator(int dimension = N)
   auto stateSpace = std::make_shared<statespace::R<N>>(dimension);
   EXPECT_EQ(stateSpace->getDimension(), dimension);
 
-  auto sampler
-      = std::make_shared<constraint::RConstantSampler<N>>(stateSpace, value);
+  auto sampler = std::make_shared<constraint::uniform::RConstantSampler<N>>(
+      stateSpace, value);
   EXPECT_EQ(sampler->getStateSpace(), stateSpace);
   EXPECT_TRUE(
       tests::CompareEigenMatrices(sampler->getConstantValue(), value, 1e-6));

--- a/tests/constraint/test_SE2BoxConstraint.cpp
+++ b/tests/constraint/test_SE2BoxConstraint.cpp
@@ -5,7 +5,7 @@
 #include "SampleGeneratorCoverage.hpp"
 
 using aikido::statespace::SE2;
-using aikido::constraint::SE2BoxConstraint;
+using aikido::constraint::uniform::SE2BoxConstraint;
 using aikido::constraint::ConstraintType;
 using aikido::constraint::SampleGenerator;
 using aikido::distance::SE2Weighted;

--- a/tests/constraint/test_SO2UniformSampler.cpp
+++ b/tests/constraint/test_SO2UniformSampler.cpp
@@ -5,7 +5,7 @@
 #include "SampleGeneratorCoverage.hpp"
 
 using aikido::statespace::SO2;
-using aikido::constraint::SO2UniformSampler;
+using aikido::constraint::uniform::SO2UniformSampler;
 using aikido::constraint::SampleGenerator;
 using aikido::common::RNG;
 using aikido::common::RNGWrapper;

--- a/tests/constraint/test_SO3UniformSampler.cpp
+++ b/tests/constraint/test_SO3UniformSampler.cpp
@@ -5,7 +5,7 @@
 #include "SampleGeneratorCoverage.hpp"
 
 using aikido::statespace::SO3;
-using aikido::constraint::SO3UniformSampler;
+using aikido::constraint::uniform::SO3UniformSampler;
 using aikido::constraint::SampleGenerator;
 using aikido::distance::SO3Angular;
 using aikido::common::RNG;

--- a/tests/constraint/test_SampleableSubspace.cpp
+++ b/tests/constraint/test_SampleableSubspace.cpp
@@ -12,9 +12,9 @@ using aikido::constraint::CartesianProductSampleable;
 using aikido::constraint::SampleablePtr;
 using aikido::statespace::CartesianProduct;
 using aikido::statespace::SO2;
-using aikido::constraint::SO2UniformSampler;
+using aikido::constraint::uniform::SO2UniformSampler;
 using aikido::statespace::R3;
-using aikido::constraint::R3BoxConstraint;
+using aikido::constraint::uniform::R3BoxConstraint;
 using aikido::common::RNG;
 using aikido::common::RNGWrapper;
 

--- a/tests/constraint/test_TSR.cpp
+++ b/tests/constraint/test_TSR.cpp
@@ -5,10 +5,10 @@
 #include <gtest/gtest.h>
 #include <aikido/common/RNG.hpp>
 #include <aikido/constraint/Differentiable.hpp>
-#include <aikido/constraint/TSR.hpp>
+#include <aikido/constraint/dart/TSR.hpp>
 #include <aikido/statespace/SE3.hpp>
 
-using aikido::constraint::TSR;
+using aikido::constraint::dart::TSR;
 using aikido::constraint::ConstraintType;
 using aikido::statespace::SE3;
 using aikido::common::RNGWrapper;

--- a/tests/planner/ompl/OMPLTestHelpers.hpp
+++ b/tests/planner/ompl/OMPLTestHelpers.hpp
@@ -5,8 +5,7 @@
 #include <gtest/gtest.h>
 #include <ompl/base/State.h>
 #include <aikido/common/RNG.hpp>
-#include <aikido/constraint/JointStateSpaceHelpers.hpp>
-#include <aikido/constraint/Testable.hpp>
+#include <aikido/constraint.hpp>
 #include <aikido/distance/defaults.hpp>
 #include <aikido/planner/ompl/GeometricStateSpace.hpp>
 #include <aikido/statespace/GeodesicInterpolator.hpp>

--- a/tests/planner/ompl/test_OMPLPlanner.cpp
+++ b/tests/planner/ompl/test_OMPLPlanner.cpp
@@ -1,9 +1,6 @@
 #include <ompl/geometric/planners/rrt/RRTConnect.h>
 #include <aikido/common/StepSequence.hpp>
-#include <aikido/constraint/CartesianProductSampleable.hpp>
-#include <aikido/constraint/CartesianProductTestable.hpp>
-#include <aikido/constraint/JointStateSpaceHelpers.hpp>
-#include <aikido/constraint/uniform/RnBoxConstraint.hpp>
+#include <aikido/constraint.hpp>
 #include <aikido/planner/ompl/CRRT.hpp>
 #include <aikido/planner/ompl/CRRTConnect.hpp>
 #include <aikido/planner/ompl/MotionValidator.hpp>

--- a/tests/planner/ompl/test_OMPLSimplifier.cpp
+++ b/tests/planner/ompl/test_OMPLSimplifier.cpp
@@ -1,9 +1,5 @@
 #include <dart/dart.hpp>
 #include <aikido/common/StepSequence.hpp>
-#include <aikido/constraint/CartesianProductSampleable.hpp>
-#include <aikido/constraint/CartesianProductTestable.hpp>
-#include <aikido/constraint/JointStateSpaceHelpers.hpp>
-#include <aikido/constraint/uniform/RnBoxConstraint.hpp>
 #include <aikido/planner/ompl/MotionValidator.hpp>
 #include <aikido/planner/ompl/Planner.hpp>
 #include <aikido/trajectory/Interpolated.hpp>

--- a/tests/planner/ompl/test_TrajectoryConversions.cpp
+++ b/tests/planner/ompl/test_TrajectoryConversions.cpp
@@ -1,8 +1,4 @@
 #include <aikido/common/StepSequence.hpp>
-#include <aikido/constraint/CartesianProductSampleable.hpp>
-#include <aikido/constraint/CartesianProductTestable.hpp>
-#include <aikido/constraint/JointStateSpaceHelpers.hpp>
-#include <aikido/constraint/uniform/RnBoxConstraint.hpp>
 #include <aikido/planner/ompl/MotionValidator.hpp>
 #include <aikido/planner/ompl/Planner.hpp>
 #include "../../constraint/MockConstraints.hpp"

--- a/tests/planner/test_SnapPlanner.cpp
+++ b/tests/planner/test_SnapPlanner.cpp
@@ -1,7 +1,6 @@
 #include <tuple>
 #include <dart/dart.hpp>
 #include <gtest/gtest.h>
-#include <aikido/constraint/CollisionFree.hpp>
 #include <aikido/constraint/Testable.hpp>
 #include <aikido/distance/defaults.hpp>
 #include <aikido/planner/PlanningResult.hpp>
@@ -18,7 +17,6 @@ class SnapPlannerTest : public ::testing::Test
 {
 public:
   using FCLCollisionDetector = dart::collision::FCLCollisionDetector;
-  using CollisionFree = aikido::constraint::CollisionFree;
   using DistanceMetric = aikido::distance::DistanceMetric;
   using MetaSkeletonStateSpace
       = aikido::statespace::dart::MetaSkeletonStateSpace;

--- a/tests/planner/vectorfield/test_VectorFieldPlanner.cpp
+++ b/tests/planner/vectorfield/test_VectorFieldPlanner.cpp
@@ -1,7 +1,6 @@
 ﻿#include <gtest/gtest.h>
 #include <tuple>
 #include <dart/dart.hpp>
-#include <aikido/constraint/CollisionFree.hpp>
 #include <aikido/constraint/Testable.hpp>
 #include <aikido/distance/defaults.hpp>
 #include <aikido/planner/vectorfield/MoveEndEffectorOffsetVectorField.hpp>
@@ -19,7 +18,6 @@ class VectorFieldPlannerTest : public ::testing::Test
 {
 public:
   using FCLCollisionDetector = dart::collision::FCLCollisionDetector;
-  using CollisionFree = aikido::constraint::CollisionFree;
   using DistanceMetric = aikido::distance::DistanceMetric;
   using MetaSkeletonStateSpacePtr
       = aikido::statespace::dart::MetaSkeletonStateSpacePtr;


### PR DESCRIPTION
- Creates the `constraint::uniform` namespace to mirror the existing directory structure
- Resolves #85 by introducing a `constraint::dart` namespace

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
