### PR TITLE
Speed up tests

### DIFF
--- a/tests/constraint/test_SE2BoxConstraint.cpp
+++ b/tests/constraint/test_SE2BoxConstraint.cpp
@@ -20,11 +20,19 @@ using Eigen::Matrix2d;
 class SE2BoxConstraintTests : public ::testing::Test
 {
 protected:
+#ifndef NDEBUG
+  static constexpr std::size_t NUM_A_TARGETS{5};
+  static constexpr std::size_t NUM_X_TARGETS{5};
+  static constexpr std::size_t NUM_Y_TARGETS{5};
+  static constexpr std::size_t NUM_SAMPLES{100};
+  static constexpr double DISTANCE_THRESHOLD{0.9};
+#else
   static constexpr std::size_t NUM_A_TARGETS{10};
   static constexpr std::size_t NUM_X_TARGETS{10};
   static constexpr std::size_t NUM_Y_TARGETS{10};
   static constexpr std::size_t NUM_SAMPLES{1000};
   static constexpr double DISTANCE_THRESHOLD{0.8};
+#endif
 
   void SetUp() override
   {
@@ -229,7 +237,7 @@ TEST_F(SE2BoxConstraintTests, createSampleGenerator)
 }
 
 //==============================================================================
-TEST_F(SE2BoxConstraintTests, createSampleGeneratorThrowOnNUllRNG)
+TEST_F(SE2BoxConstraintTests, createSampleGeneratorThrowOnNullRNG)
 {
   // We need to use make_shared here because createSampleGenerator calls
   // shared_from_this, provided by enable_shared_from_this.

--- a/tests/planner/parabolic/test_ParabolicSmoother.cpp
+++ b/tests/planner/parabolic/test_ParabolicSmoother.cpp
@@ -140,6 +140,9 @@ protected:
   double mNonStraightLineLength;
   double mNonStraightLineWithNonZeroStartTimeLength;
   double mTimelimit = 60.0;
+  double mBlendRadius = 0.5;
+  int mBlendIterations = 4;
+  double mCheckResolution = 1e-1;
   const double mTolerance = 1e-5;
 };
 
@@ -224,7 +227,8 @@ TEST_F(ParabolicSmootherTests, doShortcut)
       mMaxVelocity,
       mMaxAcceleration,
       mRng,
-      mTimelimit);
+      mTimelimit,
+      mCheckResolution);
 
   // Position.
   auto state = mStateSpace->createState();
@@ -253,15 +257,14 @@ TEST_F(ParabolicSmootherTests, doBlend)
 
   auto splineTrajectory = computeParabolicTiming(
       *mNonStraightLine, mMaxVelocity, mMaxAcceleration);
-  double blendRadius = 0.5;
-  int blendIterations = 100;
   auto smoothedTrajectory = doBlend(
       *splineTrajectory.get(),
       testable,
       mMaxVelocity,
       mMaxAcceleration,
-      blendRadius,
-      blendIterations);
+      mBlendRadius,
+      mBlendIterations,
+      mCheckResolution);
 
   // Position.
   auto state = mStateSpace->createState();
@@ -290,8 +293,6 @@ TEST_F(ParabolicSmootherTests, doShortcutAndBlend)
 
   auto splineTrajectory = computeParabolicTiming(
       *mNonStraightLine, mMaxVelocity, mMaxAcceleration);
-  double blendRadius = 0.5;
-  int blendIterations = 100;
   auto smoothedTrajectory = doShortcutAndBlend(
       *splineTrajectory.get(),
       testable,
@@ -299,8 +300,9 @@ TEST_F(ParabolicSmootherTests, doShortcutAndBlend)
       mMaxAcceleration,
       mRng,
       mTimelimit,
-      blendRadius,
-      blendIterations);
+      mBlendRadius,
+      mBlendIterations,
+      mCheckResolution);
 
   // Position.
   auto state = mStateSpace->createState();

--- a/tests/planner/parabolic/test_SmoothPostProcessor.cpp
+++ b/tests/planner/parabolic/test_SmoothPostProcessor.cpp
@@ -83,11 +83,11 @@ protected:
   std::shared_ptr<Interpolated> mTrajectory;
 
   double mOriginalTrajectoryLength;
-  double mFeasibilityCheckResolution = 1e-4;
-  double mFeasibilityApproxTolerance = 1e-3;
+  double mTimelimit = 60.0;
   double mBlendRadius = 0.5;
   double mBlendIterations = 100;
-  double mTimelimit = 60.0;
+  double mFeasibilityCheckResolution = 1e-1;
+  double mFeasibilityApproxTolerance = 1e-3;
   const double mTolerance = 1e-5;
 };
 


### PR DESCRIPTION
This PR speeds up the tests that are taking an egregiously long time to run (40-120 seconds). The goal is to have every test under a second (hopefully, significantly under a second).

- One of the coverage tests in `test_SE2BoxConstraint` runs much faster in release mode than in debug mode. This PR reduces the number of points that are sampled in debug mode only.
- The default value for constraint-checking resolution (`1e-4`) in `ParabolicSmoother` might be too fine. We saw with one of the HERB demos that `1e-3` was sufficient for avoiding collisions without taking too long to run. Since our parabolic smoother tests are using the `Satisfied` constraint, there's no point in actually checking this at any resolution, so I set it to `1e-1` here.

Resolves #412.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
