### PR TITLE
Use "ompl" to find OMPL package

### DIFF
--- a/src/planner/ompl/CMakeLists.txt
+++ b/src/planner/ompl/CMakeLists.txt
@@ -1,7 +1,7 @@
 #==============================================================================
 # Dependencies
 #
-find_package(OMPL QUIET)
+find_package(ompl QUIET)
 aikido_check_package(OMPL "planner_ompl" "OMPL")
 
 #==============================================================================


### PR DESCRIPTION
This PR uses `ompl` instead of `OMPL` to find OMPL. This is because [OMPL changed the config file name from `ompl-config.cmake` to `omplConfig.cmake`](https://bitbucket.org/ompl/ompl/commits/a4612f15d931721e44de015df7b1bd5129836850) in version 1.3.2. CMake supports two patters for config names: X-config.cmake and XConfig.cmake (where X is the package name). The former pattern is not case sensitive so that we could find the package using either `x` or `X`, but the later pattern is case sensitive. That said, we should use `ompl` to be able to work over the two patterns. 

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
