### PR TITLE
Disable OMPL planners for OMPL (>= 1.2.0) + GCC

### DIFF
--- a/src/planner/ompl/CMakeLists.txt
+++ b/src/planner/ompl/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
         "For details, please see: "
         " https://github.com/personalrobotics/aikido/issues/363"
     )
+    return()
   endif()
 endif()
 

--- a/src/planner/ompl/CMakeLists.txt
+++ b/src/planner/ompl/CMakeLists.txt
@@ -1,7 +1,7 @@
 #==============================================================================
 # Dependencies
 #
-find_package(ompl QUIET)
+find_package(OMPL QUIET)
 aikido_check_package(OMPL "planner_ompl" "OMPL")
 
 if(CMAKE_COMPILER_IS_GNUCXX)

--- a/src/planner/ompl/CMakeLists.txt
+++ b/src/planner/ompl/CMakeLists.txt
@@ -1,8 +1,17 @@
 #==============================================================================
 # Dependencies
 #
-find_package(OMPL QUIET)
+find_package(ompl REQUIRED)
 aikido_check_package(OMPL "planner_ompl" "OMPL")
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+  if(OMPL_VERSION VERSION_GREATER 1.2.0 OR OMPL_VERSION VERSION_EQUAL 1.2.0)
+    message(STATUS "OMPL planners are disabled for OMPL (>=1.2.0) + GCC. "
+        "For details, please see: "
+        " https://github.com/personalrobotics/aikido/issues/363"
+    )
+  endif()
+endif()
 
 #==============================================================================
 # Libraries

--- a/src/planner/ompl/CMakeLists.txt
+++ b/src/planner/ompl/CMakeLists.txt
@@ -1,7 +1,7 @@
 #==============================================================================
 # Dependencies
 #
-find_package(ompl REQUIRED)
+find_package(ompl QUIET)
 aikido_check_package(OMPL "planner_ompl" "OMPL")
 
 if(CMAKE_COMPILER_IS_GNUCXX)


### PR DESCRIPTION
This is a temporary solution for the [test failures](https://github.com/personalrobotics/aikido/issues/363) with OMPL (>= 1.2.0) + GCC.

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
