### PR TITLE
DEMO: Use ScopedState in Problem classes

### DIFF
--- a/include/aikido/planner/ConfigurationToConfiguration.hpp
+++ b/include/aikido/planner/ConfigurationToConfiguration.hpp
@@ -41,10 +41,10 @@ public:
 
 protected:
   /// Start state.
-  const statespace::StateSpace::State* mStartState;
+  statespace::StateSpace::ScopedState mStartState;
 
   /// Goal state.
-  const statespace::StateSpace::State* mGoalState;
+  statespace::StateSpace::ScopedState mGoalState;
 };
 
 } // namespace planner

--- a/include/aikido/planner/dart/ConfigurationToEndEffectorOffset.hpp
+++ b/include/aikido/planner/dart/ConfigurationToEndEffectorOffset.hpp
@@ -63,7 +63,7 @@ protected:
   const ::dart::dynamics::ConstBodyNodePtr mEndEffectorBodyNode;
 
   /// Start state.
-  const statespace::dart::MetaSkeletonStateSpace::State* mStartState;
+  statespace::dart::MetaSkeletonStateSpace::ScopedState mStartState;
 
   /// Direction of motion.
   const Eigen::Vector3d mDirection;

--- a/include/aikido/planner/dart/ConfigurationToTSR.hpp
+++ b/include/aikido/planner/dart/ConfigurationToTSR.hpp
@@ -60,7 +60,7 @@ protected:
   std::size_t mMaxSamples;
 
   /// Start state.
-  const statespace::dart::MetaSkeletonStateSpace::State* mStartState;
+  statespace::dart::MetaSkeletonStateSpace::ScopedState mStartState;
 
   /// Goal TSR.
   const constraint::dart::ConstTSRPtr mGoalTSR;

--- a/src/planner/ConfigurationToConfiguration.cpp
+++ b/src/planner/ConfigurationToConfiguration.cpp
@@ -11,9 +11,9 @@ ConfigurationToConfiguration::ConfigurationToConfiguration(
     const statespace::StateSpace::State* startState,
     const statespace::StateSpace::State* goalState,
     constraint::ConstTestablePtr constraint)
-  : Problem(std::move(stateSpace), std::move(constraint))
-  , mStartState(std::move(startState))
-  , mGoalState(std::move(goalState))
+  : Problem(stateSpace, std::move(constraint))
+  , mStartState(std::move(stateSpace->cloneState(startState)))
+  , mGoalState(std::move(stateSpace->cloneState(goalState)))
 {
   // Do nothing
 }

--- a/src/planner/dart/ConfigurationToConfiguration_to_ConfigurationToTSR.cpp
+++ b/src/planner/dart/ConfigurationToConfiguration_to_ConfigurationToTSR.cpp
@@ -73,14 +73,7 @@ ConfigurationToConfiguration_to_ConfigurationToTSR::plan(
   auto saver = MetaSkeletonStateSaver(mMetaSkeleton);
   DART_UNUSED(saver);
 
-  // Create ConfigurationToConfiguration Problem
   auto goalState = mMetaSkeletonStateSpace->createState();
-  auto delegateProblem = ConfigurationToConfiguration(
-      mMetaSkeletonStateSpace,
-      problem.getStartState(),
-      goalState,
-      problem.getConstraint());
-
   while (generator->canSample())
   {
     // Sample from TSR
@@ -94,6 +87,15 @@ ConfigurationToConfiguration_to_ConfigurationToTSR::plan(
       mMetaSkeletonStateSpace->setState(
           mMetaSkeleton.get(), problem.getStartState());
     }
+
+    // Create ConfigurationToConfiguration Problem.
+    // NOTE: This is done here because the ConfigurationToConfiguration
+    // problem stores a *cloned* scoped state of the passed state.
+    auto delegateProblem = ConfigurationToConfiguration(
+        mMetaSkeletonStateSpace,
+        problem.getStartState(),
+        goalState,
+        problem.getConstraint());
 
     auto traj = mDelegate->plan(delegateProblem, result);
     if (traj)

--- a/src/planner/dart/ConfigurationToEndEffectorOffset.cpp
+++ b/src/planner/dart/ConfigurationToEndEffectorOffset.cpp
@@ -14,9 +14,9 @@ ConfigurationToEndEffectorOffset::ConfigurationToEndEffectorOffset(
     const Eigen::Vector3d& direction,
     const double signedDistance,
     constraint::ConstTestablePtr constraint)
-  : Problem(std::move(stateSpace), std::move(constraint))
+  : Problem(stateSpace, std::move(constraint))
   , mEndEffectorBodyNode(std::move(endEffectorBodyNode))
-  , mStartState(startState)
+  , mStartState(std::move(stateSpace->cloneState(startState)))
   , mDirection(direction.normalized())
   , mDistance(signedDistance)
 {

--- a/src/planner/dart/ConfigurationToTSR.cpp
+++ b/src/planner/dart/ConfigurationToTSR.cpp
@@ -14,10 +14,10 @@ ConfigurationToTSR::ConfigurationToTSR(
     std::size_t maxSamples,
     constraint::dart::ConstTSRPtr goalTSR,
     constraint::ConstTestablePtr constraint)
-  : Problem(std::move(stateSpace), std::move(constraint))
+  : Problem(stateSpace, std::move(constraint))
   , mEndEffectorBodyNode(std::move(endEffectorBodyNode))
   , mMaxSamples(maxSamples)
-  , mStartState(startState)
+  , mStartState(std::move(stateSpace->cloneState(startState)))
   , mGoalTSR(goalTSR)
 {
   // Do nothing


### PR DESCRIPTION
This is a small set of commits from the `sniyaz/new_demo` branch I'd like to have reviewed for merging.

This PR changes the problem classes relevant to the demo to use a `ScopedState` internally, since using raw pointers causes the pointers to dangle once the original pointer goes out of scope.

I've only modified the problems that were relevant to the demo, but if we like I can go and do this for all the problems in the new Planner API.

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [ ] Format code with `make format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
