### PR TITLE
Fix clang warnings

### DIFF
--- a/src/common/StepSequence.cpp
+++ b/src/common/StepSequence.cpp
@@ -6,8 +6,6 @@
 namespace aikido {
 namespace common {
 
-constexpr double precision = 1e-7;
-
 //==============================================================================
 StepSequence::StepSequence(
     double stepSize,

--- a/src/control/KinematicSimulationTrajectoryExecutor.cpp
+++ b/src/control/KinematicSimulationTrajectoryExecutor.cpp
@@ -79,9 +79,8 @@ std::future<void> KinematicSimulationTrajectoryExecutor::execute(
     mPromise.reset(new std::promise<void>());
 
     mTraj = std::move(traj);
-    mStateSpace = std::move(
-        std::dynamic_pointer_cast<const MetaSkeletonStateSpace>(
-            mTraj->getStateSpace()));
+    mStateSpace = std::dynamic_pointer_cast<const MetaSkeletonStateSpace>(
+        mTraj->getStateSpace());
     mInProgress = true;
     mExecutionStartTime = std::chrono::system_clock::now();
   }

--- a/tests/control/test_InstantaneousTrajectoryExecutor.cpp
+++ b/tests/control/test_InstantaneousTrajectoryExecutor.cpp
@@ -23,7 +23,6 @@ using ::dart::dynamics::BodyNodePtr;
 using ::dart::dynamics::RevoluteJoint;
 
 const static std::chrono::milliseconds waitTime{0};
-const static std::chrono::milliseconds stepTime{0};
 
 class InstantaneousTrajectoryExecutorTest : public testing::Test
 {


### PR DESCRIPTION
- Remove unnecessary `std::move` introduced by #337 
- Remove unused `precision` from `StepSequence`, as suggested in #220 
- Remove unused `stepTime` from `test_InstantaneousTrajectoryExecutor`

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
