### PR TITLE
Fix compilation errors with Eigen 3.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 
   * Fixed Eigen memory alignment issues on 32bit Ubuntu: [#368](https://github.com/personalrobotics/aikido/pull/368)
   * Defined optional dependencies: [#376](https://github.com/personalrobotics/aikido/pull/376)
+  * Fixed compilation bug with Eigen 3.3.5: [#452](https://github.com/personalrobotics/aikido/pull/452)
 
 ### 0.2.0 (2018-01-09)
 

--- a/include/aikido/common/detail/Spline-impl.hpp
+++ b/include/aikido/common/detail/Spline-impl.hpp
@@ -403,7 +403,11 @@ auto SplineProblem<Scalar, Index, _NumCoefficients, _NumOutputs, _NumKnots>::
   for (Index ioutput = 0; ioutput < mNumOutputs; ++ioutput)
   {
     // Solve for the spline coefficients for each output dimension.
-    Eigen::Matrix<Scalar, DimensionAtCompileTime, 1> solutionVector
+    //
+    // TODO: As of Eigen 3.3.5, the output type of SparseQR::solve() is not
+    // assignable to a fixed size vector, so we use Eigen::Dynamic here instead
+    // of DimensionAtCompileTime.
+    Eigen::Matrix<Scalar, Eigen::Dynamic, 1> solutionVector
         = solver.solve(mB.col(ioutput));
 
     // Split the coefficients by segment.


### PR DESCRIPTION
Resolves #451. I've tested this locally with both 3.3.4 and 3.3.5.

We should probably try to figure out how to take advantage of knowing the correct fixed-size output vector, but maybe this isn't possible.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change