### PR TITLE
Update package name of DART

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
 
   <!-- Required dependencies -->
   <depend>boost</depend>
-  <depend>dart</depend>
+  <depend>dartsim</depend>
   <depend>eigen</depend>
   <depend>ompl</depend>
   <depend>python</depend>


### PR DESCRIPTION
[The ROS package name of DART was changed to `dartsim`](https://github.com/dartsim/dart/pull/1027).

This PR depends on https://github.com/personalrobotics/pr-rosinstalls/pull/38.

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
