### PR TITLE
Allow for current configuration to be used as seed for solving IK

### DIFF
--- a/include/aikido/constraint/dart/InverseKinematicsSampleable.hpp
+++ b/include/aikido/constraint/dart/InverseKinematicsSampleable.hpp
@@ -31,12 +31,13 @@ public:
   /// \param _maxNumTrials Max number of trials for its sample generator
   ///        to retry sampling and finding an inverse kinematics solution.
   InverseKinematicsSampleable(
-      statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
-      ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
-      SampleablePtr _poseConstraint,
-      SampleablePtr _seedConstraint,
-      ::dart::dynamics::InverseKinematicsPtr _inverseKinematics,
-      int _maxNumTrials);
+      statespace::dart::MetaSkeletonStateSpacePtr metaSkeletonStateSpace,
+      ::dart::dynamics::MetaSkeletonPtr metaskeleton,
+      SampleablePtr poseConstraint,
+      SampleablePtr seedConstraint,
+      ::dart::dynamics::InverseKinematicsPtr inverseKinematics,
+      int maxNumTrials,
+      bool seedCurrentConfiguration = true);
 
   virtual ~InverseKinematicsSampleable() = default;
 
@@ -53,6 +54,7 @@ private:
   SampleablePtr mSeedConstraint;
   ::dart::dynamics::InverseKinematicsPtr mInverseKinematics;
   int mMaxNumTrials;
+  bool mSeedCurrentConfiguration;
 };
 
 } // namespace dart


### PR DESCRIPTION
Allows the current configuration to be used as a seed (initial guess) by the DART IK Solver. This is especially useful when solving for trajectories. IF the current configuration fails to give a solution, we allow for random configuration to be used as initial guesses for the solver.

Looking for comments on the general solution/idea for doing this. A few things:
1. We could have a sampler that samples from a finite set and use them as initial seeds before trying random initial guesses. This can, however, be set at a higher level. For example in `planToTSR` we might want to pass in a sampler that samples from a region around the current configuration since we want smooth and short trajectories. [will be addressed in a different PR] 
2. We can get rid of random sampler as an input to `inverseKinematicsSampleable` completely and instead pass a vector of seeds which can be preferred before using random guesses [and pass these seeds to DART solver]. However, as discussed with @jslee02 this can be disadvantageous since a Sampleable is potentially more generic/extendable, and the user might want to sample more intelligently when required than DARTs general sampler. Same example as in point 1.

Need to add tests to test both boolean instances for whether to use the current configuration as a seed.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
