### PR TITLE
DEMO: Add getTrajectoryPostProcessor method to ConcreteRobot class.

### DIFF
--- a/include/aikido/robot/ConcreteRobot.hpp
+++ b/include/aikido/robot/ConcreteRobot.hpp
@@ -102,12 +102,19 @@ public:
       const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
       const constraint::dart::CollisionFreePtr& collisionFree) const override;
 
-  // Get a TrajectoryPostProcessor that respects velocity and acceleration
-  // limits.
+  // Get a smoothing post postprocessor that respects velocity and acceleration
+  // limits, as well as the passed constraint.
   /// \param[in] metaSkeleton The MetaSkeleton whose limits must be respected.
   std::shared_ptr<aikido::planner::TrajectoryPostProcessor>
   getTrajectoryPostProcessor(
-      const dart::dynamics::MetaSkeletonPtr& metaSkeleton) const;
+      const statespace::dart::ConstMetaSkeletonStateSpacePtr& stateSpace,
+      const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
+      const constraint::dart::CollisionFreePtr& collisionFree,
+      bool enableShortcut,
+      bool enableBlend,
+      double shortcutTimelimit,
+      double blendRadius,
+      int blendIterations) const;
 
   /// TODO: Replace this with Problem interface.
   /// Plan the robot to a specific configuration. Restores the robot to its

--- a/include/aikido/robot/ConcreteRobot.hpp
+++ b/include/aikido/robot/ConcreteRobot.hpp
@@ -114,7 +114,9 @@ public:
       bool enableBlend,
       double shortcutTimelimit,
       double blendRadius,
-      int blendIterations) const;
+      int blendIterations,
+      double feasibilityCheckResolution,
+      double feasibilityApproxTolerance) const;
 
   /// TODO: Replace this with Problem interface.
   /// Plan the robot to a specific configuration. Restores the robot to its

--- a/include/aikido/robot/ConcreteRobot.hpp
+++ b/include/aikido/robot/ConcreteRobot.hpp
@@ -102,6 +102,13 @@ public:
       const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
       const constraint::dart::CollisionFreePtr& collisionFree) const override;
 
+  // Get a TrajectoryPostProcessor that respects velocity and acceleration
+  // limits.
+  /// \param[in] metaSkeleton The MetaSkeleton whose limits must be respected.
+  std::shared_ptr<aikido::planner::TrajectoryPostProcessor>
+  getTrajectoryPostProcessor(
+      const dart::dynamics::MetaSkeletonPtr& metaSkeleton) const;
+
   /// TODO: Replace this with Problem interface.
   /// Plan the robot to a specific configuration. Restores the robot to its
   /// initial configuration after planning.

--- a/src/robot/ConcreteRobot.cpp
+++ b/src/robot/ConcreteRobot.cpp
@@ -10,6 +10,7 @@ using constraint::dart::CollisionFreePtr;
 using constraint::dart::TSRPtr;
 using constraint::TestablePtr;
 using constraint::ConstTestablePtr;
+using planner::TrajectoryPostProcessor;
 using planner::parabolic::ParabolicSmoother;
 using planner::parabolic::ParabolicTimer;
 using statespace::dart::MetaSkeletonStateSpace;
@@ -289,6 +290,18 @@ TestablePtr ConcreteRobot::getFullCollisionConstraint(
   }
 
   return std::make_shared<TestableIntersection>(space, constraints);
+}
+
+//==============================================================================
+std::shared_ptr<TrajectoryPostProcessor>
+ConcreteRobot::getTrajectoryPostProcessor(
+    const dart::dynamics::MetaSkeletonPtr& metaSkeleton) const
+{
+  Eigen::VectorXd velocityLimits = getVelocityLimits(*metaSkeleton);
+  Eigen::VectorXd accelerationLimits = getAccelerationLimits(*metaSkeleton);
+
+  return std::make_shared<ParabolicSmoother>(
+      velocityLimits, accelerationLimits);
 }
 
 //==============================================================================

--- a/src/robot/ConcreteRobot.cpp
+++ b/src/robot/ConcreteRobot.cpp
@@ -302,7 +302,9 @@ ConcreteRobot::getTrajectoryPostProcessor(
     bool enableBlend,
     double shortcutTimelimit,
     double blendRadius,
-    int blendIterations) const
+    int blendIterations,
+    double feasibilityCheckResolution,
+    double feasibilityApproxTolerance) const
 {
   auto collisionConstraint
       = getFullCollisionConstraint(stateSpace, metaSkeleton, collisionFree);
@@ -317,7 +319,9 @@ ConcreteRobot::getTrajectoryPostProcessor(
       enableBlend,
       shortcutTimelimit,
       blendRadius,
-      blendIterations);
+      blendIterations,
+      feasibilityCheckResolution,
+      feasibilityApproxTolerance);
 }
 
 //==============================================================================

--- a/src/robot/ConcreteRobot.cpp
+++ b/src/robot/ConcreteRobot.cpp
@@ -295,13 +295,29 @@ TestablePtr ConcreteRobot::getFullCollisionConstraint(
 //==============================================================================
 std::shared_ptr<TrajectoryPostProcessor>
 ConcreteRobot::getTrajectoryPostProcessor(
-    const dart::dynamics::MetaSkeletonPtr& metaSkeleton) const
+    const ConstMetaSkeletonStateSpacePtr& stateSpace,
+    const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
+    const constraint::dart::CollisionFreePtr& collisionFree,
+    bool enableShortcut,
+    bool enableBlend,
+    double shortcutTimelimit,
+    double blendRadius,
+    int blendIterations) const
 {
+  auto collisionConstraint
+      = getFullCollisionConstraint(stateSpace, metaSkeleton, collisionFree);
+
   Eigen::VectorXd velocityLimits = getVelocityLimits(*metaSkeleton);
   Eigen::VectorXd accelerationLimits = getAccelerationLimits(*metaSkeleton);
 
   return std::make_shared<ParabolicSmoother>(
-      velocityLimits, accelerationLimits);
+      velocityLimits,
+      accelerationLimits,
+      enableShortcut,
+      enableBlend,
+      shortcutTimelimit,
+      blendRadius,
+      blendIterations);
 }
 
 //==============================================================================


### PR DESCRIPTION
This is a small set of commits from the `sniyaz/new_demo` branch I'd like to have reviewed for merging.

See title. This is needed for restoring MAGI actions to libherb. Previously a function like this existed in the HERB class in libherb, but it was removed after the refactor that based things on the new robot class. I've added a function in my libherb PR that wraps this function.

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [ ] Format code with `make format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
