### PR TITLE
Fix documentation typo.

### DIFF
--- a/include/aikido/control/TrajectoryExecutor.hpp
+++ b/include/aikido/control/TrajectoryExecutor.hpp
@@ -27,7 +27,7 @@ public:
   /// is already running, raise an exception unless the executor supports
   /// queuing.
   ///
-  /// \param _traj Trajectory to be executed.
+  /// \param traj Trajectory to be executed.
   /// \return future<void> for trajectory execution. If trajectory terminates
   ///        before completion, future will be set to a runtime_error.
   virtual std::future<void> execute(const trajectory::ConstTrajectoryPtr& traj)


### PR DESCRIPTION
`traj` was documented as `_traj`. Continuation of #357.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
