### PR TITLE
Const changes to support new VFP Planner API refactor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * Fixed const correctness of StateHandle::getState(): [#419](https://github.com/personalrobotics/aikido/pull/419)
   * Fixed hidden compose function (in-place version): [#421](https://github.com/personalrobotics/aikido/pull/421)
   * Added clone functionality to StateSpace: [#422](https://github.com/personalrobotics/aikido/pull/422)
+  * Used const StateSpaces everywhere: [#429](https://github.com/personalrobotics/aikido/pull/429)
 
 * Constraint
 

--- a/include/aikido/constraint/CartesianProductProjectable.hpp
+++ b/include/aikido/constraint/CartesianProductProjectable.hpp
@@ -23,7 +23,7 @@ public:
       std::vector<ProjectablePtr> _constraints);
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   bool project(

--- a/include/aikido/constraint/CartesianProductProjectable.hpp
+++ b/include/aikido/constraint/CartesianProductProjectable.hpp
@@ -19,7 +19,7 @@ public:
   ///        should match the number of subspaces in _stateSpace.
   ///        i-th constraint applies to i-th subspace.
   CartesianProductProjectable(
-      std::shared_ptr<statespace::CartesianProduct> _stateSpace,
+      std::shared_ptr<const statespace::CartesianProduct> _stateSpace,
       std::vector<ProjectablePtr> _constraints);
 
   // Documentation inherited.
@@ -31,7 +31,7 @@ public:
       statespace::StateSpace::State* _out) const override;
 
 private:
-  std::shared_ptr<statespace::CartesianProduct> mStateSpace;
+  std::shared_ptr<const statespace::CartesianProduct> mStateSpace;
   std::vector<ProjectablePtr> mConstraints;
 };
 

--- a/include/aikido/constraint/CartesianProductSampleable.hpp
+++ b/include/aikido/constraint/CartesianProductSampleable.hpp
@@ -20,7 +20,7 @@ public:
   ///        should match the number of subspaces in _stateSpace.
   ///        i-th constraint applies to i-th subspace.
   CartesianProductSampleable(
-      std::shared_ptr<statespace::CartesianProduct> _stateSpace,
+      std::shared_ptr<const statespace::CartesianProduct> _stateSpace,
       std::vector<std::shared_ptr<Sampleable>> _constraints);
 
   // Documentation inherited.
@@ -30,7 +30,7 @@ public:
   std::unique_ptr<SampleGenerator> createSampleGenerator() const override;
 
 private:
-  std::shared_ptr<statespace::CartesianProduct> mStateSpace;
+  std::shared_ptr<const statespace::CartesianProduct> mStateSpace;
   std::vector<std::shared_ptr<Sampleable>> mConstraints;
 };
 

--- a/include/aikido/constraint/CartesianProductSampleable.hpp
+++ b/include/aikido/constraint/CartesianProductSampleable.hpp
@@ -24,7 +24,7 @@ public:
       std::vector<std::shared_ptr<Sampleable>> _constraints);
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   std::unique_ptr<SampleGenerator> createSampleGenerator() const override;

--- a/include/aikido/constraint/CartesianProductTestable.hpp
+++ b/include/aikido/constraint/CartesianProductTestable.hpp
@@ -20,10 +20,10 @@ public:
   ///        should match the number of subspaces in _stateSpace.
   ///        i-th constraint applies to i-th subspace.
   CartesianProductTestable(
-      std::shared_ptr<statespace::CartesianProduct> _stateSpace,
-      std::vector<TestablePtr> _constraints);
+      std::shared_ptr<const statespace::CartesianProduct> _stateSpace,
+      std::vector<ConstTestablePtr> _constraints);
 
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   bool isSatisfied(
       const aikido::statespace::StateSpace::State* _state,
@@ -34,8 +34,8 @@ public:
   std::unique_ptr<TestableOutcome> createOutcome() const override;
 
 private:
-  std::shared_ptr<statespace::CartesianProduct> mStateSpace;
-  std::vector<TestablePtr> mConstraints;
+  std::shared_ptr<const statespace::CartesianProduct> mStateSpace;
+  std::vector<ConstTestablePtr> mConstraints;
 };
 
 } // namespace constraint

--- a/include/aikido/constraint/CyclicSampleable.hpp
+++ b/include/aikido/constraint/CyclicSampleable.hpp
@@ -20,14 +20,14 @@ public:
   explicit CyclicSampleable(SampleablePtr _sampleable);
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   std::unique_ptr<SampleGenerator> createSampleGenerator() const override;
 
 private:
   SampleablePtr mSampleable;
-  statespace::StateSpacePtr mStateSpace;
+  statespace::ConstStateSpacePtr mStateSpace;
 };
 
 } // namespace constraint

--- a/include/aikido/constraint/Differentiable.hpp
+++ b/include/aikido/constraint/Differentiable.hpp
@@ -28,7 +28,7 @@ public:
   virtual ~Differentiable() = default;
 
   /// Gets the StateSpace that this constraint operates on.
-  virtual statespace::StateSpacePtr getStateSpace() const = 0;
+  virtual statespace::ConstStateSpacePtr getStateSpace() const = 0;
 
   /// Returns a vector of constraints' types, i-th element correspoinding to
   /// the type of i-th constraint.

--- a/include/aikido/constraint/DifferentiableIntersection.hpp
+++ b/include/aikido/constraint/DifferentiableIntersection.hpp
@@ -34,7 +34,7 @@ public:
   std::vector<ConstraintType> getConstraintTypes() const override;
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   void getValueAndJacobian(

--- a/include/aikido/constraint/DifferentiableIntersection.hpp
+++ b/include/aikido/constraint/DifferentiableIntersection.hpp
@@ -16,7 +16,7 @@ class DifferentiableIntersection : public Differentiable
 public:
   DifferentiableIntersection(
       std::vector<DifferentiablePtr> _constraints,
-      statespace::StateSpacePtr _stateSpace);
+      statespace::ConstStateSpacePtr _stateSpace);
 
   // Documentation inherited.
   std::size_t getConstraintDimension() const override;
@@ -44,7 +44,7 @@ public:
 
 private:
   std::vector<DifferentiablePtr> mConstraints;
-  std::shared_ptr<aikido::statespace::StateSpace> mStateSpace;
+  statespace::ConstStateSpacePtr mStateSpace;
 };
 
 } // namespace constraint

--- a/include/aikido/constraint/DifferentiableSubspace.hpp
+++ b/include/aikido/constraint/DifferentiableSubspace.hpp
@@ -24,7 +24,7 @@ public:
   virtual ~DifferentiableSubspace() = default;
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   std::vector<ConstraintType> getConstraintTypes() const override;

--- a/include/aikido/constraint/DifferentiableSubspace.hpp
+++ b/include/aikido/constraint/DifferentiableSubspace.hpp
@@ -17,7 +17,7 @@ public:
   /// \param _constraint Constraint being applied.
   /// \param _index Subspace of _stateSpace to apply _constraint.
   DifferentiableSubspace(
-      std::shared_ptr<statespace::CartesianProduct> _stateSpace,
+      std::shared_ptr<const statespace::CartesianProduct> _stateSpace,
       DifferentiablePtr _constraint,
       std::size_t _index);
 
@@ -48,7 +48,7 @@ public:
       Eigen::MatrixXd& _jac) const override;
 
 private:
-  std::shared_ptr<statespace::CartesianProduct> mStateSpace;
+  std::shared_ptr<const statespace::CartesianProduct> mStateSpace;
   DifferentiablePtr mConstraint;
   std::size_t mIndex;
 };

--- a/include/aikido/constraint/FiniteSampleable.hpp
+++ b/include/aikido/constraint/FiniteSampleable.hpp
@@ -42,7 +42,7 @@ public:
   std::unique_ptr<SampleGenerator> createSampleGenerator() const override;
 
 private:
-  statespace::StateSpacePtr mStateSpace;
+  statespace::ConstStateSpacePtr mStateSpace;
   std::vector<statespace::StateSpace::State*> mStates;
 };
 

--- a/include/aikido/constraint/FiniteSampleable.hpp
+++ b/include/aikido/constraint/FiniteSampleable.hpp
@@ -36,7 +36,7 @@ public:
   virtual ~FiniteSampleable();
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   std::unique_ptr<SampleGenerator> createSampleGenerator() const override;

--- a/include/aikido/constraint/NewtonsMethodProjectable.hpp
+++ b/include/aikido/constraint/NewtonsMethodProjectable.hpp
@@ -33,14 +33,14 @@ public:
       statespace::StateSpace::State* _out) const override;
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
 private:
   DifferentiablePtr mDifferentiable;
   std::vector<double> mTolerance;
   int mMaxIteration;
   double mMinStepSize;
-  statespace::StateSpacePtr mStateSpace;
+  statespace::ConstStateSpacePtr mStateSpace;
 
   bool contains(const statespace::StateSpace::State* _s) const;
 };

--- a/include/aikido/constraint/Projectable.hpp
+++ b/include/aikido/constraint/Projectable.hpp
@@ -14,7 +14,7 @@ public:
   virtual ~Projectable() = default;
 
   /// Gets the StateSpace that this constraint operates on.
-  virtual statespace::StateSpacePtr getStateSpace() const = 0;
+  virtual statespace::ConstStateSpacePtr getStateSpace() const = 0;
 
   /// Projection _s to _out. Returns false if projection cannot be done.
   /// \param _s state to be projected.

--- a/include/aikido/constraint/RejectionSampleable.hpp
+++ b/include/aikido/constraint/RejectionSampleable.hpp
@@ -36,7 +36,7 @@ public:
   std::unique_ptr<SampleGenerator> createSampleGenerator() const override;
 
 private:
-  statespace::StateSpacePtr mStateSpace;
+  statespace::ConstStateSpacePtr mStateSpace;
   SampleablePtr mSampleable;
   TestablePtr mTestable;
   int mMaxTrialPerSample;

--- a/include/aikido/constraint/RejectionSampleable.hpp
+++ b/include/aikido/constraint/RejectionSampleable.hpp
@@ -30,7 +30,7 @@ public:
       int _maxTrialPerSample);
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   std::unique_ptr<SampleGenerator> createSampleGenerator() const override;

--- a/include/aikido/constraint/Sampleable.hpp
+++ b/include/aikido/constraint/Sampleable.hpp
@@ -29,7 +29,7 @@ public:
   virtual ~Sampleable() = default;
 
   /// Gets the StateSpace that this constraint operates on.
-  virtual statespace::StateSpacePtr getStateSpace() const = 0;
+  virtual statespace::ConstStateSpacePtr getStateSpace() const = 0;
 
   /// Creates a SampleGenerator for sampling from this constraint.
   virtual std::unique_ptr<SampleGenerator> createSampleGenerator() const = 0;

--- a/include/aikido/constraint/Sampleable.hpp
+++ b/include/aikido/constraint/Sampleable.hpp
@@ -49,7 +49,7 @@ public:
   static constexpr int NO_LIMIT = std::numeric_limits<int>::max();
 
   /// Gets the StateSpace that this SampleGenerator samples from.
-  virtual statespace::StateSpacePtr getStateSpace() const = 0;
+  virtual statespace::ConstStateSpacePtr getStateSpace() const = 0;
 
   /// Returns one sample from this constraint; returns true if succeeded.
   virtual bool sample(statespace::StateSpace::State* _state) = 0;

--- a/include/aikido/constraint/Satisfied.hpp
+++ b/include/aikido/constraint/Satisfied.hpp
@@ -20,7 +20,7 @@ public:
 
   /// Constructor.
   /// \param _space StateSpace in which this constraint operates.
-  explicit Satisfied(statespace::StateSpacePtr _space);
+  explicit Satisfied(statespace::ConstStateSpacePtr _space);
 
   // Documentation inherited.
   statespace::ConstStateSpacePtr getStateSpace() const override;
@@ -68,7 +68,7 @@ public:
       Eigen::MatrixXd& _out) const override;
 
 private:
-  statespace::StateSpacePtr mStateSpace;
+  statespace::ConstStateSpacePtr mStateSpace;
 };
 
 } // namespace constraint

--- a/include/aikido/constraint/Satisfied.hpp
+++ b/include/aikido/constraint/Satisfied.hpp
@@ -23,7 +23,7 @@ public:
   explicit Satisfied(statespace::StateSpacePtr _space);
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   /// Returns \c 0.
   std::size_t getConstraintDimension() const override;

--- a/include/aikido/constraint/SequentialSampleable.hpp
+++ b/include/aikido/constraint/SequentialSampleable.hpp
@@ -19,7 +19,6 @@ public:
       const std::vector<ConstSampleablePtr>& sampleables);
 
   // Documentation inherited.
-  // TODO (avk): const-correctness after planner API is merged.
   statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
@@ -27,7 +26,7 @@ public:
 
 private:
   /// StateSpace in which the constraint operates.
-  statespace::StateSpacePtr mStateSpace;
+  statespace::ConstStateSpacePtr mStateSpace;
 
   /// Sequence of sampleables.
   const std::vector<ConstSampleablePtr> mSampleables;

--- a/include/aikido/constraint/SequentialSampleable.hpp
+++ b/include/aikido/constraint/SequentialSampleable.hpp
@@ -20,7 +20,7 @@ public:
 
   // Documentation inherited.
   // TODO (avk): const-correctness after planner API is merged.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   std::unique_ptr<SampleGenerator> createSampleGenerator() const override;

--- a/include/aikido/constraint/Testable.hpp
+++ b/include/aikido/constraint/Testable.hpp
@@ -30,7 +30,7 @@ public:
       TestableOutcome* outcome = nullptr) const = 0;
 
   /// Returns StateSpace in which this constraint operates.
-  virtual statespace::StateSpacePtr getStateSpace() const = 0;
+  virtual statespace::ConstStateSpacePtr getStateSpace() const = 0;
 
   /// Return an instance of a TestableOutcome derivative class that corresponds
   /// to this constraint class. Ensures that correct outcome object is passed

--- a/include/aikido/constraint/TestableIntersection.hpp
+++ b/include/aikido/constraint/TestableIntersection.hpp
@@ -21,7 +21,7 @@ public:
   /// \param _constraints Set of constraints.
   TestableIntersection(
       statespace::StateSpacePtr _stateSpace,
-      std::vector<TestablePtr> _constraints = std::vector<TestablePtr>());
+      std::vector<ConstTestablePtr> _constraints = std::vector<ConstTestablePtr>());
 
   // Documentation inherited.
   bool isSatisfied(
@@ -33,18 +33,18 @@ public:
   std::unique_ptr<TestableOutcome> createOutcome() const override;
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   /// Add a Testable to the conjunction.
   /// \param constraint a constraint in the same StateSpace as the
   ///        TestableIntersection was initialize with.
-  void addConstraint(TestablePtr constraint);
+  void addConstraint(ConstTestablePtr constraint);
 
 private:
   statespace::StateSpacePtr mStateSpace;
-  std::vector<TestablePtr> mConstraints;
+  std::vector<ConstTestablePtr> mConstraints;
 
-  void testConstraintStateSpaceOrThrow(const TestablePtr& constraint);
+  void testConstraintStateSpaceOrThrow(const ConstTestablePtr& constraint);
 };
 
 } // namespace constraint

--- a/include/aikido/constraint/TestableIntersection.hpp
+++ b/include/aikido/constraint/TestableIntersection.hpp
@@ -20,7 +20,7 @@ public:
   /// \param _stateSpace StateSpace this constraint operates in.
   /// \param _constraints Set of constraints.
   TestableIntersection(
-      statespace::StateSpacePtr _stateSpace,
+      statespace::ConstStateSpacePtr _stateSpace,
       std::vector<ConstTestablePtr> _constraints = std::vector<ConstTestablePtr>());
 
   // Documentation inherited.
@@ -41,7 +41,7 @@ public:
   void addConstraint(ConstTestablePtr constraint);
 
 private:
-  statespace::StateSpacePtr mStateSpace;
+  statespace::ConstStateSpacePtr mStateSpace;
   std::vector<ConstTestablePtr> mConstraints;
 
   void testConstraintStateSpaceOrThrow(const ConstTestablePtr& constraint);

--- a/include/aikido/constraint/TestableIntersection.hpp
+++ b/include/aikido/constraint/TestableIntersection.hpp
@@ -21,7 +21,8 @@ public:
   /// \param _constraints Set of constraints.
   TestableIntersection(
       statespace::ConstStateSpacePtr _stateSpace,
-      std::vector<ConstTestablePtr> _constraints = std::vector<ConstTestablePtr>());
+      std::vector<ConstTestablePtr> _constraints
+      = std::vector<ConstTestablePtr>());
 
   // Documentation inherited.
   bool isSatisfied(

--- a/include/aikido/constraint/dart/CollisionFree.hpp
+++ b/include/aikido/constraint/dart/CollisionFree.hpp
@@ -85,7 +85,8 @@ public:
 private:
   using CollisionGroup = ::dart::collision::CollisionGroup;
 
-  aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
+  aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr
+      mMetaSkeletonStateSpace;
   ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
   std::shared_ptr<::dart::collision::CollisionDetector> mCollisionDetector;
   ::dart::collision::CollisionOption mCollisionOptions;

--- a/include/aikido/constraint/dart/CollisionFree.hpp
+++ b/include/aikido/constraint/dart/CollisionFree.hpp
@@ -35,7 +35,7 @@ public:
   /// \param _collisionDetector collision detector used to test for collision
   /// \param _collisionOptions options passed to \c _collisionDetector
   CollisionFree(
-      statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
+      statespace::dart::ConstMetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
       ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
       std::shared_ptr<::dart::collision::CollisionDetector> _collisionDetector,
       ::dart::collision::CollisionOption _collisionOptions
@@ -85,7 +85,7 @@ public:
 private:
   using CollisionGroup = ::dart::collision::CollisionGroup;
 
-  aikido::statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
+  aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
   ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
   std::shared_ptr<::dart::collision::CollisionDetector> mCollisionDetector;
   ::dart::collision::CollisionOption mCollisionOptions;

--- a/include/aikido/constraint/dart/CollisionFree.hpp
+++ b/include/aikido/constraint/dart/CollisionFree.hpp
@@ -45,7 +45,7 @@ public:
           std::make_shared<::dart::collision::BodyNodeCollisionFilter>()));
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   /// \copydoc Testable::isSatisfied()
   /// \note Outcome is expected to be an instance of CollisionFreeOutcome.

--- a/include/aikido/constraint/dart/FrameDifferentiable.hpp
+++ b/include/aikido/constraint/dart/FrameDifferentiable.hpp
@@ -65,7 +65,7 @@ public:
   statespace::ConstStateSpacePtr getStateSpace() const override;
 
 private:
-  statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
+  statespace::dart::ConstMetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
   ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
   ::dart::dynamics::ConstJacobianNodePtr mJacobianNode;
   DifferentiablePtr mPoseConstraint;

--- a/include/aikido/constraint/dart/FrameDifferentiable.hpp
+++ b/include/aikido/constraint/dart/FrameDifferentiable.hpp
@@ -62,7 +62,7 @@ public:
   std::vector<ConstraintType> getConstraintTypes() const override;
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
 private:
   statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;

--- a/include/aikido/constraint/dart/FramePairDifferentiable.hpp
+++ b/include/aikido/constraint/dart/FramePairDifferentiable.hpp
@@ -60,7 +60,7 @@ public:
   statespace::ConstStateSpacePtr getStateSpace() const override;
 
 private:
-  statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
+  statespace::dart::ConstMetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
   ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
   ::dart::dynamics::ConstJacobianNodePtr mJacobianNode1;
   ::dart::dynamics::ConstJacobianNodePtr mJacobianNode2;

--- a/include/aikido/constraint/dart/FramePairDifferentiable.hpp
+++ b/include/aikido/constraint/dart/FramePairDifferentiable.hpp
@@ -57,7 +57,7 @@ public:
   std::vector<ConstraintType> getConstraintTypes() const override;
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
 private:
   statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;

--- a/include/aikido/constraint/dart/FrameTestable.hpp
+++ b/include/aikido/constraint/dart/FrameTestable.hpp
@@ -48,7 +48,7 @@ public:
   statespace::ConstStateSpacePtr getStateSpace() const override;
 
 private:
-  statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
+  statespace::dart::ConstMetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
   ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
   ::dart::dynamics::ConstJacobianNodePtr mFrame;
   TestablePtr mPoseConstraint;

--- a/include/aikido/constraint/dart/FrameTestable.hpp
+++ b/include/aikido/constraint/dart/FrameTestable.hpp
@@ -45,14 +45,14 @@ public:
   std::unique_ptr<TestableOutcome> createOutcome() const override;
 
   // Documentation inherited
-  std::shared_ptr<statespace::StateSpace> getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
 private:
   statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
   ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
   ::dart::dynamics::ConstJacobianNodePtr mFrame;
   TestablePtr mPoseConstraint;
-  std::shared_ptr<statespace::SE3> mPoseStateSpace;
+  std::shared_ptr<const statespace::SE3> mPoseStateSpace;
 };
 
 } // namespace dart

--- a/include/aikido/constraint/dart/InverseKinematicsSampleable.hpp
+++ b/include/aikido/constraint/dart/InverseKinematicsSampleable.hpp
@@ -41,7 +41,7 @@ public:
   virtual ~InverseKinematicsSampleable() = default;
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   std::unique_ptr<SampleGenerator> createSampleGenerator() const override;

--- a/include/aikido/constraint/dart/InverseKinematicsSampleable.hpp
+++ b/include/aikido/constraint/dart/InverseKinematicsSampleable.hpp
@@ -47,7 +47,7 @@ public:
   std::unique_ptr<SampleGenerator> createSampleGenerator() const override;
 
 private:
-  statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
+  statespace::dart::ConstMetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
   ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
   SampleablePtr mPoseConstraint;
   SampleablePtr mSeedConstraint;

--- a/include/aikido/constraint/dart/JointStateSpaceHelpers.hpp
+++ b/include/aikido/constraint/dart/JointStateSpaceHelpers.hpp
@@ -78,7 +78,7 @@ std::unique_ptr<Testable> createTestableBounds(
 /// \param _metaSkeleton The MetaSkeletonStateSpace where the Testable will be
 /// applied.
 std::unique_ptr<Testable> createTestableBounds(
-    statespace::dart::MetaSkeletonStateSpacePtr _metaSkeleton);
+    statespace::dart::ConstMetaSkeletonStateSpacePtr _metaSkeleton);
 
 /// Create a Sampleable constraint that can be used to sample a state that is
 /// guarenteed to lie within bounds define on the StateSpace.

--- a/include/aikido/constraint/dart/JointStateSpaceHelpers.hpp
+++ b/include/aikido/constraint/dart/JointStateSpaceHelpers.hpp
@@ -33,7 +33,7 @@ std::unique_ptr<Differentiable> createDifferentiableBounds(
 /// \param _metaSkeleton The MetaSkeletonStateSpace where the Differentiable
 /// will be applied
 std::unique_ptr<Differentiable> createDifferentiableBounds(
-    statespace::dart::MetaSkeletonStateSpacePtr _metaSkeleton);
+    statespace::dart::ConstMetaSkeletonStateSpacePtr _metaSkeleton);
 
 /// Create a Projectable that can be used to project a state from the given
 /// StateSpace back within bounds set on the StateSpace.

--- a/include/aikido/constraint/dart/JointStateSpaceHelpers.hpp
+++ b/include/aikido/constraint/dart/JointStateSpaceHelpers.hpp
@@ -24,7 +24,7 @@ std::unique_ptr<Differentiable> createDifferentiableBoundsFor(
 /// Differtiable is created.
 /// \param _stateSpace The StateSpace where the Differentiable will be applied
 std::unique_ptr<Differentiable> createDifferentiableBounds(
-    std::shared_ptr<statespace::dart::JointStateSpace> _stateSpace);
+    std::shared_ptr<const statespace::dart::JointStateSpace> _stateSpace);
 
 /// Create a set of Differentiable constraints for each joint in the
 /// MetaSkeleton wrapped by the state space.  The bounds are created from the
@@ -48,7 +48,7 @@ std::unique_ptr<Projectable> createProjectableBoundsFor(
 /// \param _stateSpace The JointStateSpace where the Projectable will be
 /// applied.
 std::unique_ptr<Projectable> createProjectableBounds(
-    std::shared_ptr<statespace::dart::JointStateSpace> _stateSpace);
+    std::shared_ptr<const statespace::dart::JointStateSpace> _stateSpace);
 
 /// Create a set of Projectable constraints for each joint in the MetaSkeleton
 /// wrapped by the state space. The constraints can be used to project a state
@@ -56,7 +56,7 @@ std::unique_ptr<Projectable> createProjectableBounds(
 /// \param _metaSkeleton The MetaSkeletonStateSpace where the Projectable will
 /// be applied.
 std::unique_ptr<Projectable> createProjectableBounds(
-    statespace::dart::MetaSkeletonStateSpacePtr _metaSkeleton);
+    statespace::dart::ConstMetaSkeletonStateSpacePtr _metaSkeleton);
 
 /// Create a Testable constraint that can be used to determine if a given state
 /// lies within bounds set on the StateSpace.
@@ -70,7 +70,7 @@ std::unique_ptr<Testable> createTestableBoundsFor(
 /// limits set on the joint wrapped by the given JointStateSpace.
 /// \param _stateSpace The JointStateSpace where the Testable will be applied
 std::unique_ptr<Testable> createTestableBounds(
-    std::shared_ptr<statespace::dart::JointStateSpace> _stateSpace);
+    std::shared_ptr<const statespace::dart::JointStateSpace> _stateSpace);
 
 /// Create a set of Testable constraints for each joint in the MetaSkeleton
 /// wrapped by the state space.  The constraints can be used to determine if a
@@ -95,7 +95,7 @@ std::unique_ptr<Sampleable> createSampleableBoundsFor(
 /// \param _stateSpace The JointStateSpace where the Sampleable will be applied
 /// \param _rng The random number generator to be used by the Sampleable
 std::unique_ptr<Sampleable> createSampleableBounds(
-    std::shared_ptr<statespace::dart::JointStateSpace> _stateSpace,
+    std::shared_ptr<const statespace::dart::JointStateSpace> _stateSpace,
     std::unique_ptr<common::RNG> _rng);
 
 /// Create a Sampleable constraint that can be used to sampel values for all
@@ -105,7 +105,7 @@ std::unique_ptr<Sampleable> createSampleableBounds(
 /// applied
 /// \param _rng The random number generator to be used by the Sampleable
 std::unique_ptr<Sampleable> createSampleableBounds(
-    statespace::dart::MetaSkeletonStateSpacePtr _metaSkeleton,
+    statespace::dart::ConstMetaSkeletonStateSpacePtr _metaSkeleton,
     std::unique_ptr<common::RNG> _rng);
 
 } // namespace dart

--- a/include/aikido/constraint/dart/TSR.hpp
+++ b/include/aikido/constraint/dart/TSR.hpp
@@ -74,7 +74,7 @@ public:
   virtual ~TSR() = default;
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   /// Returns the SE3 which this TSR operates in.
   std::shared_ptr<statespace::SE3> getSE3() const;

--- a/include/aikido/constraint/dart/detail/JointStateSpaceHelpers-impl.hpp
+++ b/include/aikido/constraint/dart/detail/JointStateSpaceHelpers-impl.hpp
@@ -22,16 +22,17 @@ namespace detail {
 using ::dart::common::make_unique;
 
 //==============================================================================
-using JointStateSpaceTypeList = common::type_list<const statespace::dart::R0Joint,
-                                                  const statespace::dart::R1Joint,
-                                                  const statespace::dart::R2Joint,
-                                                  const statespace::dart::R3Joint,
-                                                  const statespace::dart::R6Joint,
-                                                  const statespace::dart::SO2Joint,
-                                                  const statespace::dart::SO3Joint,
-                                                  const statespace::dart::SE2Joint,
-                                                  const statespace::dart::SE3Joint,
-                                                  const statespace::dart::WeldJoint>;
+using JointStateSpaceTypeList
+    = common::type_list<const statespace::dart::R0Joint,
+                        const statespace::dart::R1Joint,
+                        const statespace::dart::R2Joint,
+                        const statespace::dart::R3Joint,
+                        const statespace::dart::R6Joint,
+                        const statespace::dart::SO2Joint,
+                        const statespace::dart::SO3Joint,
+                        const statespace::dart::SE2Joint,
+                        const statespace::dart::SE3Joint,
+                        const statespace::dart::WeldJoint>;
 
 //==============================================================================
 template <class T>
@@ -93,7 +94,6 @@ struct createDifferentiableFor_impl<const statespace::dart::RJoint<N>>
         std::move(_stateSpace), nullptr);
   }
 };
-
 
 //==============================================================================
 template <int N>
@@ -309,7 +309,8 @@ struct createDifferentiableFor_impl<const statespace::dart::SE2Joint>
   using StateSpace = statespace::dart::SE2Joint;
   using ConstStateSpacePtr = std::shared_ptr<const StateSpace>;
 
-  static std::unique_ptr<Differentiable> create(ConstStateSpacePtr /*_stateSpace*/)
+  static std::unique_ptr<Differentiable> create(
+      ConstStateSpacePtr /*_stateSpace*/)
   {
     throw std::runtime_error(
         "No DifferentiableConstraint is available for SE2Joint.");
@@ -396,7 +397,8 @@ struct createDifferentiableFor_impl<const statespace::dart::SE3Joint>
   using StateSpace = statespace::dart::SE3Joint;
   using ConstStateSpacePtr = std::shared_ptr<const StateSpace>;
 
-  static std::unique_ptr<Differentiable> create(ConstStateSpacePtr /*_stateSpace*/)
+  static std::unique_ptr<Differentiable> create(
+      ConstStateSpacePtr /*_stateSpace*/)
   {
     throw std::runtime_error(
         "No DifferentiableConstraint is available for SE3Joint.");
@@ -534,7 +536,8 @@ template <class Space>
 std::unique_ptr<Testable> createTestableBoundsFor(
     std::shared_ptr<Space> _stateSpace)
 {
-  return detail::createTestableFor_impl<const Space>::create(std::move(_stateSpace));
+  return detail::createTestableFor_impl<const Space>::create(
+      std::move(_stateSpace));
 }
 
 //==============================================================================

--- a/include/aikido/constraint/dart/detail/JointStateSpaceHelpers-impl.hpp
+++ b/include/aikido/constraint/dart/detail/JointStateSpaceHelpers-impl.hpp
@@ -22,19 +22,7 @@ namespace detail {
 using ::dart::common::make_unique;
 
 //==============================================================================
-using JointStateSpaceTypeList = common::type_list<statespace::dart::R0Joint,
-                                                  statespace::dart::R1Joint,
-                                                  statespace::dart::R2Joint,
-                                                  statespace::dart::R3Joint,
-                                                  statespace::dart::R6Joint,
-                                                  statespace::dart::SO2Joint,
-                                                  statespace::dart::SO3Joint,
-                                                  statespace::dart::SE2Joint,
-                                                  statespace::dart::SE3Joint,
-                                                  statespace::dart::WeldJoint>;
-
-//==============================================================================
-using ConstJointStateSpaceTypeList = common::type_list<const statespace::dart::R0Joint,
+using JointStateSpaceTypeList = common::type_list<const statespace::dart::R0Joint,
                                                   const statespace::dart::R1Joint,
                                                   const statespace::dart::R2Joint,
                                                   const statespace::dart::R3Joint,
@@ -94,20 +82,6 @@ std::unique_ptr<OutputConstraint> createBoxConstraint(
 
 //==============================================================================
 template <int N>
-struct createDifferentiableFor_impl<statespace::dart::RJoint<N>>
-{
-  using StateSpace = statespace::dart::RJoint<N>;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Differentiable> create(StateSpacePtr _stateSpace)
-  {
-    return createBoxConstraint<N, Differentiable>(
-        std::move(_stateSpace), nullptr);
-  }
-};
-
-//==============================================================================
-template <int N>
 struct createDifferentiableFor_impl<const statespace::dart::RJoint<N>>
 {
   using StateSpace = statespace::dart::RJoint<N>;
@@ -120,18 +94,6 @@ struct createDifferentiableFor_impl<const statespace::dart::RJoint<N>>
   }
 };
 
-//==============================================================================
-template <int N>
-struct createTestableFor_impl<statespace::dart::RJoint<N>>
-{
-  using StateSpace = statespace::dart::RJoint<N>;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Testable> create(StateSpacePtr _stateSpace)
-  {
-    return createBoxConstraint<N, Testable>(std::move(_stateSpace), nullptr);
-  }
-};
 
 //==============================================================================
 template <int N>
@@ -148,19 +110,6 @@ struct createTestableFor_impl<const statespace::dart::RJoint<N>>
 
 //==============================================================================
 template <int N>
-struct createProjectableFor_impl<statespace::dart::RJoint<N>>
-{
-  using StateSpace = statespace::dart::RJoint<N>;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Projectable> create(StateSpacePtr _stateSpace)
-  {
-    return createBoxConstraint<N, Projectable>(std::move(_stateSpace), nullptr);
-  }
-};
-
-//==============================================================================
-template <int N>
 struct createProjectableFor_impl<const statespace::dart::RJoint<N>>
 {
   using StateSpace = statespace::dart::RJoint<N>;
@@ -169,33 +118,6 @@ struct createProjectableFor_impl<const statespace::dart::RJoint<N>>
   static std::unique_ptr<Projectable> create(ConstStateSpacePtr _stateSpace)
   {
     return createBoxConstraint<N, Projectable>(std::move(_stateSpace), nullptr);
-  }
-};
-
-//==============================================================================
-template <int N>
-struct createSampleableFor_impl<statespace::dart::RJoint<N>>
-{
-  using StateSpace = statespace::dart::RJoint<N>;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Sampleable> create(
-      StateSpacePtr _stateSpace, std::unique_ptr<common::RNG> _rng)
-  {
-    const auto properties = _stateSpace->getProperties();
-
-    if (properties.isPositionLimited())
-    {
-      return make_unique<uniform::RBoxConstraint<N>>(
-          std::move(_stateSpace),
-          std::move(_rng),
-          properties.getPositionLowerLimits(),
-          properties.getPositionUpperLimits());
-    }
-    else
-    {
-      throw std::runtime_error("Unable to create Sampleable for unbounded Rn.");
-    }
   }
 };
 
@@ -228,44 +150,12 @@ struct createSampleableFor_impl<const statespace::dart::RJoint<N>>
 
 //==============================================================================
 template <>
-struct createDifferentiableFor_impl<statespace::dart::SO2Joint>
-{
-  using StateSpace = statespace::dart::SO2Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Differentiable> create(StateSpacePtr _stateSpace)
-  {
-    if (_stateSpace->getProperties().isPositionLimited())
-      throw std::invalid_argument("SO2Joint must not have limits.");
-
-    return make_unique<Satisfied>(std::move(_stateSpace));
-  }
-};
-
-//==============================================================================
-template <>
 struct createDifferentiableFor_impl<const statespace::dart::SO2Joint>
 {
   using StateSpace = statespace::dart::SO2Joint;
   using ConstStateSpacePtr = std::shared_ptr<const StateSpace>;
 
   static std::unique_ptr<Differentiable> create(ConstStateSpacePtr _stateSpace)
-  {
-    if (_stateSpace->getProperties().isPositionLimited())
-      throw std::invalid_argument("SO2Joint must not have limits.");
-
-    return make_unique<Satisfied>(std::move(_stateSpace));
-  }
-};
-
-//==============================================================================
-template <>
-struct createTestableFor_impl<statespace::dart::SO2Joint>
-{
-  using StateSpace = statespace::dart::SO2Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Testable> create(StateSpacePtr _stateSpace)
   {
     if (_stateSpace->getProperties().isPositionLimited())
       throw std::invalid_argument("SO2Joint must not have limits.");
@@ -292,22 +182,6 @@ struct createTestableFor_impl<const statespace::dart::SO2Joint>
 
 //==============================================================================
 template <>
-struct createProjectableFor_impl<statespace::dart::SO2Joint>
-{
-  using StateSpace = statespace::dart::SO2Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Projectable> create(StateSpacePtr _stateSpace)
-  {
-    if (_stateSpace->getProperties().isPositionLimited())
-      throw std::invalid_argument("SO2Joint must not have limits.");
-
-    return make_unique<Satisfied>(std::move(_stateSpace));
-  }
-};
-
-//==============================================================================
-template <>
 struct createProjectableFor_impl<const statespace::dart::SO2Joint>
 {
   using StateSpace = statespace::dart::SO2Joint;
@@ -319,24 +193,6 @@ struct createProjectableFor_impl<const statespace::dart::SO2Joint>
       throw std::invalid_argument("SO2Joint must not have limits.");
 
     return make_unique<Satisfied>(std::move(_stateSpace));
-  }
-};
-
-//==============================================================================
-template <>
-struct createSampleableFor_impl<statespace::dart::SO2Joint>
-{
-  using StateSpace = statespace::dart::SO2Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Sampleable> create(
-      StateSpacePtr _stateSpace, std::unique_ptr<common::RNG> _rng)
-  {
-    if (_stateSpace->getProperties().isPositionLimited())
-      throw std::invalid_argument("SO2Joint must not have limits.");
-
-    return make_unique<uniform::SO2UniformSampler>(
-        std::move(_stateSpace), std::move(_rng));
   }
 };
 
@@ -360,44 +216,12 @@ struct createSampleableFor_impl<const statespace::dart::SO2Joint>
 
 //==============================================================================
 template <>
-struct createDifferentiableFor_impl<statespace::dart::SO3Joint>
-{
-  using StateSpace = statespace::dart::SO3Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Differentiable> create(StateSpacePtr _stateSpace)
-  {
-    if (_stateSpace->getProperties().isPositionLimited())
-      throw std::invalid_argument("SO3Joint must not have limits.");
-
-    return make_unique<Satisfied>(std::move(_stateSpace));
-  }
-};
-
-//==============================================================================
-template <>
 struct createDifferentiableFor_impl<const statespace::dart::SO3Joint>
 {
   using StateSpace = statespace::dart::SO3Joint;
   using ConstStateSpacePtr = std::shared_ptr<const StateSpace>;
 
   static std::unique_ptr<Differentiable> create(ConstStateSpacePtr _stateSpace)
-  {
-    if (_stateSpace->getProperties().isPositionLimited())
-      throw std::invalid_argument("SO3Joint must not have limits.");
-
-    return make_unique<Satisfied>(std::move(_stateSpace));
-  }
-};
-
-//==============================================================================
-template <>
-struct createTestableFor_impl<statespace::dart::SO3Joint>
-{
-  using StateSpace = statespace::dart::SO3Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Testable> create(StateSpacePtr _stateSpace)
   {
     if (_stateSpace->getProperties().isPositionLimited())
       throw std::invalid_argument("SO3Joint must not have limits.");
@@ -424,22 +248,6 @@ struct createTestableFor_impl<const statespace::dart::SO3Joint>
 
 //==============================================================================
 template <>
-struct createProjectableFor_impl<statespace::dart::SO3Joint>
-{
-  using StateSpace = statespace::dart::SO3Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Projectable> create(StateSpacePtr _stateSpace)
-  {
-    if (_stateSpace->getProperties().isPositionLimited())
-      throw std::invalid_argument("SO3Joint must not have limits.");
-
-    return make_unique<Satisfied>(std::move(_stateSpace));
-  }
-};
-
-//==============================================================================
-template <>
 struct createProjectableFor_impl<const statespace::dart::SO3Joint>
 {
   using StateSpace = statespace::dart::SO3Joint;
@@ -451,24 +259,6 @@ struct createProjectableFor_impl<const statespace::dart::SO3Joint>
       throw std::invalid_argument("SO3Joint must not have limits.");
 
     return make_unique<Satisfied>(std::move(_stateSpace));
-  }
-};
-
-//==============================================================================
-template <>
-struct createSampleableFor_impl<statespace::dart::SO3Joint>
-{
-  using StateSpace = statespace::dart::SO3Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Sampleable> create(
-      StateSpacePtr _stateSpace, std::unique_ptr<common::RNG> _rng)
-  {
-    if (_stateSpace->getProperties().isPositionLimited())
-      throw std::invalid_argument("SO3Joint must not have limits.");
-
-    return make_unique<uniform::SO3UniformSampler>(
-        std::move(_stateSpace), std::move(_rng));
   }
 };
 
@@ -514,20 +304,6 @@ std::unique_ptr<OutputConstraint> createBoxConstraint(
 
 //==============================================================================
 template <>
-struct createDifferentiableFor_impl<statespace::dart::SE2Joint>
-{
-  using StateSpace = statespace::dart::SE2Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Differentiable> create(StateSpacePtr /*_stateSpace*/)
-  {
-    throw std::runtime_error(
-        "No DifferentiableConstraint is available for SE2Joint.");
-  }
-};
-
-//==============================================================================
-template <>
 struct createDifferentiableFor_impl<const statespace::dart::SE2Joint>
 {
   using StateSpace = statespace::dart::SE2Joint;
@@ -537,26 +313,6 @@ struct createDifferentiableFor_impl<const statespace::dart::SE2Joint>
   {
     throw std::runtime_error(
         "No DifferentiableConstraint is available for SE2Joint.");
-  }
-};
-
-//==============================================================================
-template <>
-struct createTestableFor_impl<statespace::dart::SE2Joint>
-{
-  using StateSpace = statespace::dart::SE2Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Testable> create(StateSpacePtr _stateSpace)
-  {
-    const auto properties = _stateSpace->getProperties();
-    if (properties.hasPositionLimit(0))
-    {
-      throw std::invalid_argument(
-          "Rotational component of SE2Joint must not have limits.");
-    }
-
-    return createBoxConstraint<Testable>(std::move(_stateSpace), nullptr);
   }
 };
 
@@ -582,26 +338,6 @@ struct createTestableFor_impl<const statespace::dart::SE2Joint>
 
 //==============================================================================
 template <>
-struct createProjectableFor_impl<statespace::dart::SE2Joint>
-{
-  using StateSpace = statespace::dart::SE2Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Projectable> create(StateSpacePtr _stateSpace)
-  {
-    const auto properties = _stateSpace->getProperties();
-    if (properties.hasPositionLimit(0))
-    {
-      throw std::invalid_argument(
-          "Rotational component of SE2Joint must not have limits.");
-    }
-
-    return createBoxConstraint<Projectable>(std::move(_stateSpace), nullptr);
-  }
-};
-
-//==============================================================================
-template <>
 struct createProjectableFor_impl<const statespace::dart::SE2Joint>
 {
   using StateSpace = statespace::dart::SE2Joint;
@@ -617,39 +353,6 @@ struct createProjectableFor_impl<const statespace::dart::SE2Joint>
     }
 
     return createBoxConstraint<Projectable>(std::move(_stateSpace), nullptr);
-  }
-};
-
-//==============================================================================
-template <>
-struct createSampleableFor_impl<statespace::dart::SE2Joint>
-{
-  using StateSpace = statespace::dart::SE2Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Sampleable> create(
-      StateSpacePtr stateSpace, std::unique_ptr<common::RNG> rng)
-  {
-    const auto properties = stateSpace->getProperties();
-    if (properties.hasPositionLimit(0))
-    {
-      throw std::invalid_argument(
-          "Rotational component of SE2Joint must not have limits.");
-    }
-    else if (
-        !(properties.hasPositionLimit(1) && properties.hasPositionLimit(2)))
-    {
-      throw std::runtime_error(
-          "Unable to create Sampleable for unbounded SE2.");
-    }
-    else
-    {
-      return make_unique<uniform::SE2BoxConstraint>(
-          std::move(stateSpace),
-          std::move(rng),
-          properties.getPositionLowerLimits().tail<2>(),
-          properties.getPositionUpperLimits().tail<2>());
-    }
   }
 };
 
@@ -688,20 +391,6 @@ struct createSampleableFor_impl<const statespace::dart::SE2Joint>
 
 //==============================================================================
 template <>
-struct createDifferentiableFor_impl<statespace::dart::SE3Joint>
-{
-  using StateSpace = statespace::dart::SE3Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Differentiable> create(StateSpacePtr /*_stateSpace*/)
-  {
-    throw std::runtime_error(
-        "No DifferentiableConstraint is available for SE3Joint.");
-  }
-};
-
-//==============================================================================
-template <>
 struct createDifferentiableFor_impl<const statespace::dart::SE3Joint>
 {
   using StateSpace = statespace::dart::SE3Joint;
@@ -711,19 +400,6 @@ struct createDifferentiableFor_impl<const statespace::dart::SE3Joint>
   {
     throw std::runtime_error(
         "No DifferentiableConstraint is available for SE3Joint.");
-  }
-};
-
-//==============================================================================
-template <>
-struct createTestableFor_impl<statespace::dart::SE3Joint>
-{
-  using StateSpace = statespace::dart::SE3Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Testable> create(StateSpacePtr /*_stateSpace*/)
-  {
-    throw std::runtime_error("No Testable is available for SE3Joint.");
   }
 };
 
@@ -742,19 +418,6 @@ struct createTestableFor_impl<const statespace::dart::SE3Joint>
 
 //==============================================================================
 template <>
-struct createProjectableFor_impl<statespace::dart::SE3Joint>
-{
-  using StateSpace = statespace::dart::SE3Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Projectable> create(StateSpacePtr /*_stateSpace*/)
-  {
-    throw std::runtime_error("No Projectable is available for SE3Joint.");
-  }
-};
-
-//==============================================================================
-template <>
 struct createProjectableFor_impl<const statespace::dart::SE3Joint>
 {
   using StateSpace = statespace::dart::SE3Joint;
@@ -763,20 +426,6 @@ struct createProjectableFor_impl<const statespace::dart::SE3Joint>
   static std::unique_ptr<Projectable> create(ConstStateSpacePtr /*_stateSpace*/)
   {
     throw std::runtime_error("No Projectable is available for SE3Joint.");
-  }
-};
-
-//==============================================================================
-template <>
-struct createSampleableFor_impl<statespace::dart::SE3Joint>
-{
-  using StateSpace = statespace::dart::SE3Joint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Sampleable> create(
-      StateSpacePtr /*_stateSpace*/, std::unique_ptr<common::RNG> /*_rng*/)
-  {
-    throw std::runtime_error("No Sampleable is available for SE3Joint.");
   }
 };
 
@@ -805,19 +454,6 @@ std::unique_ptr<OutputConstraint> createBoxConstraint(
 
 //==============================================================================
 template <>
-struct createDifferentiableFor_impl<statespace::dart::WeldJoint>
-{
-  using StateSpace = statespace::dart::WeldJoint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Differentiable> create(StateSpacePtr _stateSpace)
-  {
-    return createBoxConstraint<Differentiable>(std::move(_stateSpace), nullptr);
-  }
-};
-
-//==============================================================================
-template <>
 struct createDifferentiableFor_impl<const statespace::dart::WeldJoint>
 {
   using StateSpace = statespace::dart::WeldJoint;
@@ -826,19 +462,6 @@ struct createDifferentiableFor_impl<const statespace::dart::WeldJoint>
   static std::unique_ptr<Differentiable> create(ConstStateSpacePtr _stateSpace)
   {
     return createBoxConstraint<Differentiable>(std::move(_stateSpace), nullptr);
-  }
-};
-
-//==============================================================================
-template <>
-struct createTestableFor_impl<statespace::dart::WeldJoint>
-{
-  using StateSpace = statespace::dart::WeldJoint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Testable> create(StateSpacePtr _stateSpace)
-  {
-    return createBoxConstraint<Testable>(std::move(_stateSpace), nullptr);
   }
 };
 
@@ -857,19 +480,6 @@ struct createTestableFor_impl<const statespace::dart::WeldJoint>
 
 //==============================================================================
 template <>
-struct createProjectableFor_impl<statespace::dart::WeldJoint>
-{
-  using StateSpace = statespace::dart::WeldJoint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Projectable> create(StateSpacePtr _stateSpace)
-  {
-    return createBoxConstraint<Projectable>(std::move(_stateSpace), nullptr);
-  }
-};
-
-//==============================================================================
-template <>
 struct createProjectableFor_impl<const statespace::dart::WeldJoint>
 {
   using StateSpace = statespace::dart::WeldJoint;
@@ -878,24 +488,6 @@ struct createProjectableFor_impl<const statespace::dart::WeldJoint>
   static std::unique_ptr<Projectable> create(ConstStateSpacePtr _stateSpace)
   {
     return createBoxConstraint<Projectable>(std::move(_stateSpace), nullptr);
-  }
-};
-
-//==============================================================================
-template <>
-struct createSampleableFor_impl<statespace::dart::WeldJoint>
-{
-  using StateSpace = statespace::dart::WeldJoint;
-  using StateSpacePtr = std::shared_ptr<StateSpace>;
-
-  static std::unique_ptr<Sampleable> create(
-      StateSpacePtr _stateSpace, std::unique_ptr<common::RNG> /*_rng*/)
-  {
-    // A WeldJoint has zero DOFs
-    Eigen::VectorXd positions = Eigen::Matrix<double, 0, 1>();
-
-    return make_unique<uniform::R0ConstantSampler>(
-        std::move(_stateSpace), positions);
   }
 };
 
@@ -924,7 +516,7 @@ template <class Space>
 std::unique_ptr<Differentiable> createDifferentiableBoundsFor(
     std::shared_ptr<Space> _stateSpace)
 {
-  return detail::createDifferentiableFor_impl<Space>::create(
+  return detail::createDifferentiableFor_impl<const Space>::create(
       std::move(_stateSpace));
 }
 
@@ -933,7 +525,7 @@ template <class Space>
 std::unique_ptr<Projectable> createProjectableBoundsFor(
     std::shared_ptr<Space> _stateSpace)
 {
-  return detail::createProjectableFor_impl<Space>::create(
+  return detail::createProjectableFor_impl<const Space>::create(
       std::move(_stateSpace));
 }
 
@@ -942,7 +534,7 @@ template <class Space>
 std::unique_ptr<Testable> createTestableBoundsFor(
     std::shared_ptr<Space> _stateSpace)
 {
-  return detail::createTestableFor_impl<Space>::create(std::move(_stateSpace));
+  return detail::createTestableFor_impl<const Space>::create(std::move(_stateSpace));
 }
 
 //==============================================================================
@@ -950,7 +542,7 @@ template <class Space>
 std::unique_ptr<Sampleable> createSampleableBoundsFor(
     std::shared_ptr<Space> _stateSpace, std::unique_ptr<common::RNG> _rng)
 {
-  return detail::createSampleableFor_impl<Space>::create(
+  return detail::createSampleableFor_impl<const Space>::create(
       std::move(_stateSpace), std::move(_rng));
 }
 

--- a/include/aikido/constraint/uniform/RnBoxConstraint.hpp
+++ b/include/aikido/constraint/uniform/RnBoxConstraint.hpp
@@ -39,7 +39,7 @@ public:
       const VectorNd& _upperLimits);
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   std::size_t getConstraintDimension() const override;

--- a/include/aikido/constraint/uniform/RnBoxConstraint.hpp
+++ b/include/aikido/constraint/uniform/RnBoxConstraint.hpp
@@ -33,7 +33,7 @@ public:
   /// \param _upperLimits Upper limits.
   ///        The length of this vector should match the dimension of _space.
   RBoxConstraint(
-      std::shared_ptr<statespace::R<N>> _space,
+      std::shared_ptr<const statespace::R<N>> _space,
       std::unique_ptr<common::RNG> _rng,
       const VectorNd& _lowerLimits,
       const VectorNd& _upperLimits);
@@ -81,7 +81,7 @@ public:
   auto getUpperLimits() const -> const VectorNd&;
 
 private:
-  std::shared_ptr<statespace::R<N>> mSpace;
+  std::shared_ptr<const statespace::R<N>> mSpace;
   std::unique_ptr<common::RNG> mRng;
   VectorNd mLowerLimits;
   VectorNd mUpperLimits;

--- a/include/aikido/constraint/uniform/RnConstantSampler.hpp
+++ b/include/aikido/constraint/uniform/RnConstantSampler.hpp
@@ -20,7 +20,7 @@ public:
   /// \param _space Space in which this constraint operates.
   /// \param _value Value to return when sampled.
   RConstantSampler(
-      std::shared_ptr<statespace::R<N>> _space, const VectorNd& _value);
+      std::shared_ptr<const statespace::R<N>> _space, const VectorNd& _value);
 
   // Documentation inherited.
   statespace::ConstStateSpacePtr getStateSpace() const override;
@@ -33,7 +33,7 @@ public:
   const VectorNd& getConstantValue() const;
 
 private:
-  std::shared_ptr<statespace::R<N>> mSpace;
+  std::shared_ptr<const statespace::R<N>> mSpace;
   VectorNd mValue;
 
 public:

--- a/include/aikido/constraint/uniform/RnConstantSampler.hpp
+++ b/include/aikido/constraint/uniform/RnConstantSampler.hpp
@@ -23,7 +23,7 @@ public:
       std::shared_ptr<statespace::R<N>> _space, const VectorNd& _value);
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   std::unique_ptr<constraint::SampleGenerator> createSampleGenerator()

--- a/include/aikido/constraint/uniform/SE2BoxConstraint.hpp
+++ b/include/aikido/constraint/uniform/SE2BoxConstraint.hpp
@@ -34,7 +34,7 @@ public:
       const Eigen::Vector2d& upperLimits);
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   /// Documentation inherited.
   bool isSatisfied(

--- a/include/aikido/constraint/uniform/SE2BoxConstraint.hpp
+++ b/include/aikido/constraint/uniform/SE2BoxConstraint.hpp
@@ -28,7 +28,7 @@ public:
   /// \param lowerLimits Lower limits on the state, only on x and y.
   /// \param upperLimits Upper limits on the state, only on x and y.
   SE2BoxConstraint(
-      std::shared_ptr<statespace::SE2> space,
+      std::shared_ptr<const statespace::SE2> space,
       std::unique_ptr<common::RNG> rng,
       const Eigen::Vector2d& lowerLimits,
       const Eigen::Vector2d& upperLimits);
@@ -61,7 +61,7 @@ public:
   Eigen::Vector2d getUpperLimits() const;
 
 private:
-  std::shared_ptr<statespace::SE2> mSpace;
+  std::shared_ptr<const statespace::SE2> mSpace;
 
   std::unique_ptr<common::RNG> mRng;
 

--- a/include/aikido/constraint/uniform/SO2UniformSampler.hpp
+++ b/include/aikido/constraint/uniform/SO2UniformSampler.hpp
@@ -19,7 +19,7 @@ public:
   /// \param _rng Random number generator which determines the sampling
   ///        sequence of this constraint's SampleGenerators.
   SO2UniformSampler(
-      std::shared_ptr<statespace::SO2> _space,
+      std::shared_ptr<const statespace::SO2> _space,
       std::unique_ptr<common::RNG> _rng);
 
   // Documentation inherited.
@@ -30,7 +30,7 @@ public:
       const override;
 
 private:
-  std::shared_ptr<statespace::SO2> mSpace;
+  std::shared_ptr<const statespace::SO2> mSpace;
   std::unique_ptr<common::RNG> mRng;
 };
 

--- a/include/aikido/constraint/uniform/SO2UniformSampler.hpp
+++ b/include/aikido/constraint/uniform/SO2UniformSampler.hpp
@@ -23,7 +23,7 @@ public:
       std::unique_ptr<common::RNG> _rng);
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   std::unique_ptr<constraint::SampleGenerator> createSampleGenerator()

--- a/include/aikido/constraint/uniform/SO3UniformSampler.hpp
+++ b/include/aikido/constraint/uniform/SO3UniformSampler.hpp
@@ -23,7 +23,7 @@ public:
       std::unique_ptr<common::RNG> _rng);
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   std::unique_ptr<constraint::SampleGenerator> createSampleGenerator()

--- a/include/aikido/constraint/uniform/SO3UniformSampler.hpp
+++ b/include/aikido/constraint/uniform/SO3UniformSampler.hpp
@@ -19,7 +19,7 @@ public:
   /// \param _rng Random number generator which determines the sampling
   ///        sequence of this constraint's SampleGenerators.
   SO3UniformSampler(
-      std::shared_ptr<statespace::SO3> _space,
+      std::shared_ptr<const statespace::SO3> _space,
       std::unique_ptr<common::RNG> _rng);
 
   // Documentation inherited.
@@ -30,7 +30,7 @@ public:
       const override;
 
 private:
-  std::shared_ptr<statespace::SO3> mSpace;
+  std::shared_ptr<const statespace::SO3> mSpace;
   std::unique_ptr<common::RNG> mRng;
 };
 

--- a/include/aikido/constraint/uniform/detail/RnBoxConstraint-impl.hpp
+++ b/include/aikido/constraint/uniform/detail/RnBoxConstraint-impl.hpp
@@ -67,8 +67,8 @@ RnBoxConstraintSampleGenerator<N>::RnBoxConstraintSampleGenerator(
 
 //==============================================================================
 template <int N>
-statespace::ConstStateSpacePtr RnBoxConstraintSampleGenerator<N>::getStateSpace()
-    const
+statespace::ConstStateSpacePtr
+RnBoxConstraintSampleGenerator<N>::getStateSpace() const
 {
   return mSpace;
 }

--- a/include/aikido/constraint/uniform/detail/RnBoxConstraint-impl.hpp
+++ b/include/aikido/constraint/uniform/detail/RnBoxConstraint-impl.hpp
@@ -27,7 +27,7 @@ class RnBoxConstraintSampleGenerator : public constraint::SampleGenerator
 public:
   using VectorNd = Eigen::Matrix<double, N, 1>;
 
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   bool sample(statespace::StateSpace::State* _state) override;
 
@@ -37,12 +37,12 @@ public:
 
 private:
   RnBoxConstraintSampleGenerator(
-      std::shared_ptr<statespace::R<N>> _space,
+      std::shared_ptr<const statespace::R<N>> _space,
       std::unique_ptr<common::RNG> _rng,
       const VectorNd& _lowerLimits,
       const VectorNd& _upperLimits);
 
-  std::shared_ptr<statespace::R<N>> mSpace;
+  std::shared_ptr<const statespace::R<N>> mSpace;
   std::unique_ptr<common::RNG> mRng;
   std::vector<std::uniform_real_distribution<double>> mDistributions;
 
@@ -52,7 +52,7 @@ private:
 //==============================================================================
 template <int N>
 RnBoxConstraintSampleGenerator<N>::RnBoxConstraintSampleGenerator(
-    std::shared_ptr<statespace::R<N>> _space,
+    std::shared_ptr<const statespace::R<N>> _space,
     std::unique_ptr<common::RNG> _rng,
     const VectorNd& _lowerLimits,
     const VectorNd& _upperLimits)
@@ -67,7 +67,7 @@ RnBoxConstraintSampleGenerator<N>::RnBoxConstraintSampleGenerator(
 
 //==============================================================================
 template <int N>
-statespace::StateSpacePtr RnBoxConstraintSampleGenerator<N>::getStateSpace()
+statespace::ConstStateSpacePtr RnBoxConstraintSampleGenerator<N>::getStateSpace()
     const
 {
   return mSpace;
@@ -106,7 +106,7 @@ bool RnBoxConstraintSampleGenerator<N>::canSample() const
 //==============================================================================
 template <int N>
 RBoxConstraint<N>::RBoxConstraint(
-    std::shared_ptr<statespace::R<N>> _space,
+    std::shared_ptr<const statespace::R<N>> _space,
     std::unique_ptr<common::RNG> _rng,
     const VectorNd& _lowerLimits,
     const VectorNd& _upperLimits)

--- a/include/aikido/constraint/uniform/detail/RnBoxConstraint-impl.hpp
+++ b/include/aikido/constraint/uniform/detail/RnBoxConstraint-impl.hpp
@@ -151,7 +151,7 @@ RBoxConstraint<N>::RBoxConstraint(
 
 //==============================================================================
 template <int N>
-statespace::StateSpacePtr RBoxConstraint<N>::getStateSpace() const
+statespace::ConstStateSpacePtr RBoxConstraint<N>::getStateSpace() const
 {
   return mSpace;
 }

--- a/include/aikido/constraint/uniform/detail/RnConstantSampler-impl.hpp
+++ b/include/aikido/constraint/uniform/detail/RnConstantSampler-impl.hpp
@@ -61,8 +61,8 @@ RnConstantSamplerSampleGenerator<N>::RnConstantSamplerSampleGenerator(
 
 //==============================================================================
 template <int N>
-statespace::ConstStateSpacePtr RnConstantSamplerSampleGenerator<N>::getStateSpace()
-    const
+statespace::ConstStateSpacePtr
+RnConstantSamplerSampleGenerator<N>::getStateSpace() const
 {
   return mSpace;
 }

--- a/include/aikido/constraint/uniform/detail/RnConstantSampler-impl.hpp
+++ b/include/aikido/constraint/uniform/detail/RnConstantSampler-impl.hpp
@@ -114,7 +114,7 @@ RConstantSampler<N>::RConstantSampler(
 
 //==============================================================================
 template <int N>
-statespace::StateSpacePtr RConstantSampler<N>::getStateSpace() const
+statespace::ConstStateSpacePtr RConstantSampler<N>::getStateSpace() const
 {
   return mSpace;
 }

--- a/include/aikido/constraint/uniform/detail/RnConstantSampler-impl.hpp
+++ b/include/aikido/constraint/uniform/detail/RnConstantSampler-impl.hpp
@@ -32,9 +32,9 @@ public:
   using VectorNd = Eigen::Matrix<double, N, 1>;
 
   RnConstantSamplerSampleGenerator(
-      std::shared_ptr<statespace::R<N>> _space, const VectorNd& _value);
+      std::shared_ptr<const statespace::R<N>> _space, const VectorNd& _value);
 
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   bool sample(statespace::StateSpace::State* _state) override;
 
@@ -43,7 +43,7 @@ public:
   bool canSample() const override;
 
 private:
-  std::shared_ptr<statespace::R<N>> mSpace;
+  std::shared_ptr<const statespace::R<N>> mSpace;
   VectorNd mValue;
 
 public:
@@ -53,7 +53,7 @@ public:
 //==============================================================================
 template <int N>
 RnConstantSamplerSampleGenerator<N>::RnConstantSamplerSampleGenerator(
-    std::shared_ptr<statespace::R<N>> _space, const VectorNd& _value)
+    std::shared_ptr<const statespace::R<N>> _space, const VectorNd& _value)
   : mSpace(std::move(_space)), mValue(_value)
 {
   // Do nothing
@@ -61,7 +61,7 @@ RnConstantSamplerSampleGenerator<N>::RnConstantSamplerSampleGenerator(
 
 //==============================================================================
 template <int N>
-statespace::StateSpacePtr RnConstantSamplerSampleGenerator<N>::getStateSpace()
+statespace::ConstStateSpacePtr RnConstantSamplerSampleGenerator<N>::getStateSpace()
     const
 {
   return mSpace;
@@ -97,7 +97,7 @@ bool RnConstantSamplerSampleGenerator<N>::canSample() const
 //==============================================================================
 template <int N>
 RConstantSampler<N>::RConstantSampler(
-    std::shared_ptr<statespace::R<N>> _space, const VectorNd& _value)
+    std::shared_ptr<const statespace::R<N>> _space, const VectorNd& _value)
   : mSpace(std::move(_space)), mValue(_value)
 {
   if (!mSpace)

--- a/include/aikido/distance/CartesianProductWeighted.hpp
+++ b/include/aikido/distance/CartesianProductWeighted.hpp
@@ -21,7 +21,7 @@ public:
   /// \param _metrics A vector containing one element for every component of the
   /// CartesianProduct
   CartesianProductWeighted(
-      std::shared_ptr<statespace::CartesianProduct> _space,
+      std::shared_ptr<const statespace::CartesianProduct> _space,
       std::vector<DistanceMetricPtr> _metrics);
 
   /// Constructor.
@@ -36,7 +36,7 @@ public:
       std::vector<std::pair<DistanceMetricPtr, double>> _metrics);
 
   // Documentation inherited
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   /// Computes distance between two states as the weighted sum of distances
   /// between their matching subcomponents.
@@ -48,7 +48,7 @@ public:
       const statespace::StateSpace::State* _state2) const override;
 
 private:
-  std::shared_ptr<statespace::CartesianProduct> mStateSpace;
+  std::shared_ptr<const statespace::CartesianProduct> mStateSpace;
   std::vector<std::pair<DistanceMetricPtr, double>> mMetrics;
 };
 

--- a/include/aikido/distance/DistanceMetric.hpp
+++ b/include/aikido/distance/DistanceMetric.hpp
@@ -17,7 +17,7 @@ public:
   virtual ~DistanceMetric() = default;
 
   /// Get the StateSpace associated with this metric
-  virtual statespace::StateSpacePtr getStateSpace() const = 0;
+  virtual statespace::ConstStateSpacePtr getStateSpace() const = 0;
 
   /// Computes distance between two states. This function satisfies
   /// the properties of a metric:

--- a/include/aikido/distance/RnEuclidean.hpp
+++ b/include/aikido/distance/RnEuclidean.hpp
@@ -17,7 +17,7 @@ public:
   explicit REuclidean(std::shared_ptr<statespace::R<N>> _space);
 
   // Documentation inherited
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   /// Computes Euclidean distance between two states.
   /// \param _state1 The first state (type Rn::State)

--- a/include/aikido/distance/RnEuclidean.hpp
+++ b/include/aikido/distance/RnEuclidean.hpp
@@ -14,7 +14,7 @@ class REuclidean : public DistanceMetric
 public:
   /// Constructor.
   /// \param _space The Rn this metric operates on
-  explicit REuclidean(std::shared_ptr<statespace::R<N>> _space);
+  explicit REuclidean(std::shared_ptr<const statespace::R<N>> _space);
 
   // Documentation inherited
   statespace::ConstStateSpacePtr getStateSpace() const override;
@@ -27,7 +27,7 @@ public:
       const statespace::StateSpace::State* _state2) const override;
 
 private:
-  std::shared_ptr<statespace::R<N>> mStateSpace;
+  std::shared_ptr<const statespace::R<N>> mStateSpace;
 };
 
 using R0Euclidean = REuclidean<0>;

--- a/include/aikido/distance/SE2Weighted.hpp
+++ b/include/aikido/distance/SE2Weighted.hpp
@@ -15,7 +15,7 @@ public:
   ///
   /// \param space The SE2 this distance metric operates on
   /// The weights have been set to 1 as default
-  explicit SE2Weighted(std::shared_ptr<statespace::SE2> space);
+  explicit SE2Weighted(std::shared_ptr<const statespace::SE2> space);
 
   /// Constructor.
   ///
@@ -24,7 +24,7 @@ public:
   /// \param space The SE2 this distance metric operates on
   /// \param weights The weights over angular and translational distances
   SE2Weighted(
-      std::shared_ptr<statespace::SE2> space, const Eigen::Vector2d& weights);
+      std::shared_ptr<const statespace::SE2> space, const Eigen::Vector2d& weights);
 
   // Documentation inherited
   statespace::ConstStateSpacePtr getStateSpace() const override;
@@ -38,7 +38,7 @@ public:
       const statespace::StateSpace::State* state2) const override;
 
 private:
-  std::shared_ptr<statespace::SE2> mStateSpace;
+  std::shared_ptr<const statespace::SE2> mStateSpace;
 
   Eigen::Vector2d mWeights;
 

--- a/include/aikido/distance/SE2Weighted.hpp
+++ b/include/aikido/distance/SE2Weighted.hpp
@@ -24,7 +24,8 @@ public:
   /// \param space The SE2 this distance metric operates on
   /// \param weights The weights over angular and translational distances
   SE2Weighted(
-      std::shared_ptr<const statespace::SE2> space, const Eigen::Vector2d& weights);
+      std::shared_ptr<const statespace::SE2> space,
+      const Eigen::Vector2d& weights);
 
   // Documentation inherited
   statespace::ConstStateSpacePtr getStateSpace() const override;

--- a/include/aikido/distance/SE2Weighted.hpp
+++ b/include/aikido/distance/SE2Weighted.hpp
@@ -27,7 +27,7 @@ public:
       std::shared_ptr<statespace::SE2> space, const Eigen::Vector2d& weights);
 
   // Documentation inherited
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   /// Computes weighted distance between two SE2 states.
   ///

--- a/include/aikido/distance/SO2Angular.hpp
+++ b/include/aikido/distance/SO2Angular.hpp
@@ -16,7 +16,7 @@ public:
   explicit SO2Angular(std::shared_ptr<statespace::SO2> _space);
 
   // Documentation inherited
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   /// Computes shortest distance between two angles. (return value between 0 and
   /// pi)

--- a/include/aikido/distance/SO2Angular.hpp
+++ b/include/aikido/distance/SO2Angular.hpp
@@ -13,7 +13,7 @@ class SO2Angular : public DistanceMetric
 public:
   /// Constructor.
   /// \param _space The SO2 this distance metric operates on
-  explicit SO2Angular(std::shared_ptr<statespace::SO2> _space);
+  explicit SO2Angular(std::shared_ptr<const statespace::SO2> _space);
 
   // Documentation inherited
   statespace::ConstStateSpacePtr getStateSpace() const override;
@@ -27,7 +27,7 @@ public:
       const statespace::StateSpace::State* _state2) const override;
 
 private:
-  std::shared_ptr<statespace::SO2> mStateSpace;
+  std::shared_ptr<const statespace::SO2> mStateSpace;
 };
 
 } // namespace distance

--- a/include/aikido/distance/SO3Angular.hpp
+++ b/include/aikido/distance/SO3Angular.hpp
@@ -16,7 +16,7 @@ public:
   explicit SO3Angular(std::shared_ptr<statespace::SO3> _space);
 
   // Documentation inherited
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   /// Computes distance (in radians) between the two states
   /// \param _state1 The first state (type SO3::State)

--- a/include/aikido/distance/SO3Angular.hpp
+++ b/include/aikido/distance/SO3Angular.hpp
@@ -13,7 +13,7 @@ class SO3Angular : public DistanceMetric
 public:
   /// Constructor.
   /// \param _space The SO3 this distance metric operates on
-  explicit SO3Angular(std::shared_ptr<statespace::SO3> _space);
+  explicit SO3Angular(std::shared_ptr<const statespace::SO3> _space);
 
   // Documentation inherited
   statespace::ConstStateSpacePtr getStateSpace() const override;
@@ -26,7 +26,7 @@ public:
       const statespace::StateSpace::State* _state2) const override;
 
 private:
-  std::shared_ptr<statespace::SO3> mStateSpace;
+  std::shared_ptr<const statespace::SO3> mStateSpace;
 };
 
 } // namespace distance

--- a/include/aikido/distance/defaults.hpp
+++ b/include/aikido/distance/defaults.hpp
@@ -16,11 +16,6 @@ std::unique_ptr<DistanceMetric> createDistanceMetricFor(
 /// Creates a DistanceMetric that is appropriate for the statespace.
 /// \param _sspace The StateSpace the distance metric will operator on
 std::unique_ptr<DistanceMetric> createDistanceMetric(
-    statespace::StateSpacePtr _sspace);
-
-/// Creates a DistanceMetric that is appropriate for the *const* statespace.
-/// \param _sspace The StateSpace the distance metric will operator on
-std::unique_ptr<DistanceMetric> createDistanceMetricConst(
     statespace::ConstStateSpacePtr _sspace);
 }
 }

--- a/include/aikido/distance/defaults.hpp
+++ b/include/aikido/distance/defaults.hpp
@@ -17,6 +17,11 @@ std::unique_ptr<DistanceMetric> createDistanceMetricFor(
 /// \param _sspace The StateSpace the distance metric will operator on
 std::unique_ptr<DistanceMetric> createDistanceMetric(
     statespace::StateSpacePtr _sspace);
+
+/// Creates a DistanceMetric that is appropriate for the *const* statespace.
+/// \param _sspace The StateSpace the distance metric will operator on
+std::unique_ptr<DistanceMetric> createDistanceMetricConst(
+    statespace::ConstStateSpacePtr _sspace);
 }
 }
 

--- a/include/aikido/distance/detail/RnEuclidean-impl.hpp
+++ b/include/aikido/distance/detail/RnEuclidean-impl.hpp
@@ -18,7 +18,7 @@ extern template class REuclidean<Eigen::Dynamic>;
 
 //==============================================================================
 template <int N>
-REuclidean<N>::REuclidean(std::shared_ptr<statespace::R<N>> _space)
+REuclidean<N>::REuclidean(std::shared_ptr<const statespace::R<N>> _space)
   : mStateSpace(std::move(_space))
 {
   if (mStateSpace == nullptr)

--- a/include/aikido/distance/detail/RnEuclidean-impl.hpp
+++ b/include/aikido/distance/detail/RnEuclidean-impl.hpp
@@ -29,7 +29,7 @@ REuclidean<N>::REuclidean(std::shared_ptr<statespace::R<N>> _space)
 
 //==============================================================================
 template <int N>
-statespace::StateSpacePtr REuclidean<N>::getStateSpace() const
+statespace::ConstStateSpacePtr REuclidean<N>::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/include/aikido/distance/detail/defaults-impl.hpp
+++ b/include/aikido/distance/detail/defaults-impl.hpp
@@ -28,9 +28,9 @@ struct createDistanceMetricFor_impl
 
 //==============================================================================
 template <>
-struct createDistanceMetricFor_impl<statespace::R0>
+struct createDistanceMetricFor_impl<const statespace::R0>
 {
-  static Ptr create(std::shared_ptr<statespace::R0> _sspace)
+  static Ptr create(std::shared_ptr<const statespace::R0> _sspace)
   {
     return make_unique<R0Euclidean>(std::move(_sspace));
   }
@@ -38,9 +38,9 @@ struct createDistanceMetricFor_impl<statespace::R0>
 
 //==============================================================================
 template <>
-struct createDistanceMetricFor_impl<statespace::R1>
+struct createDistanceMetricFor_impl<const statespace::R1>
 {
-  static Ptr create(std::shared_ptr<statespace::R1> _sspace)
+  static Ptr create(std::shared_ptr<const statespace::R1> _sspace)
   {
     return make_unique<R1Euclidean>(std::move(_sspace));
   }
@@ -48,9 +48,9 @@ struct createDistanceMetricFor_impl<statespace::R1>
 
 //==============================================================================
 template <>
-struct createDistanceMetricFor_impl<statespace::R2>
+struct createDistanceMetricFor_impl<const statespace::R2>
 {
-  static Ptr create(std::shared_ptr<statespace::R2> _sspace)
+  static Ptr create(std::shared_ptr<const statespace::R2> _sspace)
   {
     return make_unique<R2Euclidean>(std::move(_sspace));
   }
@@ -58,9 +58,9 @@ struct createDistanceMetricFor_impl<statespace::R2>
 
 //==============================================================================
 template <>
-struct createDistanceMetricFor_impl<statespace::R3>
+struct createDistanceMetricFor_impl<const statespace::R3>
 {
-  static Ptr create(std::shared_ptr<statespace::R3> _sspace)
+  static Ptr create(std::shared_ptr<const statespace::R3> _sspace)
   {
     return make_unique<R3Euclidean>(std::move(_sspace));
   }
@@ -68,9 +68,9 @@ struct createDistanceMetricFor_impl<statespace::R3>
 
 //==============================================================================
 template <>
-struct createDistanceMetricFor_impl<statespace::R6>
+struct createDistanceMetricFor_impl<const statespace::R6>
 {
-  static Ptr create(std::shared_ptr<statespace::R6> _sspace)
+  static Ptr create(std::shared_ptr<const statespace::R6> _sspace)
   {
     return make_unique<R6Euclidean>(std::move(_sspace));
   }
@@ -78,9 +78,9 @@ struct createDistanceMetricFor_impl<statespace::R6>
 
 //==============================================================================
 template <>
-struct createDistanceMetricFor_impl<statespace::SO2>
+struct createDistanceMetricFor_impl<const statespace::SO2>
 {
-  static Ptr create(std::shared_ptr<statespace::SO2> _sspace)
+  static Ptr create(std::shared_ptr<const statespace::SO2> _sspace)
   {
     return make_unique<SO2Angular>(std::move(_sspace));
   }
@@ -88,36 +88,11 @@ struct createDistanceMetricFor_impl<statespace::SO2>
 
 //==============================================================================
 template <>
-struct createDistanceMetricFor_impl<statespace::SO3>
+struct createDistanceMetricFor_impl<const statespace::SO3>
 {
-  static Ptr create(std::shared_ptr<statespace::SO3> _sspace)
+  static Ptr create(std::shared_ptr<const statespace::SO3> _sspace)
   {
     return make_unique<SO3Angular>(std::move(_sspace));
-  }
-};
-
-//==============================================================================
-template <>
-struct createDistanceMetricFor_impl<statespace::CartesianProduct>
-{
-  static Ptr create(std::shared_ptr<statespace::CartesianProduct> _sspace)
-  {
-    if (_sspace == nullptr)
-      throw std::invalid_argument(
-          "Cannot create distance metric for null statespace.");
-
-    std::vector<std::shared_ptr<DistanceMetric> > metrics;
-    metrics.reserve(_sspace->getNumSubspaces());
-
-    for (std::size_t i = 0; i < _sspace->getNumSubspaces(); ++i)
-    {
-      auto subspace = _sspace->getSubspace<>(i);
-      auto metric = createDistanceMetricConst(std::move(subspace));
-      metrics.emplace_back(std::move(metric));
-    }
-
-    return make_unique<CartesianProductWeighted>(
-        std::move(_sspace), std::move(metrics));
   }
 };
 
@@ -137,7 +112,7 @@ struct createDistanceMetricFor_impl<const statespace::CartesianProduct>
     for (std::size_t i = 0; i < _sspace->getNumSubspaces(); ++i)
     {
       auto subspace = _sspace->getSubspace<>(i);
-      auto metric = createDistanceMetricConst(std::move(subspace));
+      auto metric = createDistanceMetric(std::move(subspace));
       metrics.emplace_back(std::move(metric));
     }
 
@@ -148,27 +123,24 @@ struct createDistanceMetricFor_impl<const statespace::CartesianProduct>
 
 //==============================================================================
 template <>
-struct createDistanceMetricFor_impl<statespace::SE2>
+struct createDistanceMetricFor_impl<const statespace::SE2>
 {
-  static Ptr create(std::shared_ptr<statespace::SE2> _sspace)
+  static Ptr create(std::shared_ptr<const statespace::SE2> _sspace)
   {
     return make_unique<SE2Weighted>(std::move(_sspace));
   }
 };
 
 //==============================================================================
-using SupportedStateSpaces = common::type_list<statespace::CartesianProduct,
-                                               statespace::R0,
-                                               statespace::R1,
-                                               statespace::R2,
-                                               statespace::R3,
-                                               statespace::R6,
-                                               statespace::SO2,
-                                               statespace::SO3,
-                                               statespace::SE2>;
-
-//==============================================================================
-using ConstSupportedStateSpaces = common::type_list<const statespace::CartesianProduct>;
+using SupportedStateSpaces = common::type_list<const statespace::CartesianProduct,
+                                               const statespace::R0,
+                                               const statespace::R1,
+                                               const statespace::R2,
+                                               const statespace::R3,
+                                               const statespace::R6,
+                                               const statespace::SO2,
+                                               const statespace::SO3,
+                                               const statespace::SE2>;
 
 } // namespace detail
 
@@ -180,7 +152,7 @@ std::unique_ptr<DistanceMetric> createDistanceMetricFor(
   if (_sspace == nullptr)
     throw std::invalid_argument("_sspace is null.");
 
-  return detail::createDistanceMetricFor_impl<Space>::create(
+  return detail::createDistanceMetricFor_impl<const Space>::create(
       std::move(_sspace));
 }
 

--- a/include/aikido/distance/detail/defaults-impl.hpp
+++ b/include/aikido/distance/detail/defaults-impl.hpp
@@ -132,15 +132,16 @@ struct createDistanceMetricFor_impl<const statespace::SE2>
 };
 
 //==============================================================================
-using SupportedStateSpaces = common::type_list<const statespace::CartesianProduct,
-                                               const statespace::R0,
-                                               const statespace::R1,
-                                               const statespace::R2,
-                                               const statespace::R3,
-                                               const statespace::R6,
-                                               const statespace::SO2,
-                                               const statespace::SO3,
-                                               const statespace::SE2>;
+using SupportedStateSpaces
+    = common::type_list<const statespace::CartesianProduct,
+                        const statespace::R0,
+                        const statespace::R1,
+                        const statespace::R2,
+                        const statespace::R3,
+                        const statespace::R6,
+                        const statespace::SO2,
+                        const statespace::SO3,
+                        const statespace::SE2>;
 
 } // namespace detail
 

--- a/include/aikido/distance/detail/defaults-impl.hpp
+++ b/include/aikido/distance/detail/defaults-impl.hpp
@@ -112,7 +112,32 @@ struct createDistanceMetricFor_impl<statespace::CartesianProduct>
     for (std::size_t i = 0; i < _sspace->getNumSubspaces(); ++i)
     {
       auto subspace = _sspace->getSubspace<>(i);
-      auto metric = createDistanceMetric(std::move(subspace));
+      auto metric = createDistanceMetricConst(std::move(subspace));
+      metrics.emplace_back(std::move(metric));
+    }
+
+    return make_unique<CartesianProductWeighted>(
+        std::move(_sspace), std::move(metrics));
+  }
+};
+
+//==============================================================================
+template <>
+struct createDistanceMetricFor_impl<const statespace::CartesianProduct>
+{
+  static Ptr create(std::shared_ptr<const statespace::CartesianProduct> _sspace)
+  {
+    if (_sspace == nullptr)
+      throw std::invalid_argument(
+          "Cannot create distance metric for null statespace.");
+
+    std::vector<std::shared_ptr<DistanceMetric> > metrics;
+    metrics.reserve(_sspace->getNumSubspaces());
+
+    for (std::size_t i = 0; i < _sspace->getNumSubspaces(); ++i)
+    {
+      auto subspace = _sspace->getSubspace<>(i);
+      auto metric = createDistanceMetricConst(std::move(subspace));
       metrics.emplace_back(std::move(metric));
     }
 
@@ -141,6 +166,9 @@ using SupportedStateSpaces = common::type_list<statespace::CartesianProduct,
                                                statespace::SO2,
                                                statespace::SO3,
                                                statespace::SE2>;
+
+//==============================================================================
+using ConstSupportedStateSpaces = common::type_list<const statespace::CartesianProduct>;
 
 } // namespace detail
 

--- a/include/aikido/planner/ompl/GeometricStateSpace.hpp
+++ b/include/aikido/planner/ompl/GeometricStateSpace.hpp
@@ -55,7 +55,7 @@ public:
   /// \param _boundsProjection A Projectable that can be used to project a state
   /// back within the valid boundary defined on the space.
   GeometricStateSpace(
-      statespace::StateSpacePtr _sspace,
+      statespace::ConstStateSpacePtr _sspace,
       statespace::InterpolatorPtr _interpolator,
       distance::DistanceMetricPtr _dmetric,
       constraint::SampleablePtr _sampler,
@@ -138,10 +138,10 @@ public:
   void freeState(::ompl::base::State* _state) const override;
 
   /// Return the Aikido StateSpace that this OMPL StateSpace wraps
-  statespace::StateSpacePtr getAikidoStateSpace() const;
+  statespace::ConstStateSpacePtr getAikidoStateSpace() const;
 
 private:
-  statespace::StateSpacePtr mStateSpace;
+  statespace::ConstStateSpacePtr mStateSpace;
   statespace::InterpolatorPtr mInterpolator;
   distance::DistanceMetricPtr mDistance;
   constraint::SampleablePtr mSampler;

--- a/include/aikido/planner/ompl/Planner.hpp
+++ b/include/aikido/planner/ompl/Planner.hpp
@@ -229,7 +229,7 @@ trajectory::InterpolatedPtr planCRRTConnect(
 /// \param _maxDistanceBtwValidityChecks The maximum distance (under dmetric)
 /// between validity checking two successive points on a tree extension
 ::ompl::base::SpaceInformationPtr getSpaceInformation(
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,

--- a/include/aikido/planner/ompl/Planner.hpp
+++ b/include/aikido/planner/ompl/Planner.hpp
@@ -229,7 +229,7 @@ trajectory::InterpolatedPtr planCRRTConnect(
 /// \param _maxDistanceBtwValidityChecks The maximum distance (under dmetric)
 /// between validity checking two successive points on a tree extension
 ::ompl::base::SpaceInformationPtr getSpaceInformation(
-    statespace::ConstStateSpacePtr _stateSpace,
+    statespace::StateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,

--- a/include/aikido/planner/ompl/Planner.hpp
+++ b/include/aikido/planner/ompl/Planner.hpp
@@ -54,7 +54,7 @@ template <class PlannerType>
 trajectory::InterpolatedPtr planOMPL(
     const statespace::StateSpace::State* _start,
     const statespace::StateSpace::State* _goal,
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,
@@ -96,7 +96,7 @@ trajectory::InterpolatedPtr planOMPL(
     const statespace::StateSpace::State* _start,
     constraint::TestablePtr _goalTestable,
     constraint::SampleablePtr _goalSampler,
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,
@@ -144,7 +144,7 @@ trajectory::InterpolatedPtr planCRRT(
     constraint::TestablePtr _goalTestable,
     constraint::SampleablePtr _goalSampler,
     constraint::ProjectablePtr _trajConstraint,
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,
@@ -196,7 +196,7 @@ trajectory::InterpolatedPtr planCRRTConnect(
     constraint::TestablePtr _goalTestable,
     constraint::SampleablePtr _goalSampler,
     constraint::ProjectablePtr _trajConstraint,
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,
@@ -229,7 +229,7 @@ trajectory::InterpolatedPtr planCRRTConnect(
 /// \param _maxDistanceBtwValidityChecks The maximum distance (under dmetric)
 /// between validity checking two successive points on a tree extension
 ::ompl::base::SpaceInformationPtr getSpaceInformation(
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,
@@ -265,7 +265,7 @@ ompl_shared_ptr<::ompl::base::GoalRegion> getGoalRegion(
 trajectory::InterpolatedPtr planOMPL(
     const ::ompl::base::PlannerPtr& _planner,
     const ::ompl::base::ProblemDefinitionPtr& _pdef,
-    statespace::StateSpacePtr _sspace,
+    statespace::ConstStateSpacePtr _sspace,
     statespace::InterpolatorPtr _interpolator,
     double _maxPlanTime);
 

--- a/include/aikido/planner/ompl/detail/Planner-impl.hpp
+++ b/include/aikido/planner/ompl/detail/Planner-impl.hpp
@@ -14,7 +14,7 @@ template <class PlannerType>
 trajectory::InterpolatedPtr planOMPL(
     const statespace::StateSpace::State* _start,
     const statespace::StateSpace::State* _goal,
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,
@@ -63,7 +63,7 @@ trajectory::InterpolatedPtr planOMPL(
     const statespace::StateSpace::State* _start,
     constraint::TestablePtr _goalTestable,
     constraint::SampleablePtr _goalSampler,
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,

--- a/include/aikido/planner/vectorfield/BodyNodePoseVectorField.hpp
+++ b/include/aikido/planner/vectorfield/BodyNodePoseVectorField.hpp
@@ -90,7 +90,8 @@ public:
 
 protected:
   /// Meta skeleton state space.
-  aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
+  aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr
+      mMetaSkeletonStateSpace;
 
   /// Meta Skeleton
   dart::dynamics::MetaSkeletonPtr mMetaSkeleton;

--- a/include/aikido/planner/vectorfield/BodyNodePoseVectorField.hpp
+++ b/include/aikido/planner/vectorfield/BodyNodePoseVectorField.hpp
@@ -35,10 +35,10 @@ public:
   /// \param[in] enforceJointVelocityLimits Whether joint velocity limits
   /// are considered in computation.
   BodyNodePoseVectorField(
-      aikido::statespace::dart::MetaSkeletonStateSpacePtr
+      aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr
           metaSkeletonStateSpace,
       dart::dynamics::MetaSkeletonPtr metaSkeleton,
-      dart::dynamics::BodyNodePtr bodyNode,
+      dart::dynamics::ConstBodyNodePtr bodyNode,
       double maxStepSize,
       double jointLimitPadding,
       bool enforceJointVelocityLimits = false);
@@ -75,10 +75,6 @@ public:
       double& evalTimePivot,
       bool includeEndTime) const override;
 
-  /// Return meta skeleton state space.
-  aikido::statespace::dart::MetaSkeletonStateSpacePtr
-  getMetaSkeletonStateSpace();
-
   /// Return const meta skeleton state space.
   aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr
   getMetaSkeletonStateSpace() const;
@@ -89,21 +85,18 @@ public:
   /// Returns const meta skeleton.
   dart::dynamics::ConstMetaSkeletonPtr getMetaSkeleton() const;
 
-  /// Returns body node of end-effector.
-  dart::dynamics::BodyNodePtr getBodyNode();
-
   /// Returns const body node of end-effector.
   dart::dynamics::ConstBodyNodePtr getBodyNode() const;
 
 protected:
   /// Meta skeleton state space.
-  aikido::statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
+  aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
 
   /// Meta Skeleton
   dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
 
   /// BodyNode
-  dart::dynamics::BodyNodePtr mBodyNode;
+  dart::dynamics::ConstBodyNodePtr mBodyNode;
 
   /// Maximum step size of integrator.
   double mMaxStepSize;

--- a/include/aikido/planner/vectorfield/MoveEndEffectorOffsetVectorField.hpp
+++ b/include/aikido/planner/vectorfield/MoveEndEffectorOffsetVectorField.hpp
@@ -38,9 +38,9 @@ public:
   /// \param[in] jointLimitPadding If less then this distance to joint
   /// limit, velocity is bounded in that direction to 0.
   MoveEndEffectorOffsetVectorField(
-      aikido::statespace::dart::MetaSkeletonStateSpacePtr stateSpace,
+      aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
       dart::dynamics::MetaSkeletonPtr metaskeleton,
-      dart::dynamics::BodyNodePtr bn,
+      dart::dynamics::ConstBodyNodePtr bn,
       const Eigen::Vector3d& direction,
       double minDistance,
       double maxDistance,

--- a/include/aikido/planner/vectorfield/VectorField.hpp
+++ b/include/aikido/planner/vectorfield/VectorField.hpp
@@ -21,7 +21,7 @@ public:
   /// Constructor.
   ///
   /// \param[in] stateSpace State space that vector field is defined in.
-  explicit VectorField(aikido::statespace::StateSpacePtr stateSpace);
+  explicit VectorField(aikido::statespace::ConstStateSpacePtr stateSpace);
 
   /// Vectorfield callback function.
   ///
@@ -59,14 +59,14 @@ public:
       bool includeEndTime) const = 0;
 
   /// Returns state space.
-  aikido::statespace::StateSpacePtr getStateSpace();
+  aikido::statespace::ConstStateSpacePtr getStateSpace();
 
   /// Returns const state space.
   aikido::statespace::ConstStateSpacePtr getStateSpace() const;
 
 protected:
   /// State space
-  aikido::statespace::StateSpacePtr mStateSpace;
+  aikido::statespace::ConstStateSpacePtr mStateSpace;
 };
 
 using VectorFieldPtr = std::shared_ptr<VectorField>;

--- a/include/aikido/planner/vectorfield/VectorFieldPlanner.hpp
+++ b/include/aikido/planner/vectorfield/VectorFieldPlanner.hpp
@@ -2,7 +2,7 @@
 #define AIKIDO_PLANNER_VECTORFIELD_VECTORFIELDPLANNER_HPP_
 
 #include <aikido/constraint/Testable.hpp>
-#include <aikido/planner/PlanningResult.hpp>
+#include <aikido/planner/Planner.hpp>
 #include <aikido/planner/vectorfield/VectorField.hpp>
 #include <aikido/statespace/dart/MetaSkeletonStateSpace.hpp>
 #include <aikido/trajectory/Spline.hpp>
@@ -21,7 +21,7 @@ namespace vectorfield {
 /// vector field.
 /// \param[in] checkConstraintResolution Resolution used in checking
 /// constraint satisfaction in generated trajectory.
-/// \param[out] planningResult information about success or failure.
+/// \param[out] result information about success or failure.
 /// \return A trajectory following the vector field.
 std::unique_ptr<aikido::trajectory::Spline> followVectorField(
     const aikido::planner::vectorfield::VectorField& vectorField,
@@ -30,7 +30,7 @@ std::unique_ptr<aikido::trajectory::Spline> followVectorField(
     std::chrono::duration<double> timelimit,
     double initialStepSize,
     double checkConstraintResolution,
-    planner::PlanningResult* planningResult);
+    planner::Planner::Result* result);
 
 /// Plan to a trajectory that moves the end-effector by a given direction and
 /// distance.
@@ -52,13 +52,13 @@ std::unique_ptr<aikido::trajectory::Spline> followVectorField(
 /// limit, velocity is bounded in that direction to 0.
 /// \param[in] constraintCheckResolution Resolution used in constraint checking.
 /// \param[in] timelimit timeout in seconds.
-/// \param[out] planningResult information about success or failure.
+/// \param[out] result information about success or failure.
 /// \return Trajectory or \c nullptr if planning failed.
 std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
-    const aikido::statespace::dart::MetaSkeletonStateSpacePtr& stateSpace,
+    const aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr& stateSpace,
     dart::dynamics::MetaSkeletonPtr metaskeleton,
-    const dart::dynamics::BodyNodePtr& bn,
-    const aikido::constraint::TestablePtr& constraint,
+    const dart::dynamics::ConstBodyNodePtr& bn,
+    const aikido::constraint::ConstTestablePtr& constraint,
     const Eigen::Vector3d& direction,
     double minDistance,
     double maxDistance,
@@ -68,7 +68,7 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
     double jointLimitTolerance,
     double constraintCheckResolution,
     std::chrono::duration<double> timelimit,
-    planner::PlanningResult* planningResult = nullptr);
+    planner::Planner::Result* result = nullptr);
 
 /// Plan to an end-effector pose by following a geodesic loss function
 /// in SE(3) via an optimized Jacobian.
@@ -88,7 +88,7 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
 /// limit, velocity is bounded in that direction to 0.
 /// \param[in] constraintCheckResolution Resolution used in constraint checking.
 /// \param[in] timelimit Timeout in seconds.
-/// \param[out] planningResult information about success or failure.
+/// \param[out] result information about success or failure.
 /// \return Trajectory or \c nullptr if planning failed.
 std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorPose(
     const aikido::statespace::dart::MetaSkeletonStateSpacePtr& stateSpace,
@@ -102,7 +102,7 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorPose(
     double jointLimitTolerance,
     double constraintCheckResolution,
     std::chrono::duration<double> timelimit,
-    planner::PlanningResult* planningResult = nullptr);
+    planner::Planner::Result* result = nullptr);
 
 } // namespace vectorfield
 } // namespace planner

--- a/include/aikido/planner/vectorfield/VectorFieldUtil.hpp
+++ b/include/aikido/planner/vectorfield/VectorFieldUtil.hpp
@@ -32,7 +32,7 @@ bool computeJointVelocityFromTwist(
     Eigen::VectorXd& jointVelocity,
     const Eigen::Vector6d& desiredTwist,
     const dart::dynamics::MetaSkeletonPtr metaSkeleton,
-    const dart::dynamics::BodyNodePtr bodyNode,
+    const dart::dynamics::ConstBodyNodePtr bodyNode,
     double jointLimitPadding,
     const Eigen::VectorXd& jointVelocityLowerLimits,
     const Eigen::VectorXd& jointVelocityUpperLimits,

--- a/include/aikido/robot/ConcreteManipulator.hpp
+++ b/include/aikido/robot/ConcreteManipulator.hpp
@@ -74,12 +74,12 @@ public:
 
   // Documentation inherited.
   virtual constraint::dart::CollisionFreePtr getSelfCollisionConstraint(
-      const statespace::dart::MetaSkeletonStateSpacePtr& space,
+      const statespace::dart::ConstMetaSkeletonStateSpacePtr& space,
       const dart::dynamics::MetaSkeletonPtr& metaSkeleton) const override;
 
   // Documentation inherited.
   virtual aikido::constraint::TestablePtr getFullCollisionConstraint(
-      const statespace::dart::MetaSkeletonStateSpacePtr& space,
+      const statespace::dart::ConstMetaSkeletonStateSpacePtr& space,
       const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
       const constraint::dart::CollisionFreePtr& collisionFree) const override;
 

--- a/include/aikido/robot/ConcreteRobot.hpp
+++ b/include/aikido/robot/ConcreteRobot.hpp
@@ -93,12 +93,12 @@ public:
 
   // Documentation inherited.
   virtual aikido::constraint::dart::CollisionFreePtr getSelfCollisionConstraint(
-      const statespace::dart::MetaSkeletonStateSpacePtr& space,
+      const statespace::dart::ConstMetaSkeletonStateSpacePtr& space,
       const dart::dynamics::MetaSkeletonPtr& metaSkeleton) const override;
 
   // Documentation inherited.
   virtual aikido::constraint::TestablePtr getFullCollisionConstraint(
-      const statespace::dart::MetaSkeletonStateSpacePtr& space,
+      const statespace::dart::ConstMetaSkeletonStateSpacePtr& space,
       const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
       const constraint::dart::CollisionFreePtr& collisionFree) const override;
 

--- a/include/aikido/robot/Robot.hpp
+++ b/include/aikido/robot/Robot.hpp
@@ -92,7 +92,7 @@ public:
   /// \param[in] space Space in which this collision constraint operates.
   /// \param[in] metaSkeleton Metaskeleton for the statespace.
   virtual constraint::dart::CollisionFreePtr getSelfCollisionConstraint(
-      const statespace::dart::MetaSkeletonStateSpacePtr& space,
+      const statespace::dart::ConstMetaSkeletonStateSpacePtr& space,
       const dart::dynamics::MetaSkeletonPtr& metaSkeleton) const = 0;
 
   /// TODO: Consider changing this to return a CollisionFreePtr.
@@ -103,7 +103,7 @@ public:
   /// \param[in] collisionFree Collision constraint.
   /// \return Combined constraint.
   virtual constraint::TestablePtr getFullCollisionConstraint(
-      const statespace::dart::MetaSkeletonStateSpacePtr& space,
+      const statespace::dart::ConstMetaSkeletonStateSpacePtr& space,
       const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
       const constraint::dart::CollisionFreePtr& collisionFree) const = 0;
 };

--- a/include/aikido/statespace/CartesianProduct.hpp
+++ b/include/aikido/statespace/CartesianProduct.hpp
@@ -34,7 +34,7 @@ public:
 
   /// Construct the Cartesian product of a vector of subspaces.
   /// \param _subspaces vector of subspaces
-  explicit CartesianProduct(std::vector<StateSpacePtr> _subspaces);
+  explicit CartesianProduct(std::vector<ConstStateSpacePtr> _subspaces);
 
   /// Helper function to create a \c ScopedState.
   ///
@@ -52,7 +52,7 @@ public:
   /// \param _index in the range [ 0, \c getNumSubspaces() ]
   /// \return subspace at \c _index
   template <class Space = StateSpace>
-  std::shared_ptr<Space> getSubspace(std::size_t _index) const;
+  std::shared_ptr<const Space> getSubspace(std::size_t _index) const;
 
   /// Gets substate of type \c Space::State from a CompoundState by index.
   ///
@@ -152,7 +152,7 @@ public:
   void print(const StateSpace::State* _state, std::ostream& _os) const override;
 
 private:
-  std::vector<StateSpacePtr> mSubspaces;
+  std::vector<ConstStateSpacePtr> mSubspaces;
   std::vector<std::size_t> mOffsets;
   std::size_t mSizeInBytes;
 };

--- a/include/aikido/statespace/dart/MetaSkeletonStateSpace.hpp
+++ b/include/aikido/statespace/dart/MetaSkeletonStateSpace.hpp
@@ -153,7 +153,7 @@ public:
   /// \param _index index of a joint in the \c MetaSkeleton
   /// \return state space corresponding to \c _joint
   template <class Space = JointStateSpace>
-  std::shared_ptr<Space> getJointSpace(std::size_t _index) const;
+  std::shared_ptr<const Space> getJointSpace(std::size_t _index) const;
 
   /// Converts DART \c MetaSkeleton positions, e.g. those returned by
   /// \c getPositions, to a \c State in this state space.

--- a/include/aikido/statespace/dart/detail/MetaSkeletonStateSpace-impl.hpp
+++ b/include/aikido/statespace/dart/detail/MetaSkeletonStateSpace-impl.hpp
@@ -17,7 +17,7 @@ std::shared_ptr<Space> MetaSkeletonStateSpace::getJointSpace(
 
 //==============================================================================
 template <class Space>
-std::shared_ptr<Space> MetaSkeletonStateSpace::getJointSpace(
+std::shared_ptr<const Space> MetaSkeletonStateSpace::getJointSpace(
     std::size_t _index) const
 {
   return getSubspace<Space>(_index);

--- a/include/aikido/statespace/detail/CartesianProduct-impl.hpp
+++ b/include/aikido/statespace/detail/CartesianProduct-impl.hpp
@@ -60,7 +60,8 @@ public:
 
 //==============================================================================
 template <class Space>
-std::shared_ptr<const Space> CartesianProduct::getSubspace(std::size_t _index) const
+std::shared_ptr<const Space> CartesianProduct::getSubspace(
+    std::size_t _index) const
 {
   // TODO: Replace this with a static_cast in release mode.
   const auto rawSpace = mSubspaces[_index];

--- a/include/aikido/statespace/detail/CartesianProduct-impl.hpp
+++ b/include/aikido/statespace/detail/CartesianProduct-impl.hpp
@@ -60,11 +60,11 @@ public:
 
 //==============================================================================
 template <class Space>
-std::shared_ptr<Space> CartesianProduct::getSubspace(std::size_t _index) const
+std::shared_ptr<const Space> CartesianProduct::getSubspace(std::size_t _index) const
 {
   // TODO: Replace this with a static_cast in release mode.
   const auto rawSpace = mSubspaces[_index];
-  auto space = std::dynamic_pointer_cast<Space>(rawSpace);
+  auto space = std::dynamic_pointer_cast<const Space>(rawSpace);
   if (!space)
   {
     // Create a reference to *rawSpace so we can use it in typeid below. Doing

--- a/src/constraint/CartesianProductProjectable.cpp
+++ b/src/constraint/CartesianProductProjectable.cpp
@@ -41,7 +41,7 @@ CartesianProductProjectable::CartesianProductProjectable(
 }
 
 //==============================================================================
-statespace::StateSpacePtr CartesianProductProjectable::getStateSpace() const
+statespace::ConstStateSpacePtr CartesianProductProjectable::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/CartesianProductProjectable.cpp
+++ b/src/constraint/CartesianProductProjectable.cpp
@@ -6,7 +6,7 @@ namespace constraint {
 
 //==============================================================================
 CartesianProductProjectable::CartesianProductProjectable(
-    std::shared_ptr<statespace::CartesianProduct> _stateSpace,
+    std::shared_ptr<const statespace::CartesianProduct> _stateSpace,
     std::vector<ProjectablePtr> _constraints)
   : mStateSpace(std::move(_stateSpace)), mConstraints(std::move(_constraints))
 {

--- a/src/constraint/CartesianProductProjectable.cpp
+++ b/src/constraint/CartesianProductProjectable.cpp
@@ -41,7 +41,8 @@ CartesianProductProjectable::CartesianProductProjectable(
 }
 
 //==============================================================================
-statespace::ConstStateSpacePtr CartesianProductProjectable::getStateSpace() const
+statespace::ConstStateSpacePtr CartesianProductProjectable::getStateSpace()
+    const
 {
   return mStateSpace;
 }

--- a/src/constraint/CartesianProductSampleable.cpp
+++ b/src/constraint/CartesianProductSampleable.cpp
@@ -11,7 +11,7 @@ class SubspaceSampleGenerator : public SampleGenerator
 {
 public:
   SubspaceSampleGenerator(
-      std::shared_ptr<statespace::CartesianProduct> _stateSpace,
+      std::shared_ptr<const statespace::CartesianProduct> _stateSpace,
       std::vector<std::unique_ptr<SampleGenerator>> _generators)
     : mStateSpace(std::move(_stateSpace)), mGenerators(std::move(_generators))
   {
@@ -26,7 +26,7 @@ public:
     }
   }
 
-  statespace::StateSpacePtr getStateSpace() const override
+  statespace::ConstStateSpacePtr getStateSpace() const override
   {
     return mStateSpace;
   }
@@ -77,13 +77,13 @@ public:
   }
 
 private:
-  std::shared_ptr<statespace::CartesianProduct> mStateSpace;
+  std::shared_ptr<const statespace::CartesianProduct> mStateSpace;
   std::vector<std::unique_ptr<SampleGenerator>> mGenerators;
 };
 
 //==============================================================================
 CartesianProductSampleable::CartesianProductSampleable(
-    std::shared_ptr<statespace::CartesianProduct> _stateSpace,
+    std::shared_ptr<const statespace::CartesianProduct> _stateSpace,
     std::vector<std::shared_ptr<Sampleable>> _constraints)
   : mStateSpace(std::move(_stateSpace)), mConstraints(std::move(_constraints))
 {

--- a/src/constraint/CartesianProductSampleable.cpp
+++ b/src/constraint/CartesianProductSampleable.cpp
@@ -118,7 +118,7 @@ CartesianProductSampleable::CartesianProductSampleable(
 }
 
 //==============================================================================
-statespace::StateSpacePtr CartesianProductSampleable::getStateSpace() const
+statespace::ConstStateSpacePtr CartesianProductSampleable::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/CartesianProductTestable.cpp
+++ b/src/constraint/CartesianProductTestable.cpp
@@ -8,8 +8,8 @@ using dart::common::make_unique;
 
 //==============================================================================
 CartesianProductTestable::CartesianProductTestable(
-    std::shared_ptr<statespace::CartesianProduct> _stateSpace,
-    std::vector<std::shared_ptr<Testable>> _constraints)
+    std::shared_ptr<const statespace::CartesianProduct> _stateSpace,
+    std::vector<ConstTestablePtr> _constraints)
   : mStateSpace(std::move(_stateSpace)), mConstraints(std::move(_constraints))
 {
   if (!mStateSpace)
@@ -46,7 +46,7 @@ CartesianProductTestable::CartesianProductTestable(
 }
 
 //==============================================================================
-statespace::StateSpacePtr CartesianProductTestable::getStateSpace() const
+statespace::ConstStateSpacePtr CartesianProductTestable::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/CyclicSampleable.cpp
+++ b/src/constraint/CyclicSampleable.cpp
@@ -24,7 +24,7 @@ public:
   virtual ~FiniteCyclicSampleGenerator();
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   bool sample(statespace::StateSpace::State* _state) override;
@@ -36,7 +36,7 @@ public:
   bool canSample() const override;
 
 private:
-  statespace::StateSpacePtr mStateSpace;
+  statespace::ConstStateSpacePtr mStateSpace;
   std::vector<statespace::StateSpace::State*> mStates;
   std::unique_ptr<SampleGenerator> mGenerator;
   int mIndex;
@@ -76,7 +76,7 @@ FiniteCyclicSampleGenerator::~FiniteCyclicSampleGenerator()
 }
 
 //==============================================================================
-statespace::StateSpacePtr FiniteCyclicSampleGenerator::getStateSpace() const
+statespace::ConstStateSpacePtr FiniteCyclicSampleGenerator::getStateSpace() const
 {
   return mGenerator->getStateSpace();
 }

--- a/src/constraint/CyclicSampleable.cpp
+++ b/src/constraint/CyclicSampleable.cpp
@@ -76,7 +76,8 @@ FiniteCyclicSampleGenerator::~FiniteCyclicSampleGenerator()
 }
 
 //==============================================================================
-statespace::ConstStateSpacePtr FiniteCyclicSampleGenerator::getStateSpace() const
+statespace::ConstStateSpacePtr FiniteCyclicSampleGenerator::getStateSpace()
+    const
 {
   return mGenerator->getStateSpace();
 }

--- a/src/constraint/CyclicSampleable.cpp
+++ b/src/constraint/CyclicSampleable.cpp
@@ -148,7 +148,7 @@ CyclicSampleable::CyclicSampleable(SampleablePtr _sampleable)
 }
 
 //==============================================================================
-statespace::StateSpacePtr CyclicSampleable::getStateSpace() const
+statespace::ConstStateSpacePtr CyclicSampleable::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/DifferentiableIntersection.cpp
+++ b/src/constraint/DifferentiableIntersection.cpp
@@ -6,7 +6,7 @@ namespace constraint {
 //==============================================================================
 DifferentiableIntersection::DifferentiableIntersection(
     std::vector<DifferentiablePtr> _constraints,
-    std::shared_ptr<aikido::statespace::StateSpace> _stateSpace)
+    std::shared_ptr<const aikido::statespace::StateSpace> _stateSpace)
   : mConstraints(std::move(_constraints)), mStateSpace(std::move(_stateSpace))
 {
   if (mConstraints.size() == 0)

--- a/src/constraint/DifferentiableIntersection.cpp
+++ b/src/constraint/DifferentiableIntersection.cpp
@@ -127,7 +127,7 @@ std::vector<ConstraintType> DifferentiableIntersection::getConstraintTypes()
 }
 
 //==============================================================================
-statespace::StateSpacePtr DifferentiableIntersection::getStateSpace() const
+statespace::ConstStateSpacePtr DifferentiableIntersection::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/DifferentiableSubspace.cpp
+++ b/src/constraint/DifferentiableSubspace.cpp
@@ -6,7 +6,7 @@ namespace constraint {
 
 //==============================================================================
 DifferentiableSubspace::DifferentiableSubspace(
-    std::shared_ptr<statespace::CartesianProduct> _stateSpace,
+    std::shared_ptr<const statespace::CartesianProduct> _stateSpace,
     DifferentiablePtr _constraint,
     std::size_t _index)
   : mStateSpace(std::move(_stateSpace))

--- a/src/constraint/DifferentiableSubspace.cpp
+++ b/src/constraint/DifferentiableSubspace.cpp
@@ -35,7 +35,7 @@ DifferentiableSubspace::DifferentiableSubspace(
 }
 
 //==============================================================================
-statespace::StateSpacePtr DifferentiableSubspace::getStateSpace() const
+statespace::ConstStateSpacePtr DifferentiableSubspace::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/FiniteSampleable.cpp
+++ b/src/constraint/FiniteSampleable.cpp
@@ -11,7 +11,7 @@ class FiniteSampleGenerator : public SampleGenerator
 public:
   // For internal use only.
   FiniteSampleGenerator(
-      statespace::StateSpacePtr _stateSpace,
+      statespace::ConstStateSpacePtr _stateSpace,
       const std::vector<statespace::StateSpace::State*>& _states);
 
   FiniteSampleGenerator(const FiniteSampleGenerator&) = delete;
@@ -35,7 +35,7 @@ public:
   bool canSample() const override;
 
 private:
-  statespace::StateSpacePtr mStateSpace;
+  statespace::ConstStateSpacePtr mStateSpace;
   std::vector<statespace::StateSpace::State*> mStates;
   int mIndex;
 
@@ -44,7 +44,7 @@ private:
 
 //==============================================================================
 FiniteSampleGenerator::FiniteSampleGenerator(
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     const std::vector<statespace::StateSpace::State*>& _states)
   : mStateSpace(std::move(_stateSpace)), mIndex(0)
 {

--- a/src/constraint/FiniteSampleable.cpp
+++ b/src/constraint/FiniteSampleable.cpp
@@ -23,7 +23,7 @@ public:
   virtual ~FiniteSampleGenerator();
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   bool sample(statespace::StateSpace::State* _state) override;
@@ -82,7 +82,7 @@ FiniteSampleGenerator::~FiniteSampleGenerator()
 }
 
 //==============================================================================
-statespace::StateSpacePtr FiniteSampleGenerator::getStateSpace() const
+statespace::ConstStateSpacePtr FiniteSampleGenerator::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/FiniteSampleable.cpp
+++ b/src/constraint/FiniteSampleable.cpp
@@ -171,7 +171,7 @@ FiniteSampleable::~FiniteSampleable()
 }
 
 //==============================================================================
-statespace::StateSpacePtr FiniteSampleable::getStateSpace() const
+statespace::ConstStateSpacePtr FiniteSampleable::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/NewtonsMethodProjectable.cpp
+++ b/src/constraint/NewtonsMethodProjectable.cpp
@@ -117,7 +117,7 @@ bool NewtonsMethodProjectable::project(
 }
 
 //==============================================================================
-statespace::StateSpacePtr NewtonsMethodProjectable::getStateSpace() const
+statespace::ConstStateSpacePtr NewtonsMethodProjectable::getStateSpace() const
 {
   return mDifferentiable->getStateSpace();
 }

--- a/src/constraint/RejectionSampleable.cpp
+++ b/src/constraint/RejectionSampleable.cpp
@@ -11,7 +11,7 @@ class RejectionSampler : public SampleGenerator
 {
 public:
   RejectionSampler(
-      statespace::StateSpacePtr _stateSpace,
+      statespace::ConstStateSpacePtr _stateSpace,
       std::unique_ptr<SampleGenerator> _sampler,
       TestablePtr _testable,
       int _maxTrialPerSample);
@@ -37,7 +37,7 @@ public:
   int getNumSamples() const override;
 
 private:
-  statespace::StateSpacePtr mStateSpace;
+  statespace::ConstStateSpacePtr mStateSpace;
   std::unique_ptr<SampleGenerator> mSampler;
   TestablePtr mTestable;
   int mMaxTrialPerSample;
@@ -100,7 +100,7 @@ std::unique_ptr<SampleGenerator> RejectionSampleable::createSampleGenerator()
 
 //==============================================================================
 RejectionSampler::RejectionSampler(
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     std::unique_ptr<SampleGenerator> _sampler,
     TestablePtr _testable,
     int _maxTrialPerSample)

--- a/src/constraint/RejectionSampleable.cpp
+++ b/src/constraint/RejectionSampleable.cpp
@@ -84,7 +84,7 @@ RejectionSampleable::RejectionSampleable(
 }
 
 //==============================================================================
-statespace::StateSpacePtr RejectionSampleable::getStateSpace() const
+statespace::ConstStateSpacePtr RejectionSampleable::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/RejectionSampleable.cpp
+++ b/src/constraint/RejectionSampleable.cpp
@@ -25,7 +25,7 @@ public:
   virtual ~RejectionSampler() = default;
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   bool sample(statespace::StateSpace::State* _state) override;
@@ -123,7 +123,7 @@ RejectionSampler::RejectionSampler(
 }
 
 //==============================================================================
-statespace::StateSpacePtr RejectionSampler::getStateSpace() const
+statespace::ConstStateSpacePtr RejectionSampler::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/Satisfied.cpp
+++ b/src/constraint/Satisfied.cpp
@@ -12,7 +12,7 @@ Satisfied::Satisfied(statespace::StateSpacePtr _space)
 }
 
 //==============================================================================
-statespace::StateSpacePtr Satisfied::getStateSpace() const
+statespace::ConstStateSpacePtr Satisfied::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/Satisfied.cpp
+++ b/src/constraint/Satisfied.cpp
@@ -4,7 +4,7 @@ namespace aikido {
 namespace constraint {
 
 //==============================================================================
-Satisfied::Satisfied(statespace::StateSpacePtr _space)
+Satisfied::Satisfied(statespace::ConstStateSpacePtr _space)
   : mStateSpace(std::move(_space))
 {
   if (!mStateSpace)

--- a/src/constraint/SequentialSampleable.cpp
+++ b/src/constraint/SequentialSampleable.cpp
@@ -15,7 +15,7 @@ public:
   /// \param[in] generators Sequence of generators associated with corresponding
   /// sequence of sampleables
   SequentialSampleGenerator(
-      statespace::StateSpacePtr stateSpace,
+      statespace::ConstStateSpacePtr stateSpace,
       std::vector<std::unique_ptr<SampleGenerator>> generators);
 
   // Documentation inherited
@@ -32,7 +32,7 @@ public:
 
 private:
   /// StateSpace the associated sampleable operates in.
-  statespace::StateSpacePtr mStateSpace;
+  statespace::ConstStateSpacePtr mStateSpace;
 
   /// Sequence of generators associated with corresponding sequence of
   /// sampleables.
@@ -44,7 +44,7 @@ private:
 
 //==============================================================================
 SequentialSampleGenerator::SequentialSampleGenerator(
-    statespace::StateSpacePtr stateSpace,
+    statespace::ConstStateSpacePtr stateSpace,
     std::vector<std::unique_ptr<SampleGenerator>> generators)
   : mStateSpace(std::move(stateSpace))
   , mGenerators(std::move(generators))

--- a/src/constraint/SequentialSampleable.cpp
+++ b/src/constraint/SequentialSampleable.cpp
@@ -154,7 +154,7 @@ SequentialSampleable::SequentialSampleable(
 }
 
 //==============================================================================
-statespace::StateSpacePtr SequentialSampleable::getStateSpace() const
+statespace::ConstStateSpacePtr SequentialSampleable::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/SequentialSampleable.cpp
+++ b/src/constraint/SequentialSampleable.cpp
@@ -19,7 +19,7 @@ public:
       std::vector<std::unique_ptr<SampleGenerator>> generators);
 
   // Documentation inherited
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited
   bool sample(statespace::StateSpace::State* state) override;
@@ -78,7 +78,7 @@ SequentialSampleGenerator::SequentialSampleGenerator(
 }
 
 //==============================================================================
-statespace::StateSpacePtr SequentialSampleGenerator::getStateSpace() const
+statespace::ConstStateSpacePtr SequentialSampleGenerator::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/TestableIntersection.cpp
+++ b/src/constraint/TestableIntersection.cpp
@@ -7,7 +7,7 @@ namespace constraint {
 
 //==============================================================================
 TestableIntersection::TestableIntersection(
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     std::vector<ConstTestablePtr> _constraints)
   : mStateSpace(std::move(_stateSpace)), mConstraints(std::move(_constraints))
 {

--- a/src/constraint/TestableIntersection.cpp
+++ b/src/constraint/TestableIntersection.cpp
@@ -8,7 +8,7 @@ namespace constraint {
 //==============================================================================
 TestableIntersection::TestableIntersection(
     statespace::StateSpacePtr _stateSpace,
-    std::vector<std::shared_ptr<Testable>> _constraints)
+    std::vector<ConstTestablePtr> _constraints)
   : mStateSpace(std::move(_stateSpace)), mConstraints(std::move(_constraints))
 {
   if (!mStateSpace)
@@ -48,13 +48,13 @@ std::unique_ptr<TestableOutcome> TestableIntersection::createOutcome() const
 }
 
 //==============================================================================
-statespace::StateSpacePtr TestableIntersection::getStateSpace() const
+statespace::ConstStateSpacePtr TestableIntersection::getStateSpace() const
 {
   return mStateSpace;
 }
 
 //==============================================================================
-void TestableIntersection::addConstraint(TestablePtr _constraint)
+void TestableIntersection::addConstraint(ConstTestablePtr _constraint)
 {
   if (_constraint->getStateSpace() == mStateSpace)
   {
@@ -69,7 +69,7 @@ void TestableIntersection::addConstraint(TestablePtr _constraint)
 
 //==============================================================================
 void TestableIntersection::testConstraintStateSpaceOrThrow(
-    const TestablePtr& constraint)
+    const ConstTestablePtr& constraint)
 {
   if (constraint->getStateSpace() != mStateSpace)
   {

--- a/src/constraint/dart/CollisionFree.cpp
+++ b/src/constraint/dart/CollisionFree.cpp
@@ -27,7 +27,7 @@ CollisionFree::CollisionFree(
 }
 
 //==============================================================================
-statespace::StateSpacePtr CollisionFree::getStateSpace() const
+statespace::ConstStateSpacePtr CollisionFree::getStateSpace() const
 {
   return mMetaSkeletonStateSpace;
 }

--- a/src/constraint/dart/CollisionFree.cpp
+++ b/src/constraint/dart/CollisionFree.cpp
@@ -6,7 +6,7 @@ namespace dart {
 
 //==============================================================================
 CollisionFree::CollisionFree(
-    statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
+    statespace::dart::ConstMetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
     ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
     std::shared_ptr<::dart::collision::CollisionDetector> _collisionDetector,
     ::dart::collision::CollisionOption _collisionOptions)

--- a/src/constraint/dart/FrameDifferentiable.cpp
+++ b/src/constraint/dart/FrameDifferentiable.cpp
@@ -31,7 +31,7 @@ FrameDifferentiable::FrameDifferentiable(
 
   using SE3 = statespace::SE3;
 
-  auto space = dynamic_cast<SE3*>(mPoseConstraint->getStateSpace().get());
+  auto space = dynamic_cast<const SE3*>(mPoseConstraint->getStateSpace().get());
 
   if (!space)
     throw std::invalid_argument("_poseConstraint is not in SE3.");
@@ -123,7 +123,7 @@ std::vector<ConstraintType> FrameDifferentiable::getConstraintTypes() const
 }
 
 //==============================================================================
-statespace::StateSpacePtr FrameDifferentiable::getStateSpace() const
+statespace::ConstStateSpacePtr FrameDifferentiable::getStateSpace() const
 {
   return mMetaSkeletonStateSpace;
 }

--- a/src/constraint/dart/FramePairDifferentiable.cpp
+++ b/src/constraint/dart/FramePairDifferentiable.cpp
@@ -36,7 +36,7 @@ FramePairDifferentiable::FramePairDifferentiable(
 
   using SE3 = statespace::SE3;
 
-  auto space = dynamic_cast<SE3*>(mRelPoseConstraint->getStateSpace().get());
+  auto space = dynamic_cast<const SE3*>(mRelPoseConstraint->getStateSpace().get());
 
   if (!space)
     throw std::invalid_argument("_relPoseConstraint is not in SE3.");
@@ -145,7 +145,7 @@ std::vector<ConstraintType> FramePairDifferentiable::getConstraintTypes() const
 }
 
 //==============================================================================
-statespace::StateSpacePtr FramePairDifferentiable::getStateSpace() const
+statespace::ConstStateSpacePtr FramePairDifferentiable::getStateSpace() const
 {
   return mMetaSkeletonStateSpace;
 }

--- a/src/constraint/dart/FramePairDifferentiable.cpp
+++ b/src/constraint/dart/FramePairDifferentiable.cpp
@@ -36,7 +36,8 @@ FramePairDifferentiable::FramePairDifferentiable(
 
   using SE3 = statespace::SE3;
 
-  auto space = dynamic_cast<const SE3*>(mRelPoseConstraint->getStateSpace().get());
+  auto space
+      = dynamic_cast<const SE3*>(mRelPoseConstraint->getStateSpace().get());
 
   if (!space)
     throw std::invalid_argument("_relPoseConstraint is not in SE3.");

--- a/src/constraint/dart/FrameTestable.cpp
+++ b/src/constraint/dart/FrameTestable.cpp
@@ -28,7 +28,7 @@ FrameTestable::FrameTestable(
   if (!mFrame)
     throw std::invalid_argument("_frame is nullptr.");
 
-  mPoseStateSpace = std::dynamic_pointer_cast<statespace::SE3>(
+  mPoseStateSpace = std::dynamic_pointer_cast<const statespace::SE3>(
       mPoseConstraint->getStateSpace());
 
   if (!mPoseStateSpace)
@@ -61,7 +61,7 @@ std::unique_ptr<TestableOutcome> FrameTestable::createOutcome() const
 }
 
 //==============================================================================
-std::shared_ptr<statespace::StateSpace> FrameTestable::getStateSpace() const
+statespace::ConstStateSpacePtr FrameTestable::getStateSpace() const
 {
   return mMetaSkeletonStateSpace;
 }

--- a/src/constraint/dart/InverseKinematicsSampleable.cpp
+++ b/src/constraint/dart/InverseKinematicsSampleable.cpp
@@ -107,7 +107,7 @@ InverseKinematicsSampleable::InverseKinematicsSampleable(
   if (!mPoseConstraint)
     throw std::invalid_argument("Pose SampleGenerator is nullptr.");
 
-  if (!dynamic_cast<SE3*>(mPoseConstraint->getStateSpace().get()))
+  if (!dynamic_cast<const SE3*>(mPoseConstraint->getStateSpace().get()))
     throw std::invalid_argument("Pose Sampleable does not operate on a SE3.");
 
   if (!mSeedConstraint)
@@ -122,7 +122,7 @@ InverseKinematicsSampleable::InverseKinematicsSampleable(
 }
 
 //==============================================================================
-statespace::StateSpacePtr InverseKinematicsSampleable::getStateSpace() const
+statespace::ConstStateSpacePtr InverseKinematicsSampleable::getStateSpace() const
 {
   return mMetaSkeletonStateSpace;
 }

--- a/src/constraint/dart/InverseKinematicsSampleable.cpp
+++ b/src/constraint/dart/InverseKinematicsSampleable.cpp
@@ -40,14 +40,14 @@ public:
 private:
   // For internal use only.
   IkSampleGenerator(
-      statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
+      statespace::dart::ConstMetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
       ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
       ::dart::dynamics::InverseKinematicsPtr _inverseKinematics,
       std::unique_ptr<SampleGenerator> _poseSampler,
       std::unique_ptr<SampleGenerator> _seedSampler,
       int _maxNumTrials);
 
-  statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
+  statespace::dart::ConstMetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
   ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
   std::shared_ptr<const statespace::SE3> mPoseStateSpace;
   ::dart::dynamics::InverseKinematicsPtr mInverseKinematics;
@@ -144,7 +144,7 @@ InverseKinematicsSampleable::createSampleGenerator() const
 
 //==============================================================================
 IkSampleGenerator::IkSampleGenerator(
-    statespace::dart::MetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
+    statespace::dart::ConstMetaSkeletonStateSpacePtr _metaSkeletonStateSpace,
     ::dart::dynamics::MetaSkeletonPtr _metaskeleton,
     ::dart::dynamics::InverseKinematicsPtr _inverseKinematics,
     std::unique_ptr<SampleGenerator> _poseSampler,

--- a/src/constraint/dart/InverseKinematicsSampleable.cpp
+++ b/src/constraint/dart/InverseKinematicsSampleable.cpp
@@ -26,7 +26,7 @@ public:
   virtual ~IkSampleGenerator() = default;
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   bool sample(statespace::StateSpace::State* _state) override;
@@ -49,7 +49,7 @@ private:
 
   statespace::dart::MetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
   ::dart::dynamics::MetaSkeletonPtr mMetaSkeleton;
-  std::shared_ptr<statespace::SE3> mPoseStateSpace;
+  std::shared_ptr<const statespace::SE3> mPoseStateSpace;
   ::dart::dynamics::InverseKinematicsPtr mInverseKinematics;
   std::unique_ptr<SampleGenerator> mPoseSampler;
   std::unique_ptr<SampleGenerator> mSeedSampler;
@@ -152,7 +152,7 @@ IkSampleGenerator::IkSampleGenerator(
   : mMetaSkeletonStateSpace(std::move(_metaSkeletonStateSpace))
   , mMetaSkeleton(std::move(_metaskeleton))
   , mPoseStateSpace(
-        std::dynamic_pointer_cast<SE3>(_poseSampler->getStateSpace()))
+        std::dynamic_pointer_cast<const SE3>(_poseSampler->getStateSpace()))
   , mInverseKinematics(std::move(_inverseKinematics))
   , mPoseSampler(std::move(_poseSampler))
   , mSeedSampler(std::move(_seedSampler))
@@ -189,7 +189,7 @@ IkSampleGenerator::IkSampleGenerator(
 }
 
 //==============================================================================
-statespace::StateSpacePtr IkSampleGenerator::getStateSpace() const
+statespace::ConstStateSpacePtr IkSampleGenerator::getStateSpace() const
 {
   return mMetaSkeletonStateSpace;
 }

--- a/src/constraint/dart/InverseKinematicsSampleable.cpp
+++ b/src/constraint/dart/InverseKinematicsSampleable.cpp
@@ -122,7 +122,8 @@ InverseKinematicsSampleable::InverseKinematicsSampleable(
 }
 
 //==============================================================================
-statespace::ConstStateSpacePtr InverseKinematicsSampleable::getStateSpace() const
+statespace::ConstStateSpacePtr InverseKinematicsSampleable::getStateSpace()
+    const
 {
   return mMetaSkeletonStateSpace;
 }

--- a/src/constraint/dart/JointStateSpaceHelpers.cpp
+++ b/src/constraint/dart/JointStateSpaceHelpers.cpp
@@ -26,7 +26,7 @@ std::unique_ptr<Differentiable> createDifferentiableBounds(
 
 //==============================================================================
 std::unique_ptr<Differentiable> createDifferentiableBounds(
-    statespace::dart::MetaSkeletonStateSpacePtr _metaSkeleton)
+    statespace::dart::ConstMetaSkeletonStateSpacePtr _metaSkeleton)
 {
   if (!_metaSkeleton)
     throw std::invalid_argument("MetaSkeletonStateSpace is nullptr.");

--- a/src/constraint/dart/JointStateSpaceHelpers.cpp
+++ b/src/constraint/dart/JointStateSpaceHelpers.cpp
@@ -20,7 +20,7 @@ std::unique_ptr<Differentiable> createDifferentiableBounds(
   return common::DynamicCastFactory<detail::createDifferentiableFor_impl,
                                     common::DynamicCastFactory_shared_ptr,
                                     const statespace::dart::JointStateSpace,
-                                    detail::ConstJointStateSpaceTypeList>::
+                                    detail::JointStateSpaceTypeList>::
       create(std::move(_stateSpace));
 }
 
@@ -59,7 +59,7 @@ std::unique_ptr<Projectable> createProjectableBounds(
   return common::DynamicCastFactory<detail::createProjectableFor_impl,
                                     common::DynamicCastFactory_shared_ptr,
                                     const statespace::dart::JointStateSpace,
-                                    detail::ConstJointStateSpaceTypeList>::
+                                    detail::JointStateSpaceTypeList>::
       create(std::move(_stateSpace));
 }
 
@@ -91,7 +91,7 @@ std::unique_ptr<Testable> createTestableBounds(
   return common::DynamicCastFactory<detail::createTestableFor_impl,
                                     common::DynamicCastFactory_shared_ptr,
                                     const statespace::dart::JointStateSpace,
-                                    detail::ConstJointStateSpaceTypeList>::
+                                    detail::JointStateSpaceTypeList>::
       create(std::move(_stateSpace));
 }
 
@@ -124,7 +124,7 @@ std::unique_ptr<Sampleable> createSampleableBounds(
   return common::DynamicCastFactory<detail::createSampleableFor_impl,
                                     common::DynamicCastFactory_shared_ptr,
                                     const statespace::dart::JointStateSpace,
-                                    detail::ConstJointStateSpaceTypeList>::
+                                    detail::JointStateSpaceTypeList>::
       create(std::move(_stateSpace), std::move(_rng));
 }
 

--- a/src/constraint/dart/JointStateSpaceHelpers.cpp
+++ b/src/constraint/dart/JointStateSpaceHelpers.cpp
@@ -15,12 +15,12 @@ using ::dart::common::make_unique;
 
 //==============================================================================
 std::unique_ptr<Differentiable> createDifferentiableBounds(
-    std::shared_ptr<statespace::dart::JointStateSpace> _stateSpace)
+    std::shared_ptr<const statespace::dart::JointStateSpace> _stateSpace)
 {
   return common::DynamicCastFactory<detail::createDifferentiableFor_impl,
                                     common::DynamicCastFactory_shared_ptr,
-                                    statespace::dart::JointStateSpace,
-                                    detail::JointStateSpaceTypeList>::
+                                    const statespace::dart::JointStateSpace,
+                                    detail::ConstJointStateSpaceTypeList>::
       create(std::move(_stateSpace));
 }
 
@@ -54,18 +54,18 @@ std::unique_ptr<Differentiable> createDifferentiableBounds(
 
 //==============================================================================
 std::unique_ptr<Projectable> createProjectableBounds(
-    std::shared_ptr<statespace::dart::JointStateSpace> _stateSpace)
+    std::shared_ptr<const statespace::dart::JointStateSpace> _stateSpace)
 {
   return common::DynamicCastFactory<detail::createProjectableFor_impl,
                                     common::DynamicCastFactory_shared_ptr,
-                                    statespace::dart::JointStateSpace,
-                                    detail::JointStateSpaceTypeList>::
+                                    const statespace::dart::JointStateSpace,
+                                    detail::ConstJointStateSpaceTypeList>::
       create(std::move(_stateSpace));
 }
 
 //==============================================================================
 std::unique_ptr<Projectable> createProjectableBounds(
-    statespace::dart::MetaSkeletonStateSpacePtr _metaSkeleton)
+    statespace::dart::ConstMetaSkeletonStateSpacePtr _metaSkeleton)
 {
   const auto n = _metaSkeleton->getNumSubspaces();
 
@@ -86,12 +86,12 @@ std::unique_ptr<Projectable> createProjectableBounds(
 
 //==============================================================================
 std::unique_ptr<Testable> createTestableBounds(
-    std::shared_ptr<statespace::dart::JointStateSpace> _stateSpace)
+    std::shared_ptr<const statespace::dart::JointStateSpace> _stateSpace)
 {
   return common::DynamicCastFactory<detail::createTestableFor_impl,
                                     common::DynamicCastFactory_shared_ptr,
-                                    statespace::dart::JointStateSpace,
-                                    detail::JointStateSpaceTypeList>::
+                                    const statespace::dart::JointStateSpace,
+                                    detail::ConstJointStateSpaceTypeList>::
       create(std::move(_stateSpace));
 }
 
@@ -118,19 +118,19 @@ std::unique_ptr<Testable> createTestableBounds(
 
 //==============================================================================
 std::unique_ptr<Sampleable> createSampleableBounds(
-    std::shared_ptr<statespace::dart::JointStateSpace> _stateSpace,
+    std::shared_ptr<const statespace::dart::JointStateSpace> _stateSpace,
     std::unique_ptr<common::RNG> _rng)
 {
   return common::DynamicCastFactory<detail::createSampleableFor_impl,
                                     common::DynamicCastFactory_shared_ptr,
-                                    statespace::dart::JointStateSpace,
-                                    detail::JointStateSpaceTypeList>::
+                                    const statespace::dart::JointStateSpace,
+                                    detail::ConstJointStateSpaceTypeList>::
       create(std::move(_stateSpace), std::move(_rng));
 }
 
 //==============================================================================
 std::unique_ptr<Sampleable> createSampleableBounds(
-    statespace::dart::MetaSkeletonStateSpacePtr _metaSkeleton,
+    statespace::dart::ConstMetaSkeletonStateSpacePtr _metaSkeleton,
     std::unique_ptr<common::RNG> _rng)
 {
   const auto n = _metaSkeleton->getNumSubspaces();

--- a/src/constraint/dart/JointStateSpaceHelpers.cpp
+++ b/src/constraint/dart/JointStateSpaceHelpers.cpp
@@ -101,7 +101,7 @@ std::unique_ptr<Testable> createTestableBounds(
 {
   const auto n = _metaSkeleton->getNumSubspaces();
 
-  std::vector<std::shared_ptr<Testable>> constraints;
+  std::vector<std::shared_ptr<const Testable>> constraints;
   constraints.reserve(n);
 
   for (std::size_t i = 0; i < n; ++i)

--- a/src/constraint/dart/JointStateSpaceHelpers.cpp
+++ b/src/constraint/dart/JointStateSpaceHelpers.cpp
@@ -97,7 +97,7 @@ std::unique_ptr<Testable> createTestableBounds(
 
 //==============================================================================
 std::unique_ptr<Testable> createTestableBounds(
-    statespace::dart::MetaSkeletonStateSpacePtr _metaSkeleton)
+    statespace::dart::ConstMetaSkeletonStateSpacePtr _metaSkeleton)
 {
   const auto n = _metaSkeleton->getNumSubspaces();
 

--- a/src/constraint/dart/TSR.cpp
+++ b/src/constraint/dart/TSR.cpp
@@ -169,7 +169,7 @@ TSR& TSR::operator=(TSR&& other)
 }
 
 //==============================================================================
-std::shared_ptr<statespace::StateSpace> TSR::getStateSpace() const
+std::shared_ptr<const statespace::StateSpace> TSR::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/dart/TSR.cpp
+++ b/src/constraint/dart/TSR.cpp
@@ -29,7 +29,7 @@ public:
   virtual ~TSRSampleGenerator() = default;
 
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   /// Return a transform sampled from this TSR.
   ///
@@ -407,7 +407,7 @@ TSRSampleGenerator::TSRSampleGenerator(
 }
 
 //==============================================================================
-statespace::StateSpacePtr TSRSampleGenerator::getStateSpace() const
+statespace::ConstStateSpacePtr TSRSampleGenerator::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/constraint/uniform/SE2BoxConstraint.cpp
+++ b/src/constraint/uniform/SE2BoxConstraint.cpp
@@ -13,7 +13,7 @@ using constraint::ConstraintType;
 class SE2BoxConstraintSampleGenerator : public constraint::SampleGenerator
 {
 public:
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   bool sample(statespace::StateSpace::State* _state) override;
 
@@ -23,13 +23,13 @@ public:
 
 private:
   SE2BoxConstraintSampleGenerator(
-      std::shared_ptr<statespace::SE2> _space,
+      std::shared_ptr<const statespace::SE2> _space,
       std::unique_ptr<common::RNG> _rng,
       const Eigen::Vector3d& _lowerLimits,
       const Eigen::Vector3d& _upperLimits);
 
   const std::size_t mDimension;
-  std::shared_ptr<statespace::SE2> mSpace;
+  std::shared_ptr<const statespace::SE2> mSpace;
   std::unique_ptr<common::RNG> mRng;
   std::vector<std::uniform_real_distribution<double>> mDistributions;
   friend class SE2BoxConstraint;
@@ -37,7 +37,7 @@ private:
 
 //==============================================================================
 SE2BoxConstraintSampleGenerator::SE2BoxConstraintSampleGenerator(
-    std::shared_ptr<statespace::SE2> _space,
+    std::shared_ptr<const statespace::SE2> _space,
     std::unique_ptr<common::RNG> _rng,
     const Eigen::Vector3d& _lowerLimits,
     const Eigen::Vector3d& _upperLimits)
@@ -50,7 +50,7 @@ SE2BoxConstraintSampleGenerator::SE2BoxConstraintSampleGenerator(
 }
 
 //==============================================================================
-statespace::StateSpacePtr SE2BoxConstraintSampleGenerator::getStateSpace() const
+statespace::ConstStateSpacePtr SE2BoxConstraintSampleGenerator::getStateSpace() const
 {
   return mSpace;
 }
@@ -83,7 +83,7 @@ bool SE2BoxConstraintSampleGenerator::canSample() const
 
 //==============================================================================
 SE2BoxConstraint::SE2BoxConstraint(
-    std::shared_ptr<statespace::SE2> space,
+    std::shared_ptr<const statespace::SE2> space,
     std::unique_ptr<common::RNG> rng,
     const Eigen::Vector2d& lowerLimits,
     const Eigen::Vector2d& upperLimits)

--- a/src/constraint/uniform/SE2BoxConstraint.cpp
+++ b/src/constraint/uniform/SE2BoxConstraint.cpp
@@ -130,7 +130,7 @@ SE2BoxConstraint::SE2BoxConstraint(
 }
 
 //==============================================================================
-statespace::StateSpacePtr SE2BoxConstraint::getStateSpace() const
+statespace::ConstStateSpacePtr SE2BoxConstraint::getStateSpace() const
 {
   return mSpace;
 }

--- a/src/constraint/uniform/SE2BoxConstraint.cpp
+++ b/src/constraint/uniform/SE2BoxConstraint.cpp
@@ -50,7 +50,8 @@ SE2BoxConstraintSampleGenerator::SE2BoxConstraintSampleGenerator(
 }
 
 //==============================================================================
-statespace::ConstStateSpacePtr SE2BoxConstraintSampleGenerator::getStateSpace() const
+statespace::ConstStateSpacePtr SE2BoxConstraintSampleGenerator::getStateSpace()
+    const
 {
   return mSpace;
 }

--- a/src/constraint/uniform/SO2UniformSampler.cpp
+++ b/src/constraint/uniform/SO2UniformSampler.cpp
@@ -10,7 +10,7 @@ class SO2UniformSampleGenerator : public constraint::SampleGenerator
 {
 public:
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   bool sample(statespace::StateSpace::State* _state) override;
@@ -23,10 +23,10 @@ public:
 
 private:
   SO2UniformSampleGenerator(
-      std::shared_ptr<statespace::SO2> _space,
+      std::shared_ptr<const statespace::SO2> _space,
       std::unique_ptr<common::RNG> _rng);
 
-  std::shared_ptr<statespace::SO2> mSpace;
+  std::shared_ptr<const statespace::SO2> mSpace;
   std::unique_ptr<common::RNG> mRng;
   std::uniform_real_distribution<double> mDistribution;
 
@@ -35,14 +35,14 @@ private:
 
 //==============================================================================
 SO2UniformSampleGenerator::SO2UniformSampleGenerator(
-    std::shared_ptr<statespace::SO2> _space, std::unique_ptr<common::RNG> _rng)
+    std::shared_ptr<const statespace::SO2> _space, std::unique_ptr<common::RNG> _rng)
   : mSpace(std::move(_space)), mRng(std::move(_rng)), mDistribution(-M_PI, M_PI)
 {
   // Do nothing
 }
 
 //==============================================================================
-statespace::StateSpacePtr SO2UniformSampleGenerator::getStateSpace() const
+statespace::ConstStateSpacePtr SO2UniformSampleGenerator::getStateSpace() const
 {
   return mSpace;
 }
@@ -69,7 +69,7 @@ bool SO2UniformSampleGenerator::canSample() const
 
 //==============================================================================
 SO2UniformSampler::SO2UniformSampler(
-    std::shared_ptr<statespace::SO2> _space, std::unique_ptr<common::RNG> _rng)
+    std::shared_ptr<const statespace::SO2> _space, std::unique_ptr<common::RNG> _rng)
   : mSpace(std::move(_space)), mRng(std::move(_rng))
 {
   if (!mSpace)

--- a/src/constraint/uniform/SO2UniformSampler.cpp
+++ b/src/constraint/uniform/SO2UniformSampler.cpp
@@ -80,7 +80,7 @@ SO2UniformSampler::SO2UniformSampler(
 }
 
 //==============================================================================
-statespace::StateSpacePtr SO2UniformSampler::getStateSpace() const
+statespace::ConstStateSpacePtr SO2UniformSampler::getStateSpace() const
 {
   return mSpace;
 }

--- a/src/constraint/uniform/SO2UniformSampler.cpp
+++ b/src/constraint/uniform/SO2UniformSampler.cpp
@@ -35,7 +35,8 @@ private:
 
 //==============================================================================
 SO2UniformSampleGenerator::SO2UniformSampleGenerator(
-    std::shared_ptr<const statespace::SO2> _space, std::unique_ptr<common::RNG> _rng)
+    std::shared_ptr<const statespace::SO2> _space,
+    std::unique_ptr<common::RNG> _rng)
   : mSpace(std::move(_space)), mRng(std::move(_rng)), mDistribution(-M_PI, M_PI)
 {
   // Do nothing
@@ -69,7 +70,8 @@ bool SO2UniformSampleGenerator::canSample() const
 
 //==============================================================================
 SO2UniformSampler::SO2UniformSampler(
-    std::shared_ptr<const statespace::SO2> _space, std::unique_ptr<common::RNG> _rng)
+    std::shared_ptr<const statespace::SO2> _space,
+    std::unique_ptr<common::RNG> _rng)
   : mSpace(std::move(_space)), mRng(std::move(_rng))
 {
   if (!mSpace)

--- a/src/constraint/uniform/SO3UniformSampler.cpp
+++ b/src/constraint/uniform/SO3UniformSampler.cpp
@@ -35,7 +35,8 @@ private:
 
 //==============================================================================
 SO3UniformSampleGenerator::SO3UniformSampleGenerator(
-    std::shared_ptr<const statespace::SO3> _space, std::unique_ptr<common::RNG> _rng)
+    std::shared_ptr<const statespace::SO3> _space,
+    std::unique_ptr<common::RNG> _rng)
   : mSpace(std::move(_space)), mRng(std::move(_rng)), mDistribution(0., 1.)
 {
   // Do nothing
@@ -74,7 +75,8 @@ bool SO3UniformSampleGenerator::canSample() const
 
 //==============================================================================
 SO3UniformSampler::SO3UniformSampler(
-    std::shared_ptr<const statespace::SO3> _space, std::unique_ptr<common::RNG> _rng)
+    std::shared_ptr<const statespace::SO3> _space,
+    std::unique_ptr<common::RNG> _rng)
   : mSpace(std::move(_space)), mRng(std::move(_rng))
 {
   if (!mSpace)

--- a/src/constraint/uniform/SO3UniformSampler.cpp
+++ b/src/constraint/uniform/SO3UniformSampler.cpp
@@ -10,7 +10,7 @@ class SO3UniformSampleGenerator : public constraint::SampleGenerator
 {
 public:
   // Documentation inherited.
-  statespace::StateSpacePtr getStateSpace() const override;
+  statespace::ConstStateSpacePtr getStateSpace() const override;
 
   // Documentation inherited.
   bool sample(statespace::StateSpace::State* _state) override;
@@ -23,10 +23,10 @@ public:
 
 private:
   SO3UniformSampleGenerator(
-      std::shared_ptr<statespace::SO3> _space,
+      std::shared_ptr<const statespace::SO3> _space,
       std::unique_ptr<common::RNG> _rng);
 
-  std::shared_ptr<statespace::SO3> mSpace;
+  std::shared_ptr<const statespace::SO3> mSpace;
   std::unique_ptr<common::RNG> mRng;
   std::uniform_real_distribution<double> mDistribution;
 
@@ -35,14 +35,14 @@ private:
 
 //==============================================================================
 SO3UniformSampleGenerator::SO3UniformSampleGenerator(
-    std::shared_ptr<statespace::SO3> _space, std::unique_ptr<common::RNG> _rng)
+    std::shared_ptr<const statespace::SO3> _space, std::unique_ptr<common::RNG> _rng)
   : mSpace(std::move(_space)), mRng(std::move(_rng)), mDistribution(0., 1.)
 {
   // Do nothing
 }
 
 //==============================================================================
-statespace::StateSpacePtr SO3UniformSampleGenerator::getStateSpace() const
+statespace::ConstStateSpacePtr SO3UniformSampleGenerator::getStateSpace() const
 {
   return mSpace;
 }
@@ -74,7 +74,7 @@ bool SO3UniformSampleGenerator::canSample() const
 
 //==============================================================================
 SO3UniformSampler::SO3UniformSampler(
-    std::shared_ptr<statespace::SO3> _space, std::unique_ptr<common::RNG> _rng)
+    std::shared_ptr<const statespace::SO3> _space, std::unique_ptr<common::RNG> _rng)
   : mSpace(std::move(_space)), mRng(std::move(_rng))
 {
   if (!mSpace)

--- a/src/constraint/uniform/SO3UniformSampler.cpp
+++ b/src/constraint/uniform/SO3UniformSampler.cpp
@@ -85,7 +85,7 @@ SO3UniformSampler::SO3UniformSampler(
 }
 
 //==============================================================================
-statespace::StateSpacePtr SO3UniformSampler::getStateSpace() const
+statespace::ConstStateSpacePtr SO3UniformSampler::getStateSpace() const
 {
   return mSpace;
 }

--- a/src/control/ros/Conversions.cpp
+++ b/src/control/ros/Conversions.cpp
@@ -279,8 +279,8 @@ std::unique_ptr<SplineTrajectory> toSplineJointTrajectory(
   {
     auto jointSpace = space->getJointSpace(i);
     auto properties = jointSpace->getProperties();
-    auto r1Joint = std::dynamic_pointer_cast<R1Joint>(jointSpace);
-    auto so2Joint = std::dynamic_pointer_cast<SO2Joint>(jointSpace);
+    auto r1Joint = std::dynamic_pointer_cast<const R1Joint>(jointSpace);
+    auto so2Joint = std::dynamic_pointer_cast<const SO2Joint>(jointSpace);
 
     if (properties.getNumDofs() != 1 || (!r1Joint && !so2Joint))
     {
@@ -452,8 +452,8 @@ trajectory_msgs::JointTrajectory toRosJointTrajectory(
     auto jointSpace = space->getJointSpace(i);
 
     // Supports only R1Joints and SO2Joints.
-    auto r1Joint = std::dynamic_pointer_cast<R1Joint>(jointSpace);
-    auto so2Joint = std::dynamic_pointer_cast<SO2Joint>(jointSpace);
+    auto r1Joint = std::dynamic_pointer_cast<const R1Joint>(jointSpace);
+    auto so2Joint = std::dynamic_pointer_cast<const SO2Joint>(jointSpace);
     if (!r1Joint && !so2Joint)
     {
       throw std::invalid_argument(

--- a/src/distance/CartesianProductWeighted.cpp
+++ b/src/distance/CartesianProductWeighted.cpp
@@ -5,7 +5,7 @@ namespace distance {
 
 //==============================================================================
 CartesianProductWeighted::CartesianProductWeighted(
-    std::shared_ptr<statespace::CartesianProduct> _space,
+    std::shared_ptr<const statespace::CartesianProduct> _space,
     std::vector<DistanceMetricPtr> _metrics)
   : mStateSpace(std::move(_space))
 {
@@ -92,7 +92,7 @@ CartesianProductWeighted::CartesianProductWeighted(
 }
 
 //==============================================================================
-statespace::StateSpacePtr CartesianProductWeighted::getStateSpace() const
+statespace::ConstStateSpacePtr CartesianProductWeighted::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/distance/SE2Weighted.cpp
+++ b/src/distance/SE2Weighted.cpp
@@ -14,7 +14,8 @@ SE2Weighted::SE2Weighted(std::shared_ptr<const statespace::SE2> space)
 
 //==============================================================================
 SE2Weighted::SE2Weighted(
-    std::shared_ptr<const statespace::SE2> space, const Eigen::Vector2d& weights)
+    std::shared_ptr<const statespace::SE2> space,
+    const Eigen::Vector2d& weights)
   : mStateSpace(std::move(space)), mWeights(weights)
 {
   if (mStateSpace == nullptr)

--- a/src/distance/SE2Weighted.cpp
+++ b/src/distance/SE2Weighted.cpp
@@ -33,7 +33,7 @@ SE2Weighted::SE2Weighted(
 }
 
 //==============================================================================
-statespace::StateSpacePtr SE2Weighted::getStateSpace() const
+statespace::ConstStateSpacePtr SE2Weighted::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/distance/SE2Weighted.cpp
+++ b/src/distance/SE2Weighted.cpp
@@ -5,7 +5,7 @@ namespace aikido {
 namespace distance {
 
 //==============================================================================
-SE2Weighted::SE2Weighted(std::shared_ptr<statespace::SE2> space)
+SE2Weighted::SE2Weighted(std::shared_ptr<const statespace::SE2> space)
   : mStateSpace(std::move(space)), mWeights(Eigen::Vector2d::Ones())
 {
   if (mStateSpace == nullptr)
@@ -14,7 +14,7 @@ SE2Weighted::SE2Weighted(std::shared_ptr<statespace::SE2> space)
 
 //==============================================================================
 SE2Weighted::SE2Weighted(
-    std::shared_ptr<statespace::SE2> space, const Eigen::Vector2d& weights)
+    std::shared_ptr<const statespace::SE2> space, const Eigen::Vector2d& weights)
   : mStateSpace(std::move(space)), mWeights(weights)
 {
   if (mStateSpace == nullptr)

--- a/src/distance/SO2Angular.cpp
+++ b/src/distance/SO2Angular.cpp
@@ -14,7 +14,7 @@ SO2Angular::SO2Angular(std::shared_ptr<statespace::SO2> _space)
 }
 
 //==============================================================================
-statespace::StateSpacePtr SO2Angular::getStateSpace() const
+statespace::ConstStateSpacePtr SO2Angular::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/distance/SO2Angular.cpp
+++ b/src/distance/SO2Angular.cpp
@@ -4,7 +4,7 @@ namespace aikido {
 namespace distance {
 
 //==============================================================================
-SO2Angular::SO2Angular(std::shared_ptr<statespace::SO2> _space)
+SO2Angular::SO2Angular(std::shared_ptr<const statespace::SO2> _space)
   : mStateSpace(std::move(_space))
 {
   if (mStateSpace == nullptr)

--- a/src/distance/SO3Angular.cpp
+++ b/src/distance/SO3Angular.cpp
@@ -4,7 +4,7 @@ namespace aikido {
 namespace distance {
 
 //==============================================================================
-SO3Angular::SO3Angular(std::shared_ptr<statespace::SO3> _space)
+SO3Angular::SO3Angular(std::shared_ptr<const statespace::SO3> _space)
   : mStateSpace(std::move(_space))
 {
   if (mStateSpace == nullptr)

--- a/src/distance/SO3Angular.cpp
+++ b/src/distance/SO3Angular.cpp
@@ -14,7 +14,7 @@ SO3Angular::SO3Angular(std::shared_ptr<statespace::SO3> _space)
 }
 
 //==============================================================================
-statespace::StateSpacePtr SO3Angular::getStateSpace() const
+statespace::ConstStateSpacePtr SO3Angular::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/distance/defaults.cpp
+++ b/src/distance/defaults.cpp
@@ -17,5 +17,19 @@ std::unique_ptr<DistanceMetric> createDistanceMetric(
       create(_sspace);
 }
 
+//==============================================================================
+std::unique_ptr<DistanceMetric> createDistanceMetricConst(
+    statespace::ConstStateSpacePtr _sspace)
+{
+  if (_sspace == nullptr)
+    throw std::invalid_argument("_sspace is null.");
+
+  return common::DynamicCastFactory<detail::createDistanceMetricFor_impl,
+                                    common::DynamicCastFactory_shared_ptr,
+                                    const statespace::StateSpace,
+                                    detail::ConstSupportedStateSpaces>::
+      create(_sspace);
+}
+
 } // namespace distance
 } // namespace aikido

--- a/src/distance/defaults.cpp
+++ b/src/distance/defaults.cpp
@@ -5,20 +5,6 @@ namespace distance {
 
 //==============================================================================
 std::unique_ptr<DistanceMetric> createDistanceMetric(
-    statespace::StateSpacePtr _sspace)
-{
-  if (_sspace == nullptr)
-    throw std::invalid_argument("_sspace is null.");
-
-  return common::DynamicCastFactory<detail::createDistanceMetricFor_impl,
-                                    common::DynamicCastFactory_shared_ptr,
-                                    statespace::StateSpace,
-                                    detail::SupportedStateSpaces>::
-      create(_sspace);
-}
-
-//==============================================================================
-std::unique_ptr<DistanceMetric> createDistanceMetricConst(
     statespace::ConstStateSpacePtr _sspace)
 {
   if (_sspace == nullptr)
@@ -27,7 +13,7 @@ std::unique_ptr<DistanceMetric> createDistanceMetricConst(
   return common::DynamicCastFactory<detail::createDistanceMetricFor_impl,
                                     common::DynamicCastFactory_shared_ptr,
                                     const statespace::StateSpace,
-                                    detail::ConstSupportedStateSpaces>::
+                                    detail::SupportedStateSpaces>::
       create(_sspace);
 }
 

--- a/src/planner/ompl/GeometricStateSpace.cpp
+++ b/src/planner/ompl/GeometricStateSpace.cpp
@@ -18,7 +18,7 @@ GeometricStateSpace::StateType::StateType(statespace::StateSpace::State* _st)
 
 //==============================================================================
 GeometricStateSpace::GeometricStateSpace(
-    statespace::StateSpacePtr _sspace,
+    statespace::ConstStateSpacePtr _sspace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,
@@ -247,7 +247,7 @@ void GeometricStateSpace::freeState(::ompl::base::State* _state) const
 }
 
 //==============================================================================
-statespace::StateSpacePtr GeometricStateSpace::getAikidoStateSpace() const
+statespace::ConstStateSpacePtr GeometricStateSpace::getAikidoStateSpace() const
 {
   return mStateSpace;
 }

--- a/src/planner/ompl/Planner.cpp
+++ b/src/planner/ompl/Planner.cpp
@@ -13,7 +13,7 @@ namespace ompl {
 
 //==============================================================================
 ::ompl::base::SpaceInformationPtr getSpaceInformation(
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,
@@ -164,7 +164,7 @@ ompl_shared_ptr<::ompl::base::GoalRegion> getGoalRegion(
 trajectory::InterpolatedPtr planOMPL(
     const ::ompl::base::PlannerPtr& _planner,
     const ::ompl::base::ProblemDefinitionPtr& _pdef,
-    statespace::StateSpacePtr _sspace,
+    statespace::ConstStateSpacePtr _sspace,
     statespace::InterpolatorPtr _interpolator,
     double _maxPlanTime)
 {
@@ -206,7 +206,7 @@ trajectory::InterpolatedPtr planCRRT(
     constraint::TestablePtr _goalTestable,
     constraint::SampleablePtr _goalSampler,
     constraint::ProjectablePtr _trajConstraint,
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,
@@ -290,7 +290,7 @@ trajectory::InterpolatedPtr planCRRTConnect(
     constraint::TestablePtr _goalTestable,
     constraint::SampleablePtr _goalSampler,
     constraint::ProjectablePtr _trajConstraint,
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,

--- a/src/planner/ompl/Planner.cpp
+++ b/src/planner/ompl/Planner.cpp
@@ -13,7 +13,7 @@ namespace ompl {
 
 //==============================================================================
 ::ompl::base::SpaceInformationPtr getSpaceInformation(
-    statespace::ConstStateSpacePtr _stateSpace,
+    statespace::StateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,

--- a/src/planner/ompl/Planner.cpp
+++ b/src/planner/ompl/Planner.cpp
@@ -13,7 +13,7 @@ namespace ompl {
 
 //==============================================================================
 ::ompl::base::SpaceInformationPtr getSpaceInformation(
-    statespace::StateSpacePtr _stateSpace,
+    statespace::ConstStateSpacePtr _stateSpace,
     statespace::InterpolatorPtr _interpolator,
     distance::DistanceMetricPtr _dmetric,
     constraint::SampleablePtr _sampler,
@@ -118,7 +118,7 @@ namespace ompl {
   auto si = ompl_make_shared<::ompl::base::SpaceInformation>(std::move(sspace));
 
   // Validity checking
-  std::vector<constraint::TestablePtr> constraints{
+  std::vector<constraint::ConstTestablePtr> constraints{
       std::move(_validityConstraint), std::move(_boundsConstraint)};
   auto conjunctionConstraint
       = std::make_shared<constraint::TestableIntersection>(

--- a/src/planner/parabolic/HauserParabolicSmootherHelpers.cpp
+++ b/src/planner/parabolic/HauserParabolicSmootherHelpers.cpp
@@ -66,7 +66,7 @@ public:
 private:
   aikido::constraint::TestablePtr mTestable;
   double mCheckResolution;
-  aikido::statespace::StateSpacePtr mStateSpace;
+  aikido::statespace::ConstStateSpacePtr mStateSpace;
   aikido::statespace::GeodesicInterpolator mInterpolator;
 };
 

--- a/src/planner/vectorfield/BodyNodePoseVectorField.cpp
+++ b/src/planner/vectorfield/BodyNodePoseVectorField.cpp
@@ -9,9 +9,9 @@ namespace vectorfield {
 
 //==============================================================================
 BodyNodePoseVectorField::BodyNodePoseVectorField(
-    aikido::statespace::dart::MetaSkeletonStateSpacePtr metaSkeletonStateSpace,
+    aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
     dart::dynamics::MetaSkeletonPtr metaSkeleton,
-    dart::dynamics::BodyNodePtr bodyNode,
+    dart::dynamics::ConstBodyNodePtr bodyNode,
     double maxStepSize,
     double jointLimitPadding,
     bool enforceJointVelocityLimits)
@@ -126,13 +126,6 @@ bool BodyNodePoseVectorField::evaluateTrajectory(
 }
 
 //==============================================================================
-aikido::statespace::dart::MetaSkeletonStateSpacePtr
-BodyNodePoseVectorField::getMetaSkeletonStateSpace()
-{
-  return mMetaSkeletonStateSpace;
-}
-
-//==============================================================================
 aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr
 BodyNodePoseVectorField::getMetaSkeletonStateSpace() const
 {
@@ -150,12 +143,6 @@ dart::dynamics::ConstMetaSkeletonPtr BodyNodePoseVectorField::getMetaSkeleton()
     const
 {
   return mMetaSkeleton;
-}
-
-//==============================================================================
-dart::dynamics::BodyNodePtr BodyNodePoseVectorField::getBodyNode()
-{
-  return mBodyNode;
 }
 
 //==============================================================================

--- a/src/planner/vectorfield/BodyNodePoseVectorField.cpp
+++ b/src/planner/vectorfield/BodyNodePoseVectorField.cpp
@@ -9,7 +9,8 @@ namespace vectorfield {
 
 //==============================================================================
 BodyNodePoseVectorField::BodyNodePoseVectorField(
-    aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
+    aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr
+        metaSkeletonStateSpace,
     dart::dynamics::MetaSkeletonPtr metaSkeleton,
     dart::dynamics::ConstBodyNodePtr bodyNode,
     double maxStepSize,

--- a/src/planner/vectorfield/MoveEndEffectorOffsetVectorField.cpp
+++ b/src/planner/vectorfield/MoveEndEffectorOffsetVectorField.cpp
@@ -12,9 +12,9 @@ namespace vectorfield {
 
 //==============================================================================
 MoveEndEffectorOffsetVectorField::MoveEndEffectorOffsetVectorField(
-    aikido::statespace::dart::MetaSkeletonStateSpacePtr stateSpace,
+    aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
     dart::dynamics::MetaSkeletonPtr metaskeleton,
-    dart::dynamics::BodyNodePtr bn,
+    dart::dynamics::ConstBodyNodePtr bn,
     const Eigen::Vector3d& direction,
     double minDistance,
     double maxDistance,

--- a/src/planner/vectorfield/VectorField.cpp
+++ b/src/planner/vectorfield/VectorField.cpp
@@ -5,14 +5,14 @@ namespace planner {
 namespace vectorfield {
 
 //==============================================================================
-VectorField::VectorField(aikido::statespace::StateSpacePtr stateSpace)
+VectorField::VectorField(aikido::statespace::ConstStateSpacePtr stateSpace)
   : mStateSpace(stateSpace)
 {
   // Do nothing
 }
 
 //==============================================================================
-aikido::statespace::StateSpacePtr VectorField::getStateSpace()
+aikido::statespace::ConstStateSpacePtr VectorField::getStateSpace()
 {
   return mStateSpace;
 }

--- a/src/planner/vectorfield/VectorFieldPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldPlanner.cpp
@@ -29,7 +29,7 @@ std::unique_ptr<aikido::trajectory::Spline> followVectorField(
     std::chrono::duration<double> timelimit,
     double initialStepSize,
     double checkConstraintResolution,
-    planner::PlanningResult* planningResult)
+    planner::Planner::Result* result)
 {
   using namespace std::placeholders;
   using errorStepper = boost::numeric::odeint::
@@ -75,17 +75,17 @@ std::unique_ptr<aikido::trajectory::Spline> followVectorField(
   // integration, which does not indicate that an error has occurred.
   catch (const detail::VectorFieldTerminated& e)
   {
-    if (planningResult)
+    if (result)
     {
-      planningResult->message = e.what();
+      result->setMessage(e.what());
     }
   }
   catch (const detail::VectorFieldError& e)
   {
     dtwarn << e.what() << std::endl;
-    if (planningResult)
+    if (result)
     {
-      planningResult->message = e.what();
+      result->setMessage(e.what());
     }
     return nullptr;
   }
@@ -93,9 +93,9 @@ std::unique_ptr<aikido::trajectory::Spline> followVectorField(
   if (integrator->getCacheIndex() <= 1)
   {
     // no enough waypoints cached to make a trajectory output.
-    if (planningResult)
+    if (result)
     {
-      planningResult->message = "No segment cached.";
+      result->setMessage("No segment cached.");
     }
     return nullptr;
   }
@@ -117,7 +117,7 @@ std::unique_ptr<aikido::trajectory::Spline> followVectorField(
             lastEvaluationTime,
             true))
     {
-      planningResult->message = "Constraint violated.";
+      result->setMessage("Constraint violated.");
       return nullptr;
     }
   }
@@ -126,10 +126,10 @@ std::unique_ptr<aikido::trajectory::Spline> followVectorField(
 
 //==============================================================================
 std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
-    const aikido::statespace::dart::MetaSkeletonStateSpacePtr& stateSpace,
+    const aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr& stateSpace,
     dart::dynamics::MetaSkeletonPtr metaskeleton,
-    const dart::dynamics::BodyNodePtr& bn,
-    const aikido::constraint::TestablePtr& constraint,
+    const dart::dynamics::ConstBodyNodePtr& bn,
+    const aikido::constraint::ConstTestablePtr& constraint,
     const Eigen::Vector3d& direction,
     double minDistance,
     double maxDistance,
@@ -139,7 +139,7 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
     double jointLimitTolerance,
     double constraintCheckResolution,
     std::chrono::duration<double> timelimit,
-    planner::PlanningResult* planningResult)
+    planner::Planner::Result* result)
 {
   // ensure that no two planners run at the same time
   if (metaskeleton->getNumBodyNodes() == 0)
@@ -204,7 +204,7 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
       timelimit,
       initialStepSize,
       constraintCheckResolution,
-      planningResult);
+      result);
 }
 
 //==============================================================================
@@ -220,7 +220,7 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorPose(
     double jointLimitTolerance,
     double constraintCheckResolution,
     std::chrono::duration<double> timelimit,
-    planner::PlanningResult* planningResult)
+    planner::Planner::Result* result)
 {
   // TODO: Check compatibility between MetaSkeleton and MetaSkeletonStateSpace
 
@@ -255,7 +255,7 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorPose(
       timelimit,
       initialStepSize,
       constraintCheckResolution,
-      planningResult);
+      result);
 }
 
 } // namespace vectorfield

--- a/src/planner/vectorfield/VectorFieldUtil.cpp
+++ b/src/planner/vectorfield/VectorFieldUtil.cpp
@@ -69,7 +69,7 @@ bool computeJointVelocityFromTwist(
     Eigen::VectorXd& jointVelocity,
     const Eigen::Vector6d& desiredTwist,
     const dart::dynamics::MetaSkeletonPtr metaSkeleton,
-    const dart::dynamics::BodyNodePtr bodyNode,
+    const dart::dynamics::ConstBodyNodePtr bodyNode,
     double jointLimitPadding,
     const Eigen::VectorXd& jointVelocityLowerLimits,
     const Eigen::VectorXd& jointVelocityUpperLimits,

--- a/src/robot/ConcreteManipulator.cpp
+++ b/src/robot/ConcreteManipulator.cpp
@@ -92,7 +92,7 @@ void ConcreteManipulator::step(
 //==============================================================================
 constraint::dart::CollisionFreePtr
 ConcreteManipulator::getSelfCollisionConstraint(
-    const statespace::dart::MetaSkeletonStateSpacePtr& space,
+    const statespace::dart::ConstMetaSkeletonStateSpacePtr& space,
     const dart::dynamics::MetaSkeletonPtr& metaSkeleton) const
 {
   return mRobot->getSelfCollisionConstraint(space, metaSkeleton);
@@ -100,7 +100,7 @@ ConcreteManipulator::getSelfCollisionConstraint(
 
 //==============================================================================
 aikido::constraint::TestablePtr ConcreteManipulator::getFullCollisionConstraint(
-    const statespace::dart::MetaSkeletonStateSpacePtr& space,
+    const statespace::dart::ConstMetaSkeletonStateSpacePtr& space,
     const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
     const constraint::dart::CollisionFreePtr& collisionFree) const
 {

--- a/src/robot/ConcreteRobot.cpp
+++ b/src/robot/ConcreteRobot.cpp
@@ -9,10 +9,12 @@ namespace robot {
 using constraint::dart::CollisionFreePtr;
 using constraint::dart::TSRPtr;
 using constraint::TestablePtr;
+using constraint::ConstTestablePtr;
 using planner::parabolic::ParabolicSmoother;
 using planner::parabolic::ParabolicTimer;
 using statespace::dart::MetaSkeletonStateSpace;
 using statespace::dart::MetaSkeletonStateSpacePtr;
+using statespace::dart::ConstMetaSkeletonStateSpacePtr;
 using statespace::StateSpacePtr;
 using statespace::StateSpace;
 using trajectory::TrajectoryPtr;
@@ -234,7 +236,7 @@ Eigen::VectorXd ConcreteRobot::getAccelerationLimits(
 
 // ==============================================================================
 CollisionFreePtr ConcreteRobot::getSelfCollisionConstraint(
-    const MetaSkeletonStateSpacePtr& space,
+    const ConstMetaSkeletonStateSpacePtr& space,
     const MetaSkeletonPtr& metaSkeleton) const
 {
   using constraint::dart::CollisionFree;
@@ -258,7 +260,7 @@ CollisionFreePtr ConcreteRobot::getSelfCollisionConstraint(
 
 //=============================================================================
 TestablePtr ConcreteRobot::getFullCollisionConstraint(
-    const MetaSkeletonStateSpacePtr& space,
+    const ConstMetaSkeletonStateSpacePtr& space,
     const MetaSkeletonPtr& metaSkeleton,
     const CollisionFreePtr& collisionFree) const
 {
@@ -274,7 +276,7 @@ TestablePtr ConcreteRobot::getFullCollisionConstraint(
     return selfCollisionFree;
 
   // Make testable constraints for collision check
-  std::vector<TestablePtr> constraints;
+  std::vector<ConstTestablePtr> constraints;
   constraints.reserve(2);
   constraints.emplace_back(selfCollisionFree);
   if (collisionFree)

--- a/src/statespace/CartesianProduct.cpp
+++ b/src/statespace/CartesianProduct.cpp
@@ -5,7 +5,7 @@ namespace aikido {
 namespace statespace {
 
 //==============================================================================
-CartesianProduct::CartesianProduct(std::vector<StateSpacePtr> _subspaces)
+CartesianProduct::CartesianProduct(std::vector<ConstStateSpacePtr> _subspaces)
   : mSubspaces(std::move(_subspaces))
   , mOffsets(mSubspaces.size(), 0u)
   , mSizeInBytes(0u)

--- a/src/statespace/dart/MetaSkeletonStateSpace.cpp
+++ b/src/statespace/dart/MetaSkeletonStateSpace.cpp
@@ -17,7 +17,6 @@ using ::dart::dynamics::INVALID_INDEX;
 using JointStateSpacePtr = std::shared_ptr<JointStateSpace>;
 using ConstJointStateSpacePtr = std::shared_ptr<const JointStateSpace>;
 
-
 //==============================================================================
 template <class Input, class Output>
 std::vector<Output> convertVectorType(const std::vector<Input>& input)

--- a/src/statespace/dart/MetaSkeletonStateSpace.cpp
+++ b/src/statespace/dart/MetaSkeletonStateSpace.cpp
@@ -15,6 +15,8 @@ using ::dart::dynamics::MetaSkeleton;
 using ::dart::dynamics::INVALID_INDEX;
 
 using JointStateSpacePtr = std::shared_ptr<JointStateSpace>;
+using ConstJointStateSpacePtr = std::shared_ptr<const JointStateSpace>;
+
 
 //==============================================================================
 template <class Input, class Output>
@@ -42,10 +44,10 @@ T* isJointOfType(const ::dart::dynamics::Joint* joint)
 }
 
 //==============================================================================
-std::vector<std::shared_ptr<JointStateSpace>> createStateSpace(
+std::vector<std::shared_ptr<const JointStateSpace>> createStateSpace(
     const MetaSkeleton& metaskeleton)
 {
-  std::vector<std::shared_ptr<JointStateSpace>> spaces;
+  std::vector<std::shared_ptr<const JointStateSpace>> spaces;
   spaces.reserve(metaskeleton.getNumJoints());
 
   for (std::size_t ijoint = 0; ijoint < metaskeleton.getNumJoints(); ++ijoint)
@@ -246,7 +248,7 @@ bool MetaSkeletonStateSpace::Properties::operator!=(
 //==============================================================================
 MetaSkeletonStateSpace::MetaSkeletonStateSpace(const MetaSkeleton* metaskeleton)
   : CartesianProduct(
-        convertVectorType<JointStateSpacePtr, StateSpacePtr>(
+        convertVectorType<ConstJointStateSpacePtr, ConstStateSpacePtr>(
             createStateSpace(*metaskeleton)))
   , mProperties(MetaSkeletonStateSpace::Properties(metaskeleton))
 {

--- a/tests/constraint/MockConstraints.hpp
+++ b/tests/constraint/MockConstraints.hpp
@@ -34,7 +34,7 @@ public:
     return std::unique_ptr<TestableOutcome>(new DefaultTestableOutcome);
   }
 
-  std::shared_ptr<aikido::statespace::StateSpace> getStateSpace() const override
+  aikido::statespace::ConstStateSpacePtr getStateSpace() const override
   {
     return stateSpace;
   }
@@ -70,7 +70,7 @@ public:
     return std::unique_ptr<TestableOutcome>(new DefaultTestableOutcome);
   }
 
-  std::shared_ptr<aikido::statespace::StateSpace> getStateSpace() const override
+  aikido::statespace::ConstStateSpacePtr getStateSpace() const override
   {
     return stateSpace;
   }

--- a/tests/constraint/MockConstraints.hpp
+++ b/tests/constraint/MockConstraints.hpp
@@ -11,7 +11,7 @@ class PassingConstraint : public aikido::constraint::Testable
 {
 public:
   explicit PassingConstraint(
-      std::shared_ptr<aikido::statespace::StateSpace> stateSpace)
+      std::shared_ptr<const aikido::statespace::StateSpace> stateSpace)
     : stateSpace{stateSpace}
   {
   }
@@ -40,14 +40,14 @@ public:
   }
 
 private:
-  std::shared_ptr<aikido::statespace::StateSpace> stateSpace;
+  std::shared_ptr<const aikido::statespace::StateSpace> stateSpace;
 };
 
 class FailingConstraint : public aikido::constraint::Testable
 {
 public:
   explicit FailingConstraint(
-      std::shared_ptr<aikido::statespace::StateSpace> stateSpace)
+      std::shared_ptr<const aikido::statespace::StateSpace> stateSpace)
     : stateSpace{stateSpace}
   {
   }
@@ -76,7 +76,7 @@ public:
   }
 
 private:
-  std::shared_ptr<aikido::statespace::StateSpace> stateSpace;
+  std::shared_ptr<const aikido::statespace::StateSpace> stateSpace;
 };
 
 #endif // AIKIDO_TESTS_CONSTRAINT_MOCK_CONSTRAINTS_HPP_

--- a/tests/constraint/PolynomialConstraint-impl.hpp
+++ b/tests/constraint/PolynomialConstraint-impl.hpp
@@ -74,7 +74,7 @@ PolynomialConstraint<N>::getConstraintTypes() const
 
 //==============================================================================
 template <int N>
-aikido::statespace::StateSpacePtr PolynomialConstraint<N>::getStateSpace() const
+aikido::statespace::ConstStateSpacePtr PolynomialConstraint<N>::getStateSpace() const
 {
   return mStateSpace;
 }

--- a/tests/constraint/PolynomialConstraint-impl.hpp
+++ b/tests/constraint/PolynomialConstraint-impl.hpp
@@ -74,7 +74,8 @@ PolynomialConstraint<N>::getConstraintTypes() const
 
 //==============================================================================
 template <int N>
-aikido::statespace::ConstStateSpacePtr PolynomialConstraint<N>::getStateSpace() const
+aikido::statespace::ConstStateSpacePtr PolynomialConstraint<N>::getStateSpace()
+    const
 {
   return mStateSpace;
 }

--- a/tests/constraint/PolynomialConstraint.hpp
+++ b/tests/constraint/PolynomialConstraint.hpp
@@ -33,7 +33,7 @@ public:
       const override;
 
   // Documentation inherited.
-  aikido::statespace::StateSpacePtr getStateSpace() const override;
+  aikido::statespace::ConstStateSpacePtr getStateSpace() const override;
 
 private:
   Eigen::VectorXd mCoeffs;

--- a/tests/constraint/test_CartesianProductProjectable.cpp
+++ b/tests/constraint/test_CartesianProductProjectable.cpp
@@ -33,7 +33,7 @@ public:
     projectables.push_back(rvBox2);
 
     cs = std::make_shared<CartesianProduct>(
-        std::vector<aikido::statespace::StateSpacePtr>({rvss1, rvss2}));
+        std::vector<aikido::statespace::ConstStateSpacePtr>({rvss1, rvss2}));
   }
 
   std::shared_ptr<CartesianProduct> cs;

--- a/tests/constraint/test_CartesianProductSampleable.cpp
+++ b/tests/constraint/test_CartesianProductSampleable.cpp
@@ -37,7 +37,7 @@ public:
     sampleables.push_back(so2Sampler);
 
     cs = std::make_shared<CartesianProduct>(
-        std::vector<aikido::statespace::StateSpacePtr>({rvss, so2}));
+        std::vector<aikido::statespace::ConstStateSpacePtr>({rvss, so2}));
   }
 
   std::shared_ptr<CartesianProduct> cs;

--- a/tests/constraint/test_CartesianProductTestable.cpp
+++ b/tests/constraint/test_CartesianProductTestable.cpp
@@ -13,6 +13,7 @@ using aikido::statespace::CartesianProduct;
 using aikido::statespace::SO2;
 using aikido::statespace::R3;
 using aikido::constraint::TestablePtr;
+using aikido::constraint::ConstTestablePtr;
 using aikido::constraint::Testable;
 using aikido::constraint::uniform::R3BoxConstraint;
 
@@ -34,13 +35,13 @@ public:
     testables.push_back(satisfied);
 
     cs = std::make_shared<CartesianProduct>(
-        std::vector<aikido::statespace::StateSpacePtr>({rvss, so2}));
+        std::vector<aikido::statespace::ConstStateSpacePtr>({rvss, so2}));
     ts = std::make_shared<CartesianProductTestable>(cs, testables);
   }
 
   std::shared_ptr<CartesianProduct> cs;
   std::shared_ptr<CartesianProductTestable> ts;
-  std::vector<TestablePtr> testables;
+  std::vector<ConstTestablePtr> testables;
   std::shared_ptr<Satisfied> satisfied;
   std::shared_ptr<R3> rvss;
   std::shared_ptr<SO2> so2;
@@ -54,7 +55,7 @@ TEST_F(CartesianProductTestableTest, ConstructorThrowsOnNullStateSpace)
 
 TEST_F(CartesianProductTestableTest, ConstructorThrowsOnNullTestables)
 {
-  std::vector<TestablePtr> testables;
+  std::vector<ConstTestablePtr> testables;
   testables.push_back(nullptr);
   testables.push_back(nullptr);
 
@@ -66,7 +67,7 @@ TEST_F(
     ConstructorThrowsOnUnmatchingStateSpaceTestablesPair)
 {
   auto space = std::make_shared<CartesianProduct>(
-      std::vector<aikido::statespace::StateSpacePtr>({rvss, so2, rvss}));
+      std::vector<aikido::statespace::ConstStateSpacePtr>({rvss, so2, rvss}));
   EXPECT_THROW(
       CartesianProductTestable(space, testables), std::invalid_argument);
 

--- a/tests/constraint/test_DifferentiableSubspace.cpp
+++ b/tests/constraint/test_DifferentiableSubspace.cpp
@@ -45,7 +45,7 @@ TEST_F(DifferentiableSubspaceTest, ConstructorThrowsOnNullConstraint)
   auto rv = std::make_shared<R3>();
   auto constraint = std::make_shared<Satisfied>(rv);
   auto cs = std::make_shared<CartesianProduct>(
-      std::vector<aikido::statespace::StateSpacePtr>({so2, rv}));
+      std::vector<aikido::statespace::ConstStateSpacePtr>({so2, rv}));
 
   EXPECT_THROW(DifferentiableSubspace(cs, nullptr, 1), std::invalid_argument);
 }
@@ -56,7 +56,7 @@ TEST_F(DifferentiableSubspaceTest, ConstructorThrowsOnInvalidIndex)
   auto rv = std::make_shared<R3>();
   auto constraint = std::make_shared<Satisfied>(rv);
   auto cs = std::make_shared<CartesianProduct>(
-      std::vector<aikido::statespace::StateSpacePtr>({so2, rv}));
+      std::vector<aikido::statespace::ConstStateSpacePtr>({so2, rv}));
 
   EXPECT_THROW(
       DifferentiableSubspace(cs, constraint, 2), std::invalid_argument);
@@ -68,7 +68,7 @@ TEST_F(DifferentiableSubspaceTest, ConstructorThrowsOnMismatchStateSpace)
   auto rv = std::make_shared<R3>();
   auto constraint = std::make_shared<Satisfied>(rv);
   auto cs = std::make_shared<CartesianProduct>(
-      std::vector<aikido::statespace::StateSpacePtr>({so2, rv}));
+      std::vector<aikido::statespace::ConstStateSpacePtr>({so2, rv}));
 
   EXPECT_THROW(
       DifferentiableSubspace(cs, constraint, 0), std::invalid_argument);

--- a/tests/constraint/test_DifferentiableSubspace.cpp
+++ b/tests/constraint/test_DifferentiableSubspace.cpp
@@ -24,7 +24,7 @@ public:
     auto rv = constraint->getStateSpace();
 
     cs = std::make_shared<CartesianProduct>(
-        std::vector<aikido::statespace::StateSpacePtr>({so2, rv}));
+        std::vector<aikido::statespace::ConstStateSpacePtr>({so2, rv}));
     ds = std::make_shared<DifferentiableSubspace>(cs, constraint, 1);
   }
 

--- a/tests/constraint/test_FrameTestable.cpp
+++ b/tests/constraint/test_FrameTestable.cpp
@@ -25,7 +25,7 @@ public:
   {
   }
 
-  aikido::statespace::StateSpacePtr getStateSpace() const override
+  aikido::statespace::ConstStateSpacePtr getStateSpace() const override
   {
     return mStateSpace;
   }

--- a/tests/constraint/test_SE2BoxConstraint.cpp
+++ b/tests/constraint/test_SE2BoxConstraint.cpp
@@ -20,11 +20,19 @@ using Eigen::Matrix2d;
 class SE2BoxConstraintTests : public ::testing::Test
 {
 protected:
+#ifndef NDEBUG
+  static constexpr std::size_t NUM_A_TARGETS{5};
+  static constexpr std::size_t NUM_X_TARGETS{5};
+  static constexpr std::size_t NUM_Y_TARGETS{5};
+  static constexpr std::size_t NUM_SAMPLES{100};
+  static constexpr double DISTANCE_THRESHOLD{0.9};
+#else
   static constexpr std::size_t NUM_A_TARGETS{10};
   static constexpr std::size_t NUM_X_TARGETS{10};
   static constexpr std::size_t NUM_Y_TARGETS{10};
   static constexpr std::size_t NUM_SAMPLES{1000};
   static constexpr double DISTANCE_THRESHOLD{0.8};
+#endif
 
   void SetUp() override
   {
@@ -229,7 +237,7 @@ TEST_F(SE2BoxConstraintTests, createSampleGenerator)
 }
 
 //==============================================================================
-TEST_F(SE2BoxConstraintTests, createSampleGeneratorThrowOnNUllRNG)
+TEST_F(SE2BoxConstraintTests, createSampleGeneratorThrowOnNullRNG)
 {
   // We need to use make_shared here because createSampleGenerator calls
   // shared_from_this, provided by enable_shared_from_this.

--- a/tests/constraint/test_TestableIntersection.cpp
+++ b/tests/constraint/test_TestableIntersection.cpp
@@ -83,8 +83,8 @@ TEST(TestableIntersectionTest, ThrowIfDifferentStateSpacesOnConstruction)
   auto ss2 = std::make_shared<aikido::statespace::SO2>();
   auto ss2C = std::make_shared<const PassingConstraint>(ss2);
   auto avoidMacro = [&]() {
-    TestableIntersection cc{ss1,
-                            std::vector<std::shared_ptr<const Testable>>({ss2C})};
+    TestableIntersection cc{
+        ss1, std::vector<std::shared_ptr<const Testable>>({ss2C})};
     return cc;
   };
   EXPECT_THROW(avoidMacro(), std::invalid_argument);

--- a/tests/constraint/test_TestableIntersection.cpp
+++ b/tests/constraint/test_TestableIntersection.cpp
@@ -12,42 +12,42 @@ using aikido::statespace::R0;
 TEST(ConjuntionConstraintTest, ThrowOnNullStateSpace)
 {
   auto ss = std::make_shared<R0>();
-  auto pc = std::make_shared<PassingConstraint>(ss);
+  auto pc = std::make_shared<const PassingConstraint>(ss);
   EXPECT_THROW(
       TestableIntersection(
-          nullptr, std::vector<std::shared_ptr<Testable>>({pc})),
+          nullptr, std::vector<std::shared_ptr<const Testable>>({pc})),
       std::invalid_argument);
 }
 
 TEST(TestableIntersectionTest, ReturnCorrectStateSpace)
 {
   auto ss = std::make_shared<R0>();
-  auto pc = std::make_shared<PassingConstraint>(ss);
+  auto pc = std::make_shared<const PassingConstraint>(ss);
   TestableIntersection satisfiedConstraint{
-      ss, std::vector<std::shared_ptr<Testable>>({pc, pc})};
+      ss, std::vector<std::shared_ptr<const Testable>>({pc, pc})};
   EXPECT_EQ(ss, satisfiedConstraint.getStateSpace());
 }
 
 TEST(TestableIntersectionTest, IsSatisfiedReturnsConjuctionOfAllConstraints)
 {
   auto ss = std::make_shared<R0>();
-  auto pc = std::make_shared<PassingConstraint>(ss);
-  auto fc = std::make_shared<FailingConstraint>(ss);
+  auto pc = std::make_shared<const PassingConstraint>(ss);
+  auto fc = std::make_shared<const FailingConstraint>(ss);
 
   TestableIntersection satisfiedConstraint{
-      ss, std::vector<std::shared_ptr<Testable>>({pc, pc})};
+      ss, std::vector<std::shared_ptr<const Testable>>({pc, pc})};
   EXPECT_TRUE(satisfiedConstraint.isSatisfied(nullptr));
 
   TestableIntersection unsatisfiedConstraint1{
-      ss, std::vector<std::shared_ptr<Testable>>({pc, fc})};
+      ss, std::vector<std::shared_ptr<const Testable>>({pc, fc})};
   EXPECT_FALSE(unsatisfiedConstraint1.isSatisfied(nullptr));
 
   TestableIntersection unsatisfiedConstraint2{
-      ss, std::vector<std::shared_ptr<Testable>>({fc, pc})};
+      ss, std::vector<std::shared_ptr<const Testable>>({fc, pc})};
   EXPECT_FALSE(unsatisfiedConstraint2.isSatisfied(nullptr));
 
   TestableIntersection unsatisfiedConstraint3{
-      ss, std::vector<std::shared_ptr<Testable>>({fc, fc})};
+      ss, std::vector<std::shared_ptr<const Testable>>({fc, fc})};
   EXPECT_FALSE(unsatisfiedConstraint3.isSatisfied(nullptr));
 }
 
@@ -61,17 +61,17 @@ TEST(TestableIntersectionTest, ReturnsTrueIfNoConstraints)
 TEST(TestableIntersectionTest, AddConstraintAppendsInitialConstraints)
 {
   auto ss = std::make_shared<R0>();
-  auto pc = std::make_shared<PassingConstraint>(ss);
-  auto fc = std::make_shared<FailingConstraint>(ss);
+  auto pc = std::make_shared<const PassingConstraint>(ss);
+  auto fc = std::make_shared<const FailingConstraint>(ss);
   TestableIntersection originallyPassingC{
-      ss, std::vector<std::shared_ptr<Testable>>({pc})};
+      ss, std::vector<std::shared_ptr<const Testable>>({pc})};
   EXPECT_TRUE(originallyPassingC.isSatisfied(nullptr));
 
   originallyPassingC.addConstraint(fc);
   EXPECT_FALSE(originallyPassingC.isSatisfied(nullptr));
 
   TestableIntersection stillFailingC{
-      ss, std::vector<std::shared_ptr<Testable>>({fc})};
+      ss, std::vector<std::shared_ptr<const Testable>>({fc})};
 
   stillFailingC.addConstraint(pc);
   EXPECT_FALSE(stillFailingC.isSatisfied(nullptr));
@@ -81,10 +81,10 @@ TEST(TestableIntersectionTest, ThrowIfDifferentStateSpacesOnConstruction)
 {
   auto ss1 = std::make_shared<R0>();
   auto ss2 = std::make_shared<aikido::statespace::SO2>();
-  auto ss2C = std::make_shared<PassingConstraint>(ss2);
+  auto ss2C = std::make_shared<const PassingConstraint>(ss2);
   auto avoidMacro = [&]() {
     TestableIntersection cc{ss1,
-                            std::vector<std::shared_ptr<Testable>>({ss2C})};
+                            std::vector<std::shared_ptr<const Testable>>({ss2C})};
     return cc;
   };
   EXPECT_THROW(avoidMacro(), std::invalid_argument);

--- a/tests/distance/test_CartesianProductWeighted.cpp
+++ b/tests/distance/test_CartesianProductWeighted.cpp
@@ -24,7 +24,7 @@ TEST(CartesianProductWeightedDistance, ThrowsOnNullMetric)
   auto so2 = std::make_shared<SO2>();
   auto rv3 = std::make_shared<R3>();
   auto so3 = std::make_shared<SO3>();
-  std::vector<std::shared_ptr<StateSpace>> spaces = {so2, rv3, so3};
+  std::vector<std::shared_ptr<const StateSpace>> spaces = {so2, rv3, so3};
 
   auto space = std::make_shared<CartesianProduct>(spaces);
 
@@ -48,7 +48,7 @@ TEST(CartesianProductWeightedDistance, ThrowsOnMissingMetric)
   auto so2 = std::make_shared<SO2>();
   auto rv3 = std::make_shared<R3>();
   auto so3 = std::make_shared<SO3>();
-  std::vector<std::shared_ptr<StateSpace>> spaces = {so2, rv3, so3};
+  std::vector<std::shared_ptr<const StateSpace>> spaces = {so2, rv3, so3};
 
   auto space = std::make_shared<CartesianProduct>(spaces);
 
@@ -70,7 +70,7 @@ TEST(CartesianProductWeightedDistance, ThrowsOnMismatchMetricStatespace)
   auto so2 = std::make_shared<SO2>();
   auto rv3 = std::make_shared<R3>();
   auto so3 = std::make_shared<SO3>();
-  std::vector<std::shared_ptr<StateSpace>> spaces = {so2, rv3, so3};
+  std::vector<std::shared_ptr<const StateSpace>> spaces = {so2, rv3, so3};
 
   auto space = std::make_shared<CartesianProduct>(spaces);
 
@@ -96,7 +96,7 @@ TEST(CartesianProductWeightedDistance, ThrowsOnNegativeWeights)
   auto so2 = std::make_shared<SO2>();
   auto rv3 = std::make_shared<R3>();
   auto so3 = std::make_shared<SO3>();
-  std::vector<std::shared_ptr<StateSpace>> spaces = {so2, rv3, so3};
+  std::vector<std::shared_ptr<const StateSpace>> spaces = {so2, rv3, so3};
 
   auto space = std::make_shared<CartesianProduct>(spaces);
   EXPECT_THROW(
@@ -113,7 +113,7 @@ TEST(CartesianProductWeightedDistance, StateSpaceEquality)
   auto so2 = std::make_shared<SO2>();
   auto rv3 = std::make_shared<R3>();
   auto so3 = std::make_shared<SO3>();
-  std::vector<std::shared_ptr<StateSpace>> spaces = {so2, rv3, so3};
+  std::vector<std::shared_ptr<const StateSpace>> spaces = {so2, rv3, so3};
 
   auto space = std::make_shared<CartesianProduct>(spaces);
 
@@ -137,7 +137,7 @@ TEST(CartesianProductWeightedDistance, DistanceUnitWeights)
   auto so2 = std::make_shared<SO2>();
   auto rv3 = std::make_shared<R3>();
   auto so3 = std::make_shared<SO3>();
-  std::vector<std::shared_ptr<StateSpace>> spaces = {so2, rv3, so3};
+  std::vector<std::shared_ptr<const StateSpace>> spaces = {so2, rv3, so3};
 
   auto space = std::make_shared<CartesianProduct>(spaces);
 
@@ -176,7 +176,7 @@ TEST(CartesianProductWeightedDistance, DistanceCustomWeights)
   auto so2 = std::make_shared<SO2>();
   auto rv3 = std::make_shared<R3>();
   auto so3 = std::make_shared<SO3>();
-  std::vector<std::shared_ptr<StateSpace>> spaces = {so2, rv3, so3};
+  std::vector<std::shared_ptr<const StateSpace>> spaces = {so2, rv3, so3};
 
   auto space = std::make_shared<CartesianProduct>(spaces);
 

--- a/tests/distance/test_DistanceMetricDefaults.cpp
+++ b/tests/distance/test_DistanceMetricDefaults.cpp
@@ -42,9 +42,9 @@ TEST(Defaults, CreateDistanceMetricFor)
   auto so3metric_c = dynamic_cast<SO3Angular*>(so3metric.get());
   EXPECT_TRUE(so3metric_c != nullptr);
 
-  std::vector<StateSpacePtr> spaces({so2, rv3, so3});
+  std::vector<ConstStateSpacePtr> spaces({so2, rv3, so3});
   auto space = std::make_shared<CartesianProduct>(spaces);
-  auto dmetric = createDistanceMetricFor<CartesianProduct>(space);
+  auto dmetric = createDistanceMetricFor<const CartesianProduct>(space);
   auto cmetric = dynamic_cast<CartesianProductWeighted*>(dmetric.get());
   EXPECT_TRUE(cmetric != nullptr);
 }
@@ -66,7 +66,7 @@ TEST(Defaults, CreateDistanceMetric)
   auto so3metric_c = dynamic_cast<SO3Angular*>(so3metric.get());
   EXPECT_TRUE(so3metric_c != nullptr);
 
-  std::vector<StateSpacePtr> spaces({so2, rv3, so3});
+  std::vector<ConstStateSpacePtr> spaces({so2, rv3, so3});
   auto space = std::make_shared<CartesianProduct>(spaces);
   auto dmetric = createDistanceMetric(space);
   auto cmetric = dynamic_cast<CartesianProductWeighted*>(dmetric.get());

--- a/tests/planner/ompl/OMPLTestHelpers.hpp
+++ b/tests/planner/ompl/OMPLTestHelpers.hpp
@@ -47,7 +47,7 @@ dart::dynamics::SkeletonPtr createTranslationalRobot()
 
 void setTranslationalState(
     const Eigen::Vector3d& _value,
-    const aikido::statespace::dart::MetaSkeletonStateSpacePtr& _stateSpace,
+    const aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr& _stateSpace,
     ::ompl::base::State* _state)
 {
   auto st = _state->as<aikido::planner::ompl::GeometricStateSpace::StateType>();
@@ -57,7 +57,7 @@ void setTranslationalState(
 }
 
 Eigen::Vector3d getTranslationalState(
-    const aikido::statespace::dart::MetaSkeletonStateSpacePtr& _stateSpace,
+    const aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr& _stateSpace,
     ::ompl::base::State* _state)
 {
   auto st = _state->as<GeometricStateSpace::StateType>();
@@ -73,7 +73,7 @@ class MockConstrainedSampleGenerator
 
 public:
   MockConstrainedSampleGenerator(
-      aikido::statespace::dart::MetaSkeletonStateSpacePtr _stateSpace,
+      aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr _stateSpace,
       std::unique_ptr<aikido::constraint::SampleGenerator> _generator,
       double _value)
     : mStateSpace(std::move(_stateSpace))
@@ -82,7 +82,7 @@ public:
   {
   }
 
-  aikido::statespace::StateSpacePtr getStateSpace() const override
+  aikido::statespace::ConstStateSpacePtr getStateSpace() const override
   {
     return mStateSpace;
   }
@@ -112,7 +112,7 @@ public:
   }
 
 private:
-  aikido::statespace::dart::MetaSkeletonStateSpacePtr mStateSpace;
+  aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr mStateSpace;
   std::unique_ptr<aikido::constraint::SampleGenerator> mSampleGenerator;
   double mValue;
 };
@@ -124,7 +124,7 @@ class MockProjectionConstraint : public aikido::constraint::Projectable,
 public:
   // Construct a constraint that project to x=_val
   MockProjectionConstraint(
-      aikido::statespace::dart::MetaSkeletonStateSpacePtr _stateSpace,
+      aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr _stateSpace,
       aikido::constraint::SampleablePtr _sampleable,
       double _val)
     : mStateSpace(std::move(_stateSpace))
@@ -134,7 +134,7 @@ public:
   }
 
   // Documentation inherited
-  aikido::statespace::StateSpacePtr getStateSpace() const override
+  aikido::statespace::ConstStateSpacePtr getStateSpace() const override
   {
     return mStateSpace;
   }
@@ -184,7 +184,7 @@ public:
   }
 
 private:
-  aikido::statespace::dart::MetaSkeletonStateSpacePtr mStateSpace;
+  aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr mStateSpace;
   aikido::constraint::SampleablePtr mSampleable;
   double mValue;
 };
@@ -194,7 +194,7 @@ class MockTranslationalRobotConstraint : public aikido::constraint::Testable
 public:
   // Construct the mock constraint
   MockTranslationalRobotConstraint(
-      aikido::statespace::dart::MetaSkeletonStateSpacePtr _stateSpace,
+      aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr _stateSpace,
       const Eigen::Vector3d& _lowerBounds,
       const Eigen::Vector3d& _upperBounds)
     : mStateSpace(std::move(_stateSpace))
@@ -237,13 +237,13 @@ public:
   }
 
   // Documentation inherited
-  std::shared_ptr<aikido::statespace::StateSpace> getStateSpace() const override
+  aikido::statespace::ConstStateSpacePtr getStateSpace() const override
   {
     return mStateSpace;
   }
 
 private:
-  aikido::statespace::dart::MetaSkeletonStateSpacePtr mStateSpace;
+  aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr mStateSpace;
   Eigen::Vector3d mLowerBounds;
   Eigen::Vector3d mUpperBounds;
 };
@@ -251,12 +251,12 @@ private:
 class EmptySampleGenerator : public aikido::constraint::SampleGenerator
 {
 public:
-  explicit EmptySampleGenerator(aikido::statespace::StateSpacePtr sspace)
+  explicit EmptySampleGenerator(aikido::statespace::ConstStateSpacePtr sspace)
     : mStateSpace(sspace)
   {
   }
 
-  aikido::statespace::StateSpacePtr getStateSpace() const override
+  aikido::statespace::ConstStateSpacePtr getStateSpace() const override
   {
     return mStateSpace;
   }
@@ -275,18 +275,18 @@ public:
   }
 
 private:
-  aikido::statespace::StateSpacePtr mStateSpace;
+  aikido::statespace::ConstStateSpacePtr mStateSpace;
 };
 
 class FailedSampleGenerator : public aikido::constraint::SampleGenerator
 {
 public:
-  explicit FailedSampleGenerator(aikido::statespace::StateSpacePtr sspace)
+  explicit FailedSampleGenerator(aikido::statespace::ConstStateSpacePtr sspace)
     : mStateSpace(sspace)
   {
   }
 
-  aikido::statespace::StateSpacePtr getStateSpace() const override
+  aikido::statespace::ConstStateSpacePtr getStateSpace() const override
   {
     return mStateSpace;
   }
@@ -305,7 +305,7 @@ public:
   }
 
 private:
-  aikido::statespace::StateSpacePtr mStateSpace;
+  aikido::statespace::ConstStateSpacePtr mStateSpace;
 };
 
 class PlannerTest : public ::testing::Test
@@ -318,7 +318,7 @@ public:
     // Create robot
     robot = createTranslationalRobot();
 
-    stateSpace = std::make_shared<StateSpace>(robot.get());
+    stateSpace = std::make_shared<const StateSpace>(robot.get());
     interpolator = std::make_shared<aikido::statespace::GeodesicInterpolator>(
         stateSpace);
 
@@ -329,7 +329,7 @@ public:
         Eigen::Vector3d(0.1, 0.1, 0.1));
 
     // Distance metric
-    dmetric = aikido::distance::createDistanceMetric(stateSpace);
+    dmetric = aikido::distance::createDistanceMetricConst(stateSpace);
 
     // Sampler
     sampler
@@ -343,7 +343,7 @@ public:
   }
 
   dart::dynamics::SkeletonPtr robot;
-  aikido::statespace::dart::MetaSkeletonStateSpacePtr stateSpace;
+  aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace;
   aikido::statespace::InterpolatorPtr interpolator;
   aikido::distance::DistanceMetricPtr dmetric;
   aikido::constraint::SampleablePtr sampler;

--- a/tests/planner/ompl/OMPLTestHelpers.hpp
+++ b/tests/planner/ompl/OMPLTestHelpers.hpp
@@ -329,7 +329,7 @@ public:
         Eigen::Vector3d(0.1, 0.1, 0.1));
 
     // Distance metric
-    dmetric = aikido::distance::createDistanceMetricConst(stateSpace);
+    dmetric = aikido::distance::createDistanceMetric(stateSpace);
 
     // Sampler
     sampler

--- a/tests/planner/ompl/test_OMPLPlanner.cpp
+++ b/tests/planner/ompl/test_OMPLPlanner.cpp
@@ -71,7 +71,7 @@ TEST_F(PlannerTest, PlanToGoalRegion)
   aikido::constraint::SampleablePtr goalSampleable
       = std::make_shared<aikido::constraint::CartesianProductSampleable>(
           stateSpace, sConstraints);
-  std::vector<std::shared_ptr<aikido::constraint::Testable>> tConstraints;
+  std::vector<std::shared_ptr<const aikido::constraint::Testable>> tConstraints;
   tConstraints.push_back(boxConstraint);
   aikido::constraint::TestablePtr goalTestable
       = std::make_shared<aikido::constraint::CartesianProductTestable>(
@@ -122,7 +122,7 @@ TEST_F(PlannerTest, PlanConstrainedCRRTConnect)
   aikido::constraint::SampleablePtr goalSampleable
       = std::make_shared<aikido::constraint::CartesianProductSampleable>(
           stateSpace, sConstraints);
-  std::vector<std::shared_ptr<aikido::constraint::Testable>> tConstraints;
+  std::vector<std::shared_ptr<const aikido::constraint::Testable>> tConstraints;
   tConstraints.push_back(boxConstraint);
   aikido::constraint::TestablePtr goalTestable
       = std::make_shared<aikido::constraint::CartesianProductTestable>(
@@ -191,7 +191,7 @@ TEST_F(PlannerTest, PlanConstrainedCRRT)
   aikido::constraint::SampleablePtr goalSampleable
       = std::make_shared<aikido::constraint::CartesianProductSampleable>(
           stateSpace, sConstraints);
-  std::vector<std::shared_ptr<aikido::constraint::Testable>> tConstraints;
+  std::vector<std::shared_ptr<const aikido::constraint::Testable>> tConstraints;
   tConstraints.push_back(boxConstraint);
   aikido::constraint::TestablePtr goalTestable
       = std::make_shared<aikido::constraint::CartesianProductTestable>(

--- a/tests/planner/ompl/test_TrajectoryConversions.cpp
+++ b/tests/planner/ompl/test_TrajectoryConversions.cpp
@@ -13,7 +13,7 @@ using aikido::planner::ompl::getSpaceInformation;
 namespace {
 
 aikido::trajectory::InterpolatedPtr constructTrajectory(
-    aikido::statespace::dart::MetaSkeletonStateSpacePtr _stateSpace,
+    aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr _stateSpace,
     aikido::statespace::InterpolatorPtr _interpolator,
     const Eigen::Vector3d& _startPose,
     const Eigen::Vector3d& _midwayPose,

--- a/tests/planner/parabolic/test_ParabolicSmoother.cpp
+++ b/tests/planner/parabolic/test_ParabolicSmoother.cpp
@@ -140,6 +140,9 @@ protected:
   double mNonStraightLineLength;
   double mNonStraightLineWithNonZeroStartTimeLength;
   double mTimelimit = 60.0;
+  double mBlendRadius = 0.5;
+  int mBlendIterations = 4;
+  double mCheckResolution = 1e-1;
   const double mTolerance = 1e-5;
 };
 
@@ -224,7 +227,8 @@ TEST_F(ParabolicSmootherTests, doShortcut)
       mMaxVelocity,
       mMaxAcceleration,
       mRng,
-      mTimelimit);
+      mTimelimit,
+      mCheckResolution);
 
   // Position.
   auto state = mStateSpace->createState();
@@ -253,15 +257,14 @@ TEST_F(ParabolicSmootherTests, doBlend)
 
   auto splineTrajectory = computeParabolicTiming(
       *mNonStraightLine, mMaxVelocity, mMaxAcceleration);
-  double blendRadius = 0.5;
-  int blendIterations = 100;
   auto smoothedTrajectory = doBlend(
       *splineTrajectory.get(),
       testable,
       mMaxVelocity,
       mMaxAcceleration,
-      blendRadius,
-      blendIterations);
+      mBlendRadius,
+      mBlendIterations,
+      mCheckResolution);
 
   // Position.
   auto state = mStateSpace->createState();
@@ -290,8 +293,6 @@ TEST_F(ParabolicSmootherTests, doShortcutAndBlend)
 
   auto splineTrajectory = computeParabolicTiming(
       *mNonStraightLine, mMaxVelocity, mMaxAcceleration);
-  double blendRadius = 0.5;
-  int blendIterations = 100;
   auto smoothedTrajectory = doShortcutAndBlend(
       *splineTrajectory.get(),
       testable,
@@ -299,8 +300,9 @@ TEST_F(ParabolicSmootherTests, doShortcutAndBlend)
       mMaxAcceleration,
       mRng,
       mTimelimit,
-      blendRadius,
-      blendIterations);
+      mBlendRadius,
+      mBlendIterations,
+      mCheckResolution);
 
   // Position.
   auto state = mStateSpace->createState();

--- a/tests/planner/parabolic/test_ParabolicTimer.cpp
+++ b/tests/planner/parabolic/test_ParabolicTimer.cpp
@@ -15,6 +15,7 @@ using aikido::statespace::CartesianProduct;
 using aikido::statespace::SO2;
 using aikido::statespace::SO3;
 using aikido::statespace::StateSpacePtr;
+using aikido::statespace::ConstStateSpacePtr;
 using aikido::planner::parabolic::computeParabolicTiming;
 using aikido::planner::parabolic::convertToSpline;
 
@@ -337,7 +338,7 @@ TEST_F(ParabolicTimerTests, UnsupportedStateSpace_Throws)
 TEST_F(ParabolicTimerTests, UnsupportedCartesianProduct_Throws)
 {
   auto stateSpace = std::make_shared<CartesianProduct>(
-      std::vector<StateSpacePtr>{std::make_shared<SO3>()});
+      std::vector<ConstStateSpacePtr>{std::make_shared<SO3>()});
   auto state = stateSpace->createState();
 
   std::shared_ptr<GeodesicInterpolator> interpolator
@@ -358,7 +359,7 @@ TEST_F(ParabolicTimerTests, UnsupportedCartesianProduct_Throws)
 TEST_F(ParabolicTimerTests, SupportedCartesianProduct_DoesNotThrow)
 {
   auto stateSpace = std::make_shared<CartesianProduct>(
-      std::vector<StateSpacePtr>{
+      std::vector<ConstStateSpacePtr>{
           std::make_shared<R2>(), std::make_shared<SO2>(),
       });
   auto state = stateSpace->createState();

--- a/tests/planner/parabolic/test_SmoothPostProcessor.cpp
+++ b/tests/planner/parabolic/test_SmoothPostProcessor.cpp
@@ -83,11 +83,11 @@ protected:
   std::shared_ptr<Interpolated> mTrajectory;
 
   double mOriginalTrajectoryLength;
-  double mFeasibilityCheckResolution = 1e-4;
-  double mFeasibilityApproxTolerance = 1e-3;
+  double mTimelimit = 60.0;
   double mBlendRadius = 0.5;
   double mBlendIterations = 100;
-  double mTimelimit = 60.0;
+  double mFeasibilityCheckResolution = 1e-1;
+  double mFeasibilityApproxTolerance = 1e-3;
   const double mTolerance = 1e-5;
 };
 


### PR DESCRIPTION
This PR has `const` changes to support the upcoming VFP refactor onto the new Planner API. https://github.com/personalrobotics/aikido/pull/426 is currently blocking on this PR. Once this PR has been merged, I will rebase https://github.com/personalrobotics/aikido/pull/426, and we can tackle that PR.

Because the new `Problem` derivate classes from the new Planner API (https://github.com/personalrobotics/aikido/pull/314) make most members `const`, this requires shoving a bunch of `const` variables through AIKIDO (we probably don't want to cast the `const`-ness away, since this would break a promise to the user).

These changes are necessary to make `planToEndEffectorOffset` possible with the new Planner API. `planToEndEffectorPose` may require more changes- my plan is to get `planToEndEffectorOffset` refactored first, then tackle `planToEndEffectorPose`.

**Summary of changes**

1) Const all the things.

2) Update old `planToEndEffectorOffset`  with the signature it needs to have in https://github.com/personalrobotics/aikido/pull/426.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
