### PR TITLE
Split Hand::getBodyNode to getEndEffectorBodyNode and getHandBaseBody…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 * Robot
 
-  * Added Robot, Manipulator, Hand interfaces, and ConcreteRobot, ConcreteManipulator classes: [#325] https://github.com/personalrobotics/aikido/pull/325)
+  * Added Robot, Manipulator, Hand interfaces, and ConcreteRobot, ConcreteManipulator classes: [#325](https://github.com/personalrobotics/aikido/pull/325), [#392](https://github.com/personalrobotics/aikido/pull/392)
 
 * Build & Testing & ETC
 

--- a/include/aikido/control/ros/RosTrajectoryExecutor.hpp
+++ b/include/aikido/control/ros/RosTrajectoryExecutor.hpp
@@ -21,7 +21,7 @@ class RosTrajectoryExecutor : public aikido::control::TrajectoryExecutor
 public:
   /// Constructor.
   /// \param[in] node ROS node handle for action client.
-  /// \param[in] serverName Name of the server to send traejctory to.
+  /// \param[in] serverName Name of the server to send trajectory to.
   /// \param[in] waypointTimestep Step size for interpolating trajectories.
   /// \param[in] goalTimeTolerance
   /// \param[in] connectionTimeout Timeout for server connection.

--- a/include/aikido/robot/Hand.hpp
+++ b/include/aikido/robot/Hand.hpp
@@ -42,9 +42,14 @@ public:
   /// Returns the metaskeleton corresponding to this hand.
   virtual dart::dynamics::MetaSkeletonPtr getMetaSkeleton() = 0;
 
-  /// Get the end-effector body node.
+  /// Get the end-effector body node for which IK can be created.
   /// \return DART body node of end-effector
-  virtual dart::dynamics::BodyNode* getBodyNode() const = 0;
+  virtual dart::dynamics::BodyNode* getEndEffectorBodyNode() const = 0;
+
+  /// Get the body node which is the root of the hand, containing
+  /// all fingers.
+  /// \return DART body node at the root of the hand
+  virtual dart::dynamics::BodyNode* getHandBaseBodyNode() const = 0;
 };
 
 } // namespace robot


### PR DESCRIPTION
…Node

I noticed that for some of the robots we use, `end-effector` and `hand-base` are two different things. The former is typically placed at the palm of the hand (and may be a fake link), and can be used as for IK during manipulation. The latter link is at the root of the fingers, and can be used to get the hand, e.g. by creating a chain from this base. Since these two may not always coincide, I think it'd be useful to have methods to access both. (In some cases, these two may return the same node.)
***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
