### PR TITLE
Revive planSnap() not to break downstream

### DIFF
--- a/include/aikido/common/deprecated.hpp
+++ b/include/aikido/common/deprecated.hpp
@@ -1,0 +1,59 @@
+#ifndef AIKIDO_COMMON_DEPRECATED_HPP_
+#define AIKIDO_COMMON_DEPRECATED_HPP_
+
+#include <dart/config.hpp>
+
+namespace aikido {
+namespace common {
+
+// NOTE: Deprecated macros are used for backward compatibility between different
+// minor versions of AIKIDO. Deprecated API can be removed in every major
+// version up.
+
+#if defined(__GNUC__) || defined(__clang__)
+#define AIKIDO_DEPRECATED(version) __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#define AIKIDO_DEPRECATED(version) __declspec(deprecated)
+#else
+#define AIKIDO_DEPRECATED(version) ()
+#endif
+
+// We define two convenient macros that can be used to suppress
+// deprecated-warnings for a specific code block rather than a whole project.
+// This macros would be useful when you need to call deprecated function for
+// some reasons (e.g., for backward compatibility) but don't want warnings.
+//
+// Example code:
+//
+// deprecated_function()  // warning
+//
+// AIKIDO_SUPPRESS_DEPRECATED_BEGIN
+// deprecated_function()  // okay, no warning
+// AIKIDO_SUPPRESS_DEPRECATED_END
+//
+#if defined(__GNUC__) || defined(__GNUG__)
+
+#define AIKIDO_SUPPRESS_DEPRECATED_BEGIN                                       \
+  _Pragma("GCC diagnostic push")                                               \
+      _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+
+#define AIKIDO_SUPPRESS_DEPRECATED_END _Pragma("GCC diagnostic pop")
+
+#elif defined(__clang__)
+
+#define AIKIDO_SUPPRESS_DEPRECATED_BEGIN                                       \
+  _Pragma("clang diagnostic push")                                             \
+      _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+
+#define AIKIDO_SUPPRESS_DEPRECATED_END _Pragma("clang diagnostic pop")
+
+#else
+
+#warning "AIKIDO is being built by unsupported compiler."
+
+#define AIKIDO_SUPPRESS_DEPRECATED_BEGIN
+#define AIKIDO_SUPPRESS_DEPRECATED_END
+
+#endif
+
+#endif // AIKIDO_COMMON_DEPRECATED_HPP_

--- a/include/aikido/planner/SnapPlanner.hpp
+++ b/include/aikido/planner/SnapPlanner.hpp
@@ -1,0 +1,43 @@
+#ifndef AIKIDO_PLANNER_SNAPPLANNER_HPP_
+#define AIKIDO_PLANNER_SNAPPLANNER_HPP_
+
+#include <memory>
+#include "aikido/common/deprecated.hpp"
+#include "aikido/constraint/Testable.hpp"
+#include "aikido/planner/PlanningResult.hpp"
+#include "aikido/statespace/Interpolator.hpp"
+#include "aikido/statespace/StateSpace.hpp"
+#include "aikido/trajectory/Interpolated.hpp"
+
+namespace aikido {
+namespace planner {
+
+/// Plan a trajectory from \c startState to \c goalState by using
+/// \c interpolator to interpolate between them. The planner returns success if
+/// the resulting trajectory satisfies \c constraint at some resolution and
+/// failure (returning \c nullptr) otherwise. The reason for the failure is
+/// stored in the \c planningResult output parameter.
+///
+/// \param stateSpace state space
+/// \param startState start state
+/// \param goalState goal state
+/// \param interpolator interpolator used to produce the output trajectory
+/// \param constraint trajectory-wide constraint that must be satisfied
+/// \param[out] planningResult information about success or failure
+/// \return trajectory or \c nullptr if planning failed
+///
+/// \deprecated Deprecated in 0.3. Please use
+/// SnapConfigurationToConfigurationPlanner instead.
+AIKIDO_DEPRECATED(0.3)
+trajectory::InterpolatedPtr planSnap(
+    const statespace::ConstStateSpacePtr& stateSpace,
+    const statespace::StateSpace::State* startState,
+    const statespace::StateSpace::State* goalState,
+    const std::shared_ptr<statespace::Interpolator>& interpolator,
+    const std::shared_ptr<constraint::Testable>& constraint,
+    planner::PlanningResult& planningResult);
+
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_SNAPPLANNER_HPP_

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -12,6 +12,7 @@ set(sources
   Problem.cpp
   RankedMetaPlanner.cpp
   SnapConfigurationToConfigurationPlanner.cpp
+  SnapPlanner.cpp
   SequenceMetaPlanner.cpp
   World.cpp
   WorldStateSaver.cpp

--- a/src/planner/SnapPlanner.cpp
+++ b/src/planner/SnapPlanner.cpp
@@ -1,0 +1,28 @@
+#include "aikido/planner/SnapPlanner.hpp"
+
+#include "aikido/planner/ConfigurationToConfiguration.hpp"
+#include "aikido/planner/PlanningResult.hpp"
+#include "aikido/planner/SnapConfigurationToConfigurationPlanner.hpp"
+
+namespace aikido {
+namespace planner {
+
+trajectory::InterpolatedPtr planSnap(
+    const statespace::ConstStateSpacePtr& stateSpace,
+    const aikido::statespace::StateSpace::State* startState,
+    const aikido::statespace::StateSpace::State* goalState,
+    const std::shared_ptr<aikido::statespace::Interpolator>& interpolator,
+    const std::shared_ptr<aikido::constraint::Testable>& constraint,
+    aikido::planner::PlanningResult& planningResult)
+{
+  auto problem = ConfigurationToConfiguration(
+      stateSpace, *startState, *goalState, constraint);
+
+  auto planner = std::make_shared<SnapConfigurationToConfigurationPlanner>(
+      stateSpace, interpolator);
+
+  return planner->plan(problem, &planningResult);
+}
+
+} // namespace planner
+} // namespace aikido


### PR DESCRIPTION
We will keep old function `planSnap()` for the downstream projects until they settled to the new planning API.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`

