### PR TITLE
Bugfix/planning locks

### DIFF
--- a/include/aikido/robot/ConcreteRobot.hpp
+++ b/include/aikido/robot/ConcreteRobot.hpp
@@ -224,6 +224,10 @@ public:
   void setCRRTPlannerParameters(
       const util::CRRTPlannerParameters& crrtParameters);
 
+  // Returns a pointer of the RNG belonging to this robot
+  // The ConcreteRobot is still responsible for cleaning this RNG, so use it only while the ConcreteRobot is alive!
+  aikido::common::RNG* getRNGPtr();
+
 private:
   // Named Configurations are read from a YAML file
   using ConfigurationMap

--- a/include/aikido/robot/util.hpp
+++ b/include/aikido/robot/util.hpp
@@ -24,14 +24,13 @@ namespace util {
 
 struct VectorFieldPlannerParameters
 {
-  VectorFieldPlannerParameters() = default;
   VectorFieldPlannerParameters(
-      double linearVelocity,
-      double negativeDistanceTolerance,
-      double positiveDistanceTolerance,
-      double initialStepSize,
-      double jointLimitTolerance,
-      double constraintCheckResolution,
+      double linearVelocity = 0.2,
+      double negativeDistanceTolerance = 0.001,
+      double positiveDistanceTolerance = 0.001,
+      double initialStepSize = 0.001,
+      double jointLimitTolerance = 1e-3,
+      double constraintCheckResolution = 1e-3,
       double linearGain = 1.0,
       double angularGain = 0.2,
       double timestep = 0.1)

--- a/src/constraint/dart/InverseKinematicsSampleable.cpp
+++ b/src/constraint/dart/InverseKinematicsSampleable.cpp
@@ -83,6 +83,12 @@ InverseKinematicsSampleable::InverseKinematicsSampleable(
     throw std::invalid_argument("InverseKinematics is nullptr.");
 
   const auto ikSkeleton = mInverseKinematics->getNode()->getSkeleton();
+
+  if (mInverseKinematics->getDofs().size() == 0)
+  {
+    throw std::invalid_argument("Zero degree of freedom for InverseKinematics solver.");
+  }
+
   for (const std::size_t dofIndex : mInverseKinematics->getDofs())
   {
     const auto dof = ikSkeleton->getDof(dofIndex);

--- a/src/constraint/dart/InverseKinematicsSampleable.cpp
+++ b/src/constraint/dart/InverseKinematicsSampleable.cpp
@@ -86,7 +86,8 @@ InverseKinematicsSampleable::InverseKinematicsSampleable(
 
   if (mInverseKinematics->getDofs().size() == 0)
   {
-    throw std::invalid_argument("Zero degree of freedom for InverseKinematics solver.");
+    throw std::invalid_argument(
+      "Zero degree of freedom for InverseKinematics solver.");
   }
 
   for (const std::size_t dofIndex : mInverseKinematics->getDofs())

--- a/src/planner/vectorfield/VectorFieldPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldPlanner.cpp
@@ -141,6 +141,11 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
     std::chrono::duration<double> timelimit,
     planner::PlanningResult* planningResult)
 {
+
+  // ensure that no two planners run at the same time
+  auto robot = metaskeleton->getBodyNode(0)->getSkeleton();
+  std::lock_guard<std::mutex> lock(robot->getMutex());
+
   if (minDistance < 0.)
   {
     std::stringstream ss;

--- a/src/robot/ConcreteRobot.cpp
+++ b/src/robot/ConcreteRobot.cpp
@@ -444,5 +444,9 @@ std::unique_ptr<common::RNG> ConcreteRobot::cloneRNG()
   return mRng->clone();
 }
 
+aikido::common::RNG* ConcreteRobot::getRNGPtr() {
+  return &*mRng;
+}
+
 } // namespace robot
 } // namespace aikido

--- a/src/robot/util.cpp
+++ b/src/robot/util.cpp
@@ -303,7 +303,7 @@ InterpolatedPtr planToTSRwithTrajectoryConstraint(
   std::shared_ptr<Sampleable> seedConstraint
       = std::move(createSampleableBounds(space, crrtParameters.rng->clone()));
 
-  // Create an IK solver with metaSkeleton dofs.
+  // Create an IK solver with metaSkeleton dofs
   auto ik = InverseKinematics::create(bodyNode);
   ik->setDofs(metaSkeleton->getDofs());
 

--- a/src/robot/util.cpp
+++ b/src/robot/util.cpp
@@ -378,9 +378,6 @@ trajectory::TrajectoryPtr planToEndEffectorOffset(
     const CRRTPlannerParameters& crrtParameters)
 {
 
-  auto robot = metaSkeleton->getBodyNode(0)->getSkeleton();
-  std::lock_guard<std::mutex> lock(robot->getMutex());
-
   auto saver = MetaSkeletonStateSaver(metaSkeleton);
   DART_UNUSED(saver);
 

--- a/src/robot/util.cpp
+++ b/src/robot/util.cpp
@@ -180,13 +180,17 @@ InterpolatedPtr planToTSR(
     double timelimit,
     std::size_t maxNumTrials)
 {
+  // Create an IK solver with metaSkeleton dofs.
+  auto ik = InverseKinematics::create(bn);
+  ik->setDofs(metaSkeleton->getDofs());
+
   // Convert TSR constraint into IK constraint
   InverseKinematicsSampleable ikSampleable(
       space,
       metaSkeleton,
       tsr,
       createSampleableBounds(space, rng->clone()),
-      InverseKinematics::create(bn),
+      ik,
       maxNumTrials);
 
   auto generator = ikSampleable.createSampleGenerator();
@@ -195,8 +199,6 @@ InterpolatedPtr planToTSR(
   auto goalState = space->createState();
 
   auto startState = space->getScopedStateFromMetaSkeleton(metaSkeleton.get());
-
-  Eigen::VectorXd goal;
 
   // TODO: Change this to timelimit once we use a fail-fast planner
   double timelimitPerSample = timelimit / maxNumTrials;
@@ -218,8 +220,6 @@ InterpolatedPtr planToTSR(
       bool sampled = generator->sample(goalState);
       if (!sampled)
         continue;
-
-      space->convertStateToPositions(goalState, goal);
 
       // Set to start state
       space->setState(metaSkeleton.get(), startState);
@@ -303,8 +303,9 @@ InterpolatedPtr planToTSRwithTrajectoryConstraint(
   std::shared_ptr<Sampleable> seedConstraint
       = std::move(createSampleableBounds(space, crrtParameters.rng->clone()));
 
-  // crate IK
+  // Create an IK solver with metaSkeleton dofs.
   auto ik = InverseKinematics::create(bodyNode);
+  ik->setDofs(metaSkeleton->getDofs());
 
   // create goal sampleable
   auto goalSampleable = std::make_shared<InverseKinematicsSampleable>(


### PR DESCRIPTION
Fixed locking issue where planner locked the robot and then called another planner which tried to lock it again.

Exposed the pointer to the ConcreteRobot's RNG, so we can use it for the CRRTPlannerParameters RNG.