### PR TITLE
Add before_deploy step to .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,9 @@ after_failure:
     else
       '.ci/after_failure.sh';
     fi
+    
+before_deploy:
+  - cd "${HOME}"
 
 deploy:
   github-token: $GITHUB_TOKEN


### PR DESCRIPTION
The Travis GitHub Pages deployment requires that paths are specified as relative paths and doesn't support absolute paths. This PR makes the previously-specified relative path resolve to the correct directory.