### PR TITLE
Refactor VFP with new Planner API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 
   * Added parabolic timing for linear spline [#302](https://github.com/personalrobotics/aikido/pull/302), [#324](https://github.com/personalrobotics/aikido/pull/324)
   * Fixed step sequence iteration in VPF: [#303](https://github.com/personalrobotics/aikido/pull/303)
-  * Refactored planning API: [#314](https://github.com/personalrobotics/aikido/pull/314), [#414](https://github.com/personalrobotics/aikido/pull/414)
+  * Refactored planning API: [#314](https://github.com/personalrobotics/aikido/pull/314), [#414](https://github.com/personalrobotics/aikido/pull/414), [#426](https://github.com/personalrobotics/aikido/pull/426)
   * Added flags to WorldStateSaver to specify what to save: [#339](https://github.com/personalrobotics/aikido/pull/339)
   * Changed interface for TrajectoryPostProcessor: [#341](https://github.com/personalrobotics/aikido/pull/341)
   * Planning calls with InverseKinematicsSampleable constraints explicitly set MetaSkeleton to solve IK with: [#379](https://github.com/personalrobotics/aikido/pull/379)

--- a/include/aikido/planner/ConfigurationToEndEffectorOffset.hpp
+++ b/include/aikido/planner/ConfigurationToEndEffectorOffset.hpp
@@ -4,7 +4,7 @@
 #include <dart/dart.hpp>
 #include "aikido/constraint/Testable.hpp"
 #include "aikido/planner/Problem.hpp"
-#include "aikido/statespace/StateSpace.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
 #include "aikido/trajectory/Interpolated.hpp"
 
 namespace aikido {
@@ -29,9 +29,9 @@ public:
   /// \param[in] constraint Trajectory-wide constraint that must be satisfied.
   /// \throw If the size of \c direction is zero.
   ConfigurationToEndEffectorOffset(
-      statespace::ConstStateSpacePtr stateSpace,
+      statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
       dart::dynamics::ConstBodyNodePtr endEffectorBodyNode,
-      const statespace::StateSpace::State* startState,
+      const statespace::dart::MetaSkeletonStateSpace::State* startState,
       const Eigen::Vector3d& direction,
       double signedDistance,
       constraint::ConstTestablePtr constraint);
@@ -47,7 +47,7 @@ public:
   dart::dynamics::ConstBodyNodePtr getEndEffectorBodyNode() const;
 
   /// Returns the start state.
-  const statespace::StateSpace::State* getStartState() const;
+  const statespace::dart::MetaSkeletonStateSpace::State* getStartState() const;
 
   /// Returns the direction of motion specified in the world frame.
   ///
@@ -62,7 +62,7 @@ protected:
   const dart::dynamics::ConstBodyNodePtr mEndEffectorBodyNode;
 
   /// Start state.
-  const statespace::StateSpace::State* mStartState;
+  const statespace::dart::MetaSkeletonStateSpace::State* mStartState;
 
   /// Direction of motion.
   const Eigen::Vector3d mDirection;

--- a/include/aikido/planner/ConfigurationToEndEffectorOffsetPlanner.hpp
+++ b/include/aikido/planner/ConfigurationToEndEffectorOffsetPlanner.hpp
@@ -1,0 +1,42 @@
+#ifndef AIKIDO_PLANNER_CONFIGURATIONTOENDEFFECTOROFFSETPLANNER_HPP_
+#define AIKIDO_PLANNER_CONFIGURATIONTOENDEFFECTOROFFSETPLANNER_HPP_
+
+#include "aikido/planner/ConfigurationToEndEffectorOffset.hpp"
+#include "aikido/planner/SingleProblemPlanner.hpp"
+#include "aikido/trajectory/Trajectory.hpp"
+
+namespace aikido {
+namespace planner {
+
+/// Base planner class for ConfigurationToEndEffectorOffset planning problem.
+class ConfigurationToEndEffectorOffsetPlanner
+    : public SingleProblemPlanner<ConfigurationToEndEffectorOffsetPlanner,
+                                  ConfigurationToEndEffectorOffset>
+{
+public:
+  // Expose the implementation of Planner::plan(const Problem&, Result*) in
+  // SingleProblemPlanner. Note that plan() of the base class takes Problem
+  // while the virtual function defined in this class takes SolverbleProblem,
+  // which is simply ConfigurationToEndEffectorOffset.
+  using SingleProblemPlanner::plan;
+
+  /// Constructor
+  ///
+  /// \param[in] stateSpace State space that this planner associated with.
+  explicit ConfigurationToEndEffectorOffsetPlanner(
+      statespace::ConstStateSpacePtr stateSpace);
+
+  /// Solves \c problem returning the result to \c result.
+  ///
+  /// \param[in] problem Planning problem to be solved by the planner.
+  /// \param[out] result Result of planning procedure.
+  virtual trajectory::TrajectoryPtr plan(
+      const SolvableProblem& problem, Result* result = nullptr)
+      = 0;
+  // Note: SolvableProblem is defined in SingleProblemPlanner.
+};
+
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_CONFIGURATIONTOENDEFFECTOROFFSETPLANNER_HPP_

--- a/include/aikido/planner/ConfigurationToEndEffectorOffsetPlanner.hpp
+++ b/include/aikido/planner/ConfigurationToEndEffectorOffsetPlanner.hpp
@@ -39,6 +39,11 @@ public:
   /// Return ConstMetaSkeletonStateSpacePtr by performing a static cast on
   /// mStateSpace.
   statespace::dart::ConstMetaSkeletonStateSpacePtr getMetaSkeletonStateSpace();
+
+protected:
+  /// Stores stateSpace pointer as aConstMetaSkeletonStateSpacePtr. Prevents
+  /// use of an expensive dynamic cast.
+  statespace::dart::ConstMetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
 };
 
 } // namespace planner

--- a/include/aikido/planner/ConfigurationToEndEffectorOffsetPlanner.hpp
+++ b/include/aikido/planner/ConfigurationToEndEffectorOffsetPlanner.hpp
@@ -3,6 +3,7 @@
 
 #include "aikido/planner/ConfigurationToEndEffectorOffset.hpp"
 #include "aikido/planner/SingleProblemPlanner.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
 #include "aikido/trajectory/Trajectory.hpp"
 
 namespace aikido {
@@ -24,7 +25,7 @@ public:
   ///
   /// \param[in] stateSpace State space that this planner associated with.
   explicit ConfigurationToEndEffectorOffsetPlanner(
-      statespace::ConstStateSpacePtr stateSpace);
+      statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace);
 
   /// Solves \c problem returning the result to \c result.
   ///
@@ -34,6 +35,10 @@ public:
       const SolvableProblem& problem, Result* result = nullptr)
       = 0;
   // Note: SolvableProblem is defined in SingleProblemPlanner.
+
+  /// Return ConstMetaSkeletonStateSpacePtr by performing a static cast on
+  /// mStateSpace.
+  statespace::dart::ConstMetaSkeletonStateSpacePtr getMetaSkeletonStateSpace();
 };
 
 } // namespace planner

--- a/include/aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.hpp
+++ b/include/aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.hpp
@@ -3,7 +3,6 @@
 
 #include "aikido/planner/ConfigurationToEndEffectorOffset.hpp"
 #include "aikido/planner/ConfigurationToEndEffectorOffsetPlanner.hpp"
-#include "aikido/planner/vectorfield/VectorFieldPlanner.hpp"
 
 namespace aikido {
 namespace planner {
@@ -33,7 +32,7 @@ public:
   /// checking.
   /// \param[in] timelimit timeout in seconds.
   VectorFieldConfigurationToEndEffectorOffsetPlanner(
-      statespace::ConstStateSpacePtr stateSpace,
+      statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
       dart::dynamics::MetaSkeletonPtr metaskeleton,
       double distanceTolerance,
       double positionTolerance,
@@ -54,9 +53,6 @@ public:
   /// \param[in] problem Planning problem.
   /// \param[out] result Information about success or failure.
   /// \return Trajectory or \c nullptr if planning failed.
-  /// \throw If \c problem is not ConfigurationToEndEffectorOffset.
-  /// \throw If \c result is not ConfigurationToEndEffectorOffset::Result.
-  /// \throw If mStateSpace is not MetaSkeletonStateSpace.
   trajectory::TrajectoryPtr plan(
       const SolvableProblem& problem, Result* result = nullptr) override;
 

--- a/include/aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.hpp
+++ b/include/aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.hpp
@@ -28,7 +28,8 @@ public:
   /// \param[in] initialStepSize Initial step size.
   /// \param[in] jointLimitTolerance If less then this distance to joint
   /// limit, velocity is bounded in that direction to 0.
-  /// \param[in] constraintCheckResolution Resolution used in constraint checking.
+  /// \param[in] constraintCheckResolution Resolution used in constraint
+  /// checking.
   /// \param[in] timelimit timeout in seconds.
   VectorFieldConfigurationToEndEffectorOffsetPlanner(
       statespace::ConstStateSpacePtr stateSpace,
@@ -54,36 +55,37 @@ public:
   /// \return Trajectory or \c nullptr if planning failed.
   /// \throw If \c problem is not ConfigurationToEndEffectorOffset.
   /// \throw If \c result is not ConfigurationToEndEffectorOffset::Result.
+  /// \throw If mStateSpace is not MetaSkeletonStateSpace.
   trajectory::TrajectoryPtr plan(
       const SolvableProblem& problem, Result* result = nullptr) override;
 
-  protected:
-    /// MetaSkeleton to plan with.
-    dart::dynamics::MetaSkeletonPtr mMetaskeleton;
+protected:
+  /// MetaSkeleton to plan with.
+  dart::dynamics::MetaSkeletonPtr mMetaskeleton;
 
-    /// How much a planned trajectory is allowed to deviate from the requested
-    /// distance to move the end-effector.
-    double mDistanceTolerance;
+  /// How much a planned trajectory is allowed to deviate from the requested
+  /// distance to move the end-effector.
+  double mDistanceTolerance;
 
-    /// How a planned trajectory is allowed to deviated from a straight line
-    /// segment defined by the direction and the distance.
-    double mPositionTolerance;
+  /// How a planned trajectory is allowed to deviated from a straight line
+  /// segment defined by the direction and the distance.
+  double mPositionTolerance;
 
-    /// How a planned trajectory is allowed to deviate from a given direction.
-    double mAngularTolerance;
+  /// How a planned trajectory is allowed to deviate from a given direction.
+  double mAngularTolerance;
 
-    /// Initial step size.
-    double mInitialStepSize;
+  /// Initial step size.
+  double mInitialStepSize;
 
-    /// If less then this distance to joint limit, velocity is bounded in that
-    /// direction to 0.
-    double mJointLimitTolerance;
+  /// If less then this distance to joint limit, velocity is bounded in that
+  /// direction to 0.
+  double mJointLimitTolerance;
 
-    /// Resolution used in constraint checking.
-    double mConstraintCheckResolution;
+  /// Resolution used in constraint checking.
+  double mConstraintCheckResolution;
 
-    /// Timeout in seconds.
-    std::chrono::duration<double> mTimelimit;
+  /// Timeout in seconds.
+  std::chrono::duration<double> mTimelimit;
 };
 
 } // namespace planner

--- a/include/aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.hpp
+++ b/include/aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.hpp
@@ -7,6 +7,7 @@
 
 namespace aikido {
 namespace planner {
+namespace vectorfield {
 
 /// Planner that generates a trajectory that moves the end-effector by a given
 /// direction and distance.
@@ -88,6 +89,7 @@ protected:
   std::chrono::duration<double> mTimelimit;
 };
 
+} // namespace vectorfield
 } // namespace planner
 } // namespace aikido
 

--- a/include/aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.hpp
+++ b/include/aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.hpp
@@ -3,6 +3,7 @@
 
 #include "aikido/planner/ConfigurationToEndEffectorOffset.hpp"
 #include "aikido/planner/ConfigurationToEndEffectorOffsetPlanner.hpp"
+#include "aikido/planner/vectorfield/VectorFieldPlanner.hpp"
 
 namespace aikido {
 namespace planner {
@@ -55,6 +56,34 @@ public:
   /// \throw If \c result is not ConfigurationToEndEffectorOffset::Result.
   trajectory::TrajectoryPtr plan(
       const SolvableProblem& problem, Result* result = nullptr) override;
+
+  protected:
+    /// MetaSkeleton to plan with.
+    dart::dynamics::MetaSkeletonPtr mMetaskeleton;
+
+    /// How much a planned trajectory is allowed to deviate from the requested
+    /// distance to move the end-effector.
+    double mDistanceTolerance;
+
+    /// How a planned trajectory is allowed to deviated from a straight line
+    /// segment defined by the direction and the distance.
+    double mPositionTolerance;
+
+    /// How a planned trajectory is allowed to deviate from a given direction.
+    double mAngularTolerance;
+
+    /// Initial step size.
+    double mInitialStepSize;
+
+    /// If less then this distance to joint limit, velocity is bounded in that
+    /// direction to 0.
+    double mJointLimitTolerance;
+
+    /// Resolution used in constraint checking.
+    double mConstraintCheckResolution;
+
+    /// Timeout in seconds.
+    std::chrono::duration<double> mTimelimit;
 };
 
 } // namespace planner

--- a/include/aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.hpp
+++ b/include/aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.hpp
@@ -1,0 +1,63 @@
+#ifndef AIKIDO_PLANNER_VECTORFIELD_VECTORFIELDCONFIGURATIONTOENDEFFECTOROFFSETPLANNER_HPP_
+#define AIKIDO_PLANNER_VECTORFIELD_VECTORFIELDCONFIGURATIONTOENDEFFECTOROFFSETPLANNER_HPP_
+
+#include "aikido/planner/ConfigurationToEndEffectorOffset.hpp"
+#include "aikido/planner/ConfigurationToEndEffectorOffsetPlanner.hpp"
+
+namespace aikido {
+namespace planner {
+
+/// Planner that generates a trajectory that moves the end-effector by a given
+/// direction and distance.
+class VectorFieldConfigurationToEndEffectorOffsetPlanner
+    : public ConfigurationToEndEffectorOffsetPlanner
+{
+public:
+  /// Constructor.
+  ///
+  /// \param[in] stateSpace State space that this planner is associated with.
+  /// \param[in] metaskeleton MetaSkeleton to plan with.
+  /// \param[in] distanceTolerance How much a planned trajectory is allowed to
+  /// deviate from the requested distance to move the end-effector.
+  /// \param[in] positionTolerance How a planned trajectory is allowed to
+  /// deviated from a straight line segment defined by the direction and the
+  /// distance.
+  /// \param[in] angularTolerance How a planned trajectory is allowed to deviate
+  /// from a given direction.
+  /// \param[in] initialStepSize Initial step size.
+  /// \param[in] jointLimitTolerance If less then this distance to joint
+  /// limit, velocity is bounded in that direction to 0.
+  /// \param[in] constraintCheckResolution Resolution used in constraint checking.
+  /// \param[in] timelimit timeout in seconds.
+  VectorFieldConfigurationToEndEffectorOffsetPlanner(
+      statespace::ConstStateSpacePtr stateSpace,
+      dart::dynamics::MetaSkeletonPtr metaskeleton,
+      double distanceTolerance,
+      double positionTolerance,
+      double angularTolerance,
+      double initialStepSize,
+      double jointLimitTolerance,
+      double constraintCheckResolution,
+      std::chrono::duration<double> timelimit);
+
+  /// Plan to a trajectory that moves the end-effector by a given direction and
+  /// distance.
+  ///
+  /// The planner returns success if the resulting trajectory satisfies
+  /// constraint at some resolution and failure (returning \c nullptr)
+  /// otherwise. The reason for the failure is stored in the \c result output
+  /// parameter.
+  ///
+  /// \param[in] problem Planning problem.
+  /// \param[out] result Information about success or failure.
+  /// \return Trajectory or \c nullptr if planning failed.
+  /// \throw If \c problem is not ConfigurationToEndEffectorOffset.
+  /// \throw If \c result is not ConfigurationToEndEffectorOffset::Result.
+  trajectory::TrajectoryPtr plan(
+      const SolvableProblem& problem, Result* result = nullptr) override;
+};
+
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_VECTORFIELD_VECTORFIELDCONFIGURATIONTOENDEFFECTOROFFSETPLANNER_HPP_

--- a/include/aikido/planner/vectorfield/VectorFieldPlanner.hpp
+++ b/include/aikido/planner/vectorfield/VectorFieldPlanner.hpp
@@ -55,6 +55,7 @@ std::unique_ptr<aikido::trajectory::Spline> followVectorField(
 /// \param[out] result information about success or failure.
 /// \return Trajectory or \c nullptr if planning failed.
 std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
+    const statespace::dart::MetaSkeletonStateSpace::State& startState,
     const aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr& stateSpace,
     dart::dynamics::MetaSkeletonPtr metaskeleton,
     const dart::dynamics::ConstBodyNodePtr& bn,

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -4,6 +4,7 @@ set(sources
   ConfigurationToConfigurations.cpp
   ConfigurationToTSR.cpp
   ConfigurationToEndEffectorOffset.cpp
+  ConfigurationToEndEffectorOffsetPlanner.cpp
   ConfigurationToEndEffectorPose.cpp
   FirstSupportedMetaPlanner.cpp
   CompositePlanner.cpp

--- a/src/planner/ConfigurationToEndEffectorOffset.cpp
+++ b/src/planner/ConfigurationToEndEffectorOffset.cpp
@@ -7,9 +7,9 @@ namespace planner {
 
 //==============================================================================
 ConfigurationToEndEffectorOffset::ConfigurationToEndEffectorOffset(
-    statespace::ConstStateSpacePtr stateSpace,
+    statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
     dart::dynamics::ConstBodyNodePtr endEffectorBodyNode,
-    const statespace::StateSpace::State* startState,
+    const statespace::dart::MetaSkeletonStateSpace::State* startState,
     const Eigen::Vector3d& direction,
     const double signedDistance,
     constraint::ConstTestablePtr constraint)
@@ -44,7 +44,7 @@ ConfigurationToEndEffectorOffset::getEndEffectorBodyNode() const
 }
 
 //==============================================================================
-const statespace::StateSpace::State*
+const statespace::dart::MetaSkeletonStateSpace::State*
 ConfigurationToEndEffectorOffset::getStartState() const
 {
   return mStartState;

--- a/src/planner/ConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/ConfigurationToEndEffectorOffsetPlanner.cpp
@@ -9,7 +9,7 @@ ConfigurationToEndEffectorOffsetPlanner::
         statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace)
   : SingleProblemPlanner<ConfigurationToEndEffectorOffsetPlanner,
                          ConfigurationToEndEffectorOffset>(stateSpace)
-  , mMetaSkeletonStateSpace(move(stateSpace))
+  , mMetaSkeletonStateSpace(std::move(stateSpace))
 {
   // Do nothing
 }

--- a/src/planner/ConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/ConfigurationToEndEffectorOffsetPlanner.cpp
@@ -8,8 +8,8 @@ ConfigurationToEndEffectorOffsetPlanner::
     ConfigurationToEndEffectorOffsetPlanner(
         statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace)
   : SingleProblemPlanner<ConfigurationToEndEffectorOffsetPlanner,
-                         ConfigurationToEndEffectorOffset>(
-        std::move(stateSpace))
+                         ConfigurationToEndEffectorOffset>(stateSpace)
+  , mMetaSkeletonStateSpace(stateSpace)
 {
   // Do nothing
 }
@@ -18,9 +18,7 @@ ConfigurationToEndEffectorOffsetPlanner::
 statespace::dart::ConstMetaSkeletonStateSpacePtr
 ConfigurationToEndEffectorOffsetPlanner::getMetaSkeletonStateSpace()
 {
-  return std::
-      dynamic_pointer_cast<const statespace::dart::MetaSkeletonStateSpace>(
-          mStateSpace);
+  return mMetaSkeletonStateSpace;
 }
 
 } // namespace planner

--- a/src/planner/ConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/ConfigurationToEndEffectorOffsetPlanner.cpp
@@ -1,0 +1,16 @@
+#include "aikido/planner/ConfigurationToEndEffectorOffsetPlanner.hpp"
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+ConfigurationToEndEffectorOffsetPlanner::ConfigurationToEndEffectorOffsetPlanner(
+    statespace::ConstStateSpacePtr stateSpace)
+  : SingleProblemPlanner<ConfigurationToEndEffectorOffsetPlanner,
+                         ConfigurationToEndEffectorOffset>(std::move(stateSpace))
+{
+  // Do nothing
+}
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/ConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/ConfigurationToEndEffectorOffsetPlanner.cpp
@@ -9,7 +9,7 @@ ConfigurationToEndEffectorOffsetPlanner::
         statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace)
   : SingleProblemPlanner<ConfigurationToEndEffectorOffsetPlanner,
                          ConfigurationToEndEffectorOffset>(stateSpace)
-  , mMetaSkeletonStateSpace(stateSpace)
+  , mMetaSkeletonStateSpace(move(stateSpace))
 {
   // Do nothing
 }

--- a/src/planner/ConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/ConfigurationToEndEffectorOffsetPlanner.cpp
@@ -6,12 +6,21 @@ namespace planner {
 //==============================================================================
 ConfigurationToEndEffectorOffsetPlanner::
     ConfigurationToEndEffectorOffsetPlanner(
-        statespace::ConstStateSpacePtr stateSpace)
+        statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace)
   : SingleProblemPlanner<ConfigurationToEndEffectorOffsetPlanner,
                          ConfigurationToEndEffectorOffset>(
         std::move(stateSpace))
 {
   // Do nothing
+}
+
+//==============================================================================
+statespace::dart::ConstMetaSkeletonStateSpacePtr
+ConfigurationToEndEffectorOffsetPlanner::getMetaSkeletonStateSpace()
+{
+  return std::
+      dynamic_pointer_cast<const statespace::dart::MetaSkeletonStateSpace>(
+          mStateSpace);
 }
 
 } // namespace planner

--- a/src/planner/ConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/ConfigurationToEndEffectorOffsetPlanner.cpp
@@ -4,10 +4,12 @@ namespace aikido {
 namespace planner {
 
 //==============================================================================
-ConfigurationToEndEffectorOffsetPlanner::ConfigurationToEndEffectorOffsetPlanner(
-    statespace::ConstStateSpacePtr stateSpace)
+ConfigurationToEndEffectorOffsetPlanner::
+    ConfigurationToEndEffectorOffsetPlanner(
+        statespace::ConstStateSpacePtr stateSpace)
   : SingleProblemPlanner<ConfigurationToEndEffectorOffsetPlanner,
-                         ConfigurationToEndEffectorOffset>(std::move(stateSpace))
+                         ConfigurationToEndEffectorOffset>(
+        std::move(stateSpace))
 {
   // Do nothing
 }

--- a/src/planner/vectorfield/CMakeLists.txt
+++ b/src/planner/vectorfield/CMakeLists.txt
@@ -1,7 +1,8 @@
-set(sources 
+set(sources
   VectorFieldPlanner.cpp
   VectorField.cpp
   VectorFieldUtil.cpp
+  VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
   detail/VectorFieldIntegrator.cpp
   detail/VectorFieldPlannerExceptions.cpp
   BodyNodePoseVectorField.cpp
@@ -42,4 +43,3 @@ add_component_dependencies(${PROJECT_NAME} planner_vectorfield
 )
 
 format_add_sources(${sources})
-

--- a/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
@@ -44,6 +44,14 @@ VectorFieldConfigurationToEndEffectorOffsetPlanner::plan(
 
   auto metaskeletonStateSpace = getMetaSkeletonStateSpace();
 
+  if (problem.getDistance() - mDistanceTolerance < 0.)
+  {
+    std::stringstream ss;
+    ss << "Distance must be non-negative; min distance to move is "
+       << problem.getDistance() - mDistanceTolerance << ".";
+    throw std::runtime_error(ss.str());
+  }
+
   // Just call the core VFP function.
   // TODO: How should start state be handled?
   return planToEndEffectorOffset(
@@ -52,7 +60,6 @@ VectorFieldConfigurationToEndEffectorOffsetPlanner::plan(
       problem.getEndEffectorBodyNode(),
       problem.getConstraint(),
       problem.getDirection(),
-      // TODO: Need to handle case when negative.
       problem.getDistance() - mDistanceTolerance,
       problem.getDistance() + mDistanceTolerance,
       mPositionTolerance,

--- a/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
@@ -66,6 +66,7 @@ VectorFieldConfigurationToEndEffectorOffsetPlanner::plan(
   // Just call the core VFP function.
   // TODO: How should start state be handled?
   return planToEndEffectorOffset(
+      *problem.getStartState(),
       getMetaSkeletonStateSpace(),
       mMetaskeleton,
       problem.getEndEffectorBodyNode(),

--- a/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
@@ -35,6 +35,8 @@ trajectory::TrajectoryPtr VectorFieldConfigurationToEndEffectorOffsetPlanner::pl
   // TODO (sniyaz): Check equality between state space of this planner and given
   // problem.
 
+  using aikido::planner::vectorfield::planToEndEffectorOffset;
+
   // Just call the core VFP function.
   // TODO: How should start state be handled?
   return planToEndEffectorOffset(

--- a/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
@@ -2,6 +2,7 @@
 
 namespace aikido {
 namespace planner {
+namespace vectorfield {
 
 //==============================================================================
 VectorFieldConfigurationToEndEffectorOffsetPlanner::
@@ -64,5 +65,6 @@ VectorFieldConfigurationToEndEffectorOffsetPlanner::plan(
       result);
 }
 
+} // namespace vectorfield
 } // namespace planner
 } // namespace aikido

--- a/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
@@ -44,7 +44,20 @@ VectorFieldConfigurationToEndEffectorOffsetPlanner::plan(
 
   auto metaskeletonStateSpace = getMetaSkeletonStateSpace();
 
-  if (problem.getDistance() - mDistanceTolerance < 0.)
+  // Handle the fact that distance can be negative.
+  double distance = problem.getDistance();
+  Eigen::Vector3d direction = problem.getDirection();
+
+  if (distance < 0)
+  {
+    distance = -1.0 * distance;
+    direction = -1.0 * direction;
+  }
+
+  double minDistance = distance - mDistanceTolerance;
+  double maxDistance = distance + mDistanceTolerance;
+
+  if (minDistance < 0.)
   {
     std::stringstream ss;
     ss << "Distance must be non-negative; min distance to move is "
@@ -59,9 +72,9 @@ VectorFieldConfigurationToEndEffectorOffsetPlanner::plan(
       mMetaskeleton,
       problem.getEndEffectorBodyNode(),
       problem.getConstraint(),
-      problem.getDirection(),
-      problem.getDistance() - mDistanceTolerance,
-      problem.getDistance() + mDistanceTolerance,
+      direction,
+      minDistance,
+      maxDistance,
       mPositionTolerance,
       mAngularTolerance,
       mInitialStepSize,

--- a/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
@@ -1,5 +1,7 @@
 #include "aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.hpp"
 
+#include "aikido/planner/vectorfield/VectorFieldPlanner.hpp"
+
 namespace aikido {
 namespace planner {
 namespace vectorfield {
@@ -7,7 +9,7 @@ namespace vectorfield {
 //==============================================================================
 VectorFieldConfigurationToEndEffectorOffsetPlanner::
     VectorFieldConfigurationToEndEffectorOffsetPlanner(
-        statespace::ConstStateSpacePtr stateSpace,
+        statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
         dart::dynamics::MetaSkeletonPtr metaskeleton,
         double distanceTolerance,
         double positionTolerance,
@@ -40,10 +42,7 @@ VectorFieldConfigurationToEndEffectorOffsetPlanner::plan(
   using aikido::planner::vectorfield::planToEndEffectorOffset;
   using aikido::statespace::dart::MetaSkeletonStateSpace;
 
-  auto metaskeletonStateSpace
-      = std::dynamic_pointer_cast<const MetaSkeletonStateSpace>(mStateSpace);
-  if (!metaskeletonStateSpace)
-    throw std::invalid_argument("mStateSpace is not MetaSkeletonStateSpace!");
+  auto metaskeletonStateSpace = getMetaSkeletonStateSpace();
 
   // Just call the core VFP function.
   // TODO: How should start state be handled?

--- a/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
@@ -42,8 +42,6 @@ VectorFieldConfigurationToEndEffectorOffsetPlanner::plan(
   using aikido::planner::vectorfield::planToEndEffectorOffset;
   using aikido::statespace::dart::MetaSkeletonStateSpace;
 
-  auto metaskeletonStateSpace = getMetaSkeletonStateSpace();
-
   // Handle the fact that distance can be negative.
   double distance = problem.getDistance();
   Eigen::Vector3d direction = problem.getDirection();
@@ -68,7 +66,7 @@ VectorFieldConfigurationToEndEffectorOffsetPlanner::plan(
   // Just call the core VFP function.
   // TODO: How should start state be handled?
   return planToEndEffectorOffset(
-      metaskeletonStateSpace,
+      getMetaSkeletonStateSpace(),
       mMetaskeleton,
       problem.getEndEffectorBodyNode(),
       problem.getConstraint(),

--- a/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
@@ -29,33 +29,39 @@ VectorFieldConfigurationToEndEffectorOffsetPlanner::
 }
 
 //==============================================================================
-trajectory::TrajectoryPtr VectorFieldConfigurationToEndEffectorOffsetPlanner::plan(
+trajectory::TrajectoryPtr
+VectorFieldConfigurationToEndEffectorOffsetPlanner::plan(
     const SolvableProblem& problem, Result* result)
 {
   // TODO (sniyaz): Check equality between state space of this planner and given
   // problem.
 
   using aikido::planner::vectorfield::planToEndEffectorOffset;
+  using aikido::statespace::dart::MetaSkeletonStateSpace;
+
+  auto metaskeletonStateSpace
+      = std::dynamic_pointer_cast<const MetaSkeletonStateSpace>(mStateSpace);
+  if (!metaskeletonStateSpace)
+    throw std::invalid_argument("mStateSpace is not MetaSkeletonStateSpace!");
 
   // Just call the core VFP function.
   // TODO: How should start state be handled?
   return planToEndEffectorOffset(
-    mStateSpace,
-    mMetaskeleton,
-    problem.getEndEffectorBodyNode(),
-    problem.getConstraint(),
-    problem.getDirection(),
-    // TODO: Need to handle case when negative.
-    problem.getDistance() - mDistanceTolerance,
-    problem.getDistance() + mDistanceTolerance,
-    mPositionTolerance,
-    mAngularTolerance,
-    mInitialStepSize,
-    mJointLimitTolerance,
-    mConstraintCheckResolution,
-    mTimelimit,
-    result
-  );
+      metaskeletonStateSpace,
+      mMetaskeleton,
+      problem.getEndEffectorBodyNode(),
+      problem.getConstraint(),
+      problem.getDirection(),
+      // TODO: Need to handle case when negative.
+      problem.getDistance() - mDistanceTolerance,
+      problem.getDistance() + mDistanceTolerance,
+      mPositionTolerance,
+      mAngularTolerance,
+      mInitialStepSize,
+      mJointLimitTolerance,
+      mConstraintCheckResolution,
+      mTimelimit,
+      result);
 }
 
 } // namespace planner

--- a/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
@@ -1,0 +1,60 @@
+#include "aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorOffsetPlanner.hpp"
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+VectorFieldConfigurationToEndEffectorOffsetPlanner::
+    VectorFieldConfigurationToEndEffectorOffsetPlanner(
+        statespace::ConstStateSpacePtr stateSpace,
+        dart::dynamics::MetaSkeletonPtr metaskeleton,
+        double distanceTolerance,
+        double positionTolerance,
+        double angularTolerance,
+        double initialStepSize,
+        double jointLimitTolerance,
+        double constraintCheckResolution,
+        std::chrono::duration<double> timelimit)
+  : ConfigurationToEndEffectorOffsetPlanner(std::move(stateSpace))
+  , mMetaskeleton(std::move(metaskeleton))
+  , mDistanceTolerance(distanceTolerance)
+  , mPositionTolerance(positionTolerance)
+  , mAngularTolerance(angularTolerance)
+  , mInitialStepSize(initialStepSize)
+  , mJointLimitTolerance(jointLimitTolerance)
+  , mConstraintCheckResolution(constraintCheckResolution)
+  , mTimelimit(timelimit)
+{
+  // Do nothing here.
+}
+
+//==============================================================================
+trajectory::TrajectoryPtr VectorFieldConfigurationToEndEffectorOffsetPlanner::plan(
+    const SolvableProblem& problem, Result* result)
+{
+  // TODO (sniyaz): Check equality between state space of this planner and given
+  // problem.
+
+  // Just call the core VFP function.
+  // TODO: How should start state be handled?
+  return planToEndEffectorOffset(
+    mStateSpace,
+    mMetaskeleton,
+    problem.getEndEffectorBodyNode(),
+    problem.getConstraint(),
+    problem.getDirection(),
+    // TODO: Need to handle case when negative.
+    problem.getDistance() - mDistanceTolerance,
+    problem.getDistance() + mDistanceTolerance,
+    mPositionTolerance,
+    mAngularTolerance,
+    mInitialStepSize,
+    mJointLimitTolerance,
+    mConstraintCheckResolution,
+    mTimelimit,
+    result
+  );
+}
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/vectorfield/VectorFieldPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldPlanner.cpp
@@ -152,18 +152,6 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
   // std::lock_guard<std::mutex> lock(metaskeleton->getLockableReference())
   // once https://github.com/dartsim/dart/pull/1011 is released.
 
-  if (minDistance < 0.)
-  {
-    std::stringstream ss;
-    ss << "Distance must be non-negative; got " << minDistance << ".";
-    throw std::runtime_error(ss.str());
-  }
-
-  if (maxDistance < minDistance)
-  {
-    throw std::runtime_error("Max distance is less than distance.");
-  }
-
   // TODO: Check compatibility between MetaSkeleton and MetaSkeletonStateSpace
 
   // Save the current state of the space

--- a/src/planner/vectorfield/VectorFieldPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldPlanner.cpp
@@ -126,6 +126,7 @@ std::unique_ptr<aikido::trajectory::Spline> followVectorField(
 
 //==============================================================================
 std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
+    const statespace::dart::MetaSkeletonStateSpace::State& startState,
     const aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr& stateSpace,
     dart::dynamics::MetaSkeletonPtr metaskeleton,
     const dart::dynamics::ConstBodyNodePtr& bn,
@@ -178,11 +179,10 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
   compoundConstraint->addConstraint(
       constraint::dart::createTestableBounds(stateSpace));
 
-  auto startState
-      = stateSpace->getScopedStateFromMetaSkeleton(metaskeleton.get());
+  stateSpace->setState(metaskeleton.get(), &startState);
   return followVectorField(
       *vectorfield,
-      *startState,
+      startState,
       *compoundConstraint,
       timelimit,
       initialStepSize,

--- a/src/planner/vectorfield/VectorFieldPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldPlanner.cpp
@@ -164,11 +164,6 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
     throw std::runtime_error("Max distance is less than distance.");
   }
 
-  if (direction.norm() == 0.0)
-  {
-    throw std::runtime_error("Direction vector is a zero vector");
-  }
-
   // TODO: Check compatibility between MetaSkeleton and MetaSkeletonStateSpace
 
   // Save the current state of the space

--- a/src/robot/util.cpp
+++ b/src/robot/util.cpp
@@ -401,10 +401,14 @@ trajectory::TrajectoryPtr planToEndEffectorOffset(
   auto saver = MetaSkeletonStateSaver(metaSkeleton);
   DART_UNUSED(saver);
 
+  statespace::dart::MetaSkeletonStateSpace::State startState;
+  space->getState(metaSkeleton.get(), &startState);
+
   auto minDistance = distance - vfParameters.negativeDistanceTolerance;
   auto maxDistance = distance + vfParameters.positiveDistanceTolerance;
 
   auto traj = planner::vectorfield::planToEndEffectorOffset(
+      startState,
       space,
       metaSkeleton,
       bodyNode,

--- a/tests/planner/vectorfield/test_VectorFieldPlanner.cpp
+++ b/tests/planner/vectorfield/test_VectorFieldPlanner.cpp
@@ -340,7 +340,6 @@ TEST_F(VectorFieldPlannerTest, PlanToEndEffectorOffsetTest)
 
   // Create problem.
   auto offsetProblem = ConfigurationToEndEffectorOffset(
-      // TODO: Will this even be used?
       mStateSpace,
       mBodynode,
       startState,
@@ -435,7 +434,6 @@ TEST_F(VectorFieldPlannerTest, DirectionZeroVector)
   // Create Problem, which should fail.
   EXPECT_THROW(
       ConfigurationToEndEffectorOffset(
-          // TODO: Will this even be used?
           mStateSpace,
           mBodynode,
           startState,

--- a/tests/planner/vectorfield/test_VectorFieldPlanner.cpp
+++ b/tests/planner/vectorfield/test_VectorFieldPlanner.cpp
@@ -427,41 +427,22 @@ TEST_F(VectorFieldPlannerTest, DirectionZeroVector)
 
   Eigen::Vector3d direction = Eigen::Vector3d::Zero();
   double signedDistance = 0.21;
-  double distanceTolerance = 0.01;
-  double positionTolerance = 0.01;
-  double angularTolerance = 0.15;
-  double initialStepSize = 0.05;
-  double jointLimitTolerance = 1e-3;
-  double constraintCheckResolution = 1e-3;
-  std::chrono::duration<double> timelimit(5.);
 
   mSkel->setPositions(mStartConfig);
   auto startState = mStateSpace->createState();
   mStateSpace->convertPositionsToState(mStartConfig, startState);
 
-  // Create problem.
-  auto offsetProblem = ConfigurationToEndEffectorOffset(
-      // TODO: Will this even be used?
-      mStateSpace,
-      mBodynode,
-      startState,
-      direction,
-      signedDistance,
-      mPassingConstraint);
-
-  // Create planner.
-  auto vfOffsetPlanner = VectorFieldConfigurationToEndEffectorOffsetPlanner(
-      mStateSpace,
-      mSkel,
-      distanceTolerance,
-      positionTolerance,
-      angularTolerance,
-      initialStepSize,
-      jointLimitTolerance,
-      constraintCheckResolution,
-      timelimit);
-
-  EXPECT_THROW(vfOffsetPlanner.plan(offsetProblem), std::runtime_error);
+  // Create Problem, which should fail.
+  EXPECT_THROW(
+      ConfigurationToEndEffectorOffset(
+          // TODO: Will this even be used?
+          mStateSpace,
+          mBodynode,
+          startState,
+          direction,
+          signedDistance,
+          mPassingConstraint),
+      std::invalid_argument);
 }
 
 TEST_F(VectorFieldPlannerTest, PlanToEndEffectorPoseTest)


### PR DESCRIPTION
This PR has changes that use the new Planner API to refactor VFP.

Right now I've only refactored `planToEndEffectorOffset` by creating the new `VectorFieldConfigurationToEndEffectorOffsetPlanner` class. While these changes are looked over, I'll refactor `planToEndEffectorPose` as well.

**Summary of changes**

1) Create new `ConfigurationToEndEffectorOffsetPlanner` class for the `ConfigurationToEndEffectorOffset`  Problem.

2) Create `VectorFieldConfigurationToEndEffectorOffsetPlanner` class that extends the above and calls the old `planToEndEffectorOffset` method in `VectorFieldPlanner`.

**TODOs**

1) We need to figure out to handle the `startState` provided by `ConfigurationToEndEffectorOffset`. The old VFP code gets the current configuration from the metaSkeleton, so right now I just ignore this instance variable.

2) The old VFP code took `minDistance` and `maxDistance` for `planToEndEffectorOffset`. I provide these by taking a tolerance around the `signedDistance` provided by `ConfigurationToEndEffectorOffset`, but we should discuss whether this is appropriate (I also need to handle the negative case).

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
