### PR TITLE
Skip deploy for cron build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,4 +54,4 @@ deploy:
   verbose: true
   on:
     branch: master
-    condition: $BUILD_TYPE = Release
+    condition: "[ $BUILD_TYPE = Release ] && ! [ $TRAVIS_EVENT_TYPE = cron ]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,4 +54,4 @@ deploy:
   verbose: true
   on:
     branch: master
-    condition: "$BUILD_TYPE -eq Release -a  $TRAVIS_EVENT_TYPE -ne cron"
+    condition: $BUILD_TYPE == Release && $TRAVIS_EVENT_TYPE != cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,4 +54,4 @@ deploy:
   verbose: true
   on:
     branch: master
-    condition: "[ $BUILD_TYPE = Release ] && ! [ $TRAVIS_EVENT_TYPE = cron ]"
+    condition: "$BUILD_TYPE -eq Release -a  $TRAVIS_EVENT_TYPE -ne cron"


### PR DESCRIPTION
Based on the following references, this PR disables deploy for Travis CI's cron builds. But, I'm not sure if the syntax is correct though. Here is the instruction for `condition`:
> condition: deploy when a single bash condition evaluates to true. This must be a string value, and is equivalant to if [[ <condition> ]]; then <deploy>; fi. For example, $CC = gcc.

Another possible expression would be:
```shell
condition: "$BUILD_TYPE -eq Release -a  $TRAVIS_EVENT_TYPE -ne cron"
```

References:
* https://docs.travis-ci.com/user/deployment
* https://docs.travis-ci.com/user/environment-variables/
* https://stackoverflow.com/questions/3826425/how-to-represent-multiple-conditions-in-a-shell-if-statement