### PR TITLE
Add missing ^ in generated navtree.js for external links.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,14 +227,20 @@ if(${DOXYGEN_FOUND})
   # Create the "docs" target that runs Doxygen.
   add_custom_command(OUTPUT "${DOXYGEN_HTML_INDEX}"
     COMMAND "${DOXYGEN_EXECUTABLE}"
+
+    # Fix missing ^ in generated navtree.js for external DART link
+    COMMAND sed -i s:\"http:\"\^http:g ${DOXYGEN_OUTPUT_ROOT}/navtree.js
+
     # Strip path prefix from all paths in aikido.tag
     COMMAND ${CMAKE_COMMAND} -E echo "Stripping paths from"
         "${DOXYGEN_GENERATE_TAGFILE}"
     COMMAND sed -i s:${DOXYGEN_STRIP_FROM_PATH}::g ${DOXYGEN_GENERATE_TAGFILE}
+
     # Strip all doxygen="path" HTML tags
     COMMAND ${CMAKE_COMMAND} -E echo "Stripping Doxygen HTML tags"
     COMMAND find "${DOXYGEN_OUTPUT_ROOT}" -type f -name "*.html"
         -exec sed -i 's: doxygen=\"[^\"]*\"::g' {} \\$<SEMICOLON>
+
     DEPENDS "${DOXYGEN_WORKING_DIR}/Doxyfile"
     WORKING_DIRECTORY "${DOXYGEN_WORKING_DIR}"
   )


### PR DESCRIPTION
The external link to DART in Doxygen's tree view (left navigation) is generated incorrectly. When on a page that is not at the top level of `aikido/master` (e.g. [this](https://personalrobotics.github.io/aikido/master/d0/d16/md_include_aikido_statespace_README.html)), the resulting link points to `https://personalrobotics.github.io/aikido/master/http://dartsim.github.io/dart/v6.3.0/index.html` rather than `http://dartsim.github.io/dart/v6.3.0/index.html`.

The Doxygen-generated JavaScript that generates the side navigation [`navtree.js`](https://github.com/doxygen/doxygen/blob/dc11a3f6a207b3539ffe55a20164d4a90961ff30/templates/html/navtree.js#L209) suggests that if the first character of the link is `^`, then the remainder of the link will be taken (rather than blindly adding a relative path `../..` to the front of the already-complete URL). This PR simply replaces `http` with `^http` in `navtree.js`. At some point, maybe all the ridiculous post-processing hacks I've accumulated should go into its own script.