### PR TITLE
exposed RNG pointer of ConcreteRobot

### DIFF
--- a/include/aikido/robot/ConcreteRobot.hpp
+++ b/include/aikido/robot/ConcreteRobot.hpp
@@ -224,6 +224,10 @@ public:
   void setCRRTPlannerParameters(
       const util::CRRTPlannerParameters& crrtParameters);
 
+  // Returns a pointer of the RNG belonging to this robot
+  // The ConcreteRobot is still responsible for cleaning this RNG, so use it only while the ConcreteRobot is alive!
+  aikido::common::RNG* getRNGPtr();
+
 private:
   // Named Configurations are read from a YAML file
   using ConfigurationMap

--- a/src/robot/ConcreteRobot.cpp
+++ b/src/robot/ConcreteRobot.cpp
@@ -444,5 +444,9 @@ std::unique_ptr<common::RNG> ConcreteRobot::cloneRNG()
   return mRng->clone();
 }
 
+aikido::common::RNG* ConcreteRobot::getRNGPtr() {
+  return &*mRng;
+}
+
 } // namespace robot
 } // namespace aikido


### PR DESCRIPTION
This is a cleaned up version of #385, regarding ConcreteRobot's RNG and how it should be exposed. There are also some comments about this in #385.