### PR TITLE
Allow KinematicSimulationTrajectoryExecutor to execute trajectories containing subsets of the skeleton.

### DIFF
--- a/include/aikido/control/TrajectoryExecutor.hpp
+++ b/include/aikido/control/TrajectoryExecutor.hpp
@@ -3,6 +3,7 @@
 
 #include <chrono>
 #include <future>
+#include <set>
 #include "aikido/common/pointers.hpp"
 #include "aikido/trajectory/Trajectory.hpp"
 

--- a/src/control/InstantaneousTrajectoryExecutor.cpp
+++ b/src/control/InstantaneousTrajectoryExecutor.cpp
@@ -41,7 +41,7 @@ void InstantaneousTrajectoryExecutor::validate(
 
   // TODO: Delete this line once the skeleton is locked by isCompatible
   std::lock_guard<std::mutex> lock(mSkeleton->getMutex());
-  space->checkCompatibility(mSkeleton.get());
+  space->checkIfContained(mSkeleton.get());
 
   mValidatedTrajectories.emplace(traj);
 }

--- a/src/control/KinematicSimulationTrajectoryExecutor.cpp
+++ b/src/control/KinematicSimulationTrajectoryExecutor.cpp
@@ -58,7 +58,7 @@ void KinematicSimulationTrajectoryExecutor::validate(
 
   // TODO: Delete this line once the skeleton is locked by isCompatible
   std::lock_guard<std::mutex> lock(mSkeleton->getMutex());
-  space->checkCompatibility(mSkeleton.get());
+  space->checkIfContained(mSkeleton.get());
 
   mValidatedTrajectories.emplace(traj);
 }


### PR DESCRIPTION
This was introduced by #349.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
