### PR TITLE
[ci] Define variables where they're used.

### DIFF
--- a/.ci/before_install_linux.sh
+++ b/.ci/before_install_linux.sh
@@ -8,4 +8,3 @@ cd "${HOME}/workspace"
 git clone https://github.com/personalrobotics/pr-cleanroom.git scripts
 curl -sS "${DISTRIBUTION}" > distribution.yml
 ./scripts/internal-setup.sh
-export PACKAGE_NAMES="$(./scripts/internal-get-packages.py distribution.yml ${REPOSITORY})"

--- a/.ci/script_linux.sh
+++ b/.ci/script_linux.sh
@@ -4,6 +4,7 @@ set -ex
 
 cd "${HOME}/workspace"
 
+export PACKAGE_NAMES="$(./scripts/internal-get-packages.py distribution.yml ${REPOSITORY})"
 ./scripts/internal-build.sh ${PACKAGE_NAMES}
 ./scripts/internal-test.sh ${PACKAGE_NAMES}
 


### PR DESCRIPTION
I think we're unnecessarily defining `PACKAGE_NAMES` in `before_install_linux.sh`. As far as I can tell, we only use it in `script_linux.sh`.