### PR TITLE
Add B-spline trajectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
 
   * Added integrated PoseEstimatorModule: [#336](https://github.com/personalrobotics/aikido/pull/336)
 
+* Trajectory
+
+  * Added B-spline trajectory: [#453](https://github.com/personalrobotics/aikido/pull/453)
+
 * Planner
 
   * Make all DART planners take MetaSkeleton, and add adapter for turning planners into DART planners: [#437](https://github.com/personalrobotics/aikido/pull/437)

--- a/include/aikido/common/BSpline.hpp
+++ b/include/aikido/common/BSpline.hpp
@@ -1,0 +1,624 @@
+// This file is part of Eigen, a lightweight C++ template library
+// for linear algebra.
+//
+// Copyright (C) 20010-2011 Hauke Heibel <hauke.heibel@gmail.com>
+//
+// This Source Code Form is subject to the terms of the Mozilla
+// Public License v. 2.0. If a copy of the MPL was not distributed
+// with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// The AIKIDO development team has extended this class as follows:
+// - Enable to modify control points even after construction
+
+#ifndef AIKIDO_COMMON_BSPLINE_HPP_
+#define AIKIDO_COMMON_BSPLINE_HPP_
+
+#include "aikido/common/SplineFwd.hpp"
+
+namespace aikido {
+namespace common {
+
+/**
+ * \ingroup Splines_Module
+ * \class Spline
+ * \brief A class representing multi-dimensional spline curves.
+ *
+ * The class represents B-splines with non-uniform knot vectors. Each control
+ * point of the B-spline is associated with a basis function
+ * \f{align*}
+ *   C(u) & = \sum_{i=0}^{n}N_{i,p}(u)P_i
+ * \f}
+ *
+ * \tparam _Scalar The underlying data type (typically float or double)
+ * \tparam _Dim The curve dimension (e.g. 2 or 3)
+ * \tparam _Degree Per default set to Dynamic; could be set to the actual
+ * desired degree for optimization purposes (would result in stack *allocation
+ * of several temporary variables).
+ **/
+template <typename _Scalar, int _Dim, int _Degree>
+class BSpline
+{
+public:
+  typedef _Scalar Scalar; /*!< The spline curve's scalar type. */
+  enum
+  {
+    Dimension = _Dim /*!< The spline curve's dimension. */
+  };
+  enum
+  {
+    Degree = _Degree /*!< The spline curve's degree. */
+  };
+
+  /** \brief The point type the spline is representing. */
+  typedef typename SplineTraits<BSpline>::PointType PointType;
+
+  /** \brief The data type used to store knot vectors. */
+  typedef typename SplineTraits<BSpline>::KnotVectorType KnotVectorType;
+
+  /** \brief The data type used to store parameter vectors. */
+  typedef
+      typename SplineTraits<BSpline>::ParameterVectorType ParameterVectorType;
+
+  /** \brief The data type used to store non-zero basis functions. */
+  typedef typename SplineTraits<BSpline>::BasisVectorType BasisVectorType;
+
+  /** \brief The data type used to store the values of the basis function
+   * derivatives. */
+  typedef
+      typename SplineTraits<BSpline>::BasisDerivativeType BasisDerivativeType;
+
+  /** \brief The data type representing the spline's control points. */
+  typedef typename SplineTraits<BSpline>::ControlPointVectorType
+      ControlPointVectorType;
+
+  /**
+  * \brief Creates a (constant) zero spline.
+  * For Splines with dynamic degree, the resulting degree will be 0.
+  **/
+  BSpline()
+    : m_knots(1, (Degree == Eigen::Dynamic ? 2 : 2 * Degree + 2))
+    , m_ctrls(
+          ControlPointVectorType::Zero(
+              Dimension, (Degree == Eigen::Dynamic ? 1 : Degree + 1)))
+  {
+    // in theory this code can go to the initializer list but it will get pretty
+    // much unreadable ...
+    enum
+    {
+      MinDegree = (Degree == Eigen::Dynamic ? 0 : Degree)
+    };
+    m_knots.template segment<MinDegree + 1>(0)
+        = Eigen::Array<Scalar, 1, MinDegree + 1>::Zero();
+    m_knots.template segment<MinDegree + 1>(MinDegree + 1)
+        = Eigen::Array<Scalar, 1, MinDegree + 1>::Ones();
+  }
+
+  /**
+  * \brief Creates a spline from a knot vector and control points.
+  * \param knots The spline's knot vector.
+  * \param ctrls The spline's control point vector.
+  **/
+  template <typename OtherVectorType, typename OtherArrayType>
+  BSpline(const OtherVectorType& knots, const OtherArrayType& ctrls)
+    : m_knots(knots), m_ctrls(ctrls)
+  {
+  }
+
+  /**
+  * \brief Copy constructor for splines.
+  * \param spline The input spline.
+  **/
+  template <int OtherDegree>
+  BSpline(const BSpline<Scalar, Dimension, OtherDegree>& spline)
+    : m_knots(spline.knots()), m_ctrls(spline.ctrls())
+  {
+  }
+
+  /**
+   * \brief Returns the knots of the underlying spline.
+   **/
+  const KnotVectorType& knots() const
+  {
+    return m_knots;
+  }
+
+  /**
+   * \brief Returns the ctrls of the underlying spline.
+   **/
+  ControlPointVectorType& ctrls()
+  {
+    return m_ctrls;
+  }
+  // Note: Added by AIKIDO to be able to change the control points.
+
+  /**
+   * \brief Returns the ctrls of the underlying spline.
+   **/
+  const ControlPointVectorType& ctrls() const
+  {
+    return m_ctrls;
+  }
+
+  /**
+   * \brief Returns the spline value at a given site \f$u\f$.
+   *
+   * The function returns
+   * \f{align*}
+   *   C(u) & = \sum_{i=0}^{n}N_{i,p}P_i
+   * \f}
+   *
+   * \param u Parameter \f$u \in [0;1]\f$ at which the spline is evaluated.
+   * \return The spline value at the given location \f$u\f$.
+   **/
+  PointType operator()(Scalar u) const;
+
+  /**
+   * \brief Evaluation of spline derivatives of up-to given order.
+   *
+   * The function returns
+   * \f{align*}
+   *   \frac{d^i}{du^i}C(u) & = \sum_{i=0}^{n} \frac{d^i}{du^i} N_{i,p}(u)P_i
+   * \f}
+   * for i ranging between 0 and order.
+   *
+   * \param u Parameter \f$u \in [0;1]\f$ at which the spline derivative is
+   *evaluated.
+   * \param order The order up to which the derivatives are computed.
+   **/
+  typename SplineTraits<BSpline>::DerivativeType derivatives(
+      Scalar u, Eigen::DenseIndex order) const;
+
+  /**
+   * \copydoc Spline::derivatives
+   * Using the template version of this function is more efficieent since
+   * temporary objects are allocated on the stack whenever this is possible.
+   **/
+  template <int DerivativeOrder>
+  typename SplineTraits<BSpline, DerivativeOrder>::DerivativeType derivatives(
+      Scalar u, Eigen::DenseIndex order = DerivativeOrder) const;
+
+  /**
+   * \brief Computes the non-zero basis functions at the given site.
+   *
+   * Splines have local support and a point from their image is defined
+   * by exactly \f$p+1\f$ control points \f$P_i\f$ where \f$p\f$ is the
+   * spline degree.
+   *
+   * This function computes the \f$p+1\f$ non-zero basis function values
+   * for a given parameter value \f$u\f$. It returns
+   * \f{align*}{
+   *   N_{i,p}(u), \hdots, N_{i+p+1,p}(u)
+   * \f}
+   *
+   * \param u Parameter \f$u \in [0;1]\f$ at which the non-zero basis functions
+   *          are computed.
+   **/
+  typename SplineTraits<BSpline>::BasisVectorType basisFunctions(
+      Scalar u) const;
+
+  /**
+   * \brief Computes the non-zero spline basis function derivatives up to given
+   *order.
+   *
+   * The function computes
+   * \f{align*}{
+   *   \frac{d^i}{du^i} N_{i,p}(u), \hdots, \frac{d^i}{du^i} N_{i+p+1,p}(u)
+   * \f}
+   * with i ranging from 0 up to the specified order.
+   *
+   * \param u Parameter \f$u \in [0;1]\f$ at which the non-zero basis function
+   *          derivatives are computed.
+   * \param order The order up to which the basis function derivatives are
+   *computes.
+   **/
+  typename SplineTraits<BSpline>::BasisDerivativeType basisFunctionDerivatives(
+      Scalar u, Eigen::DenseIndex order) const;
+
+  /**
+   * \copydoc Spline::basisFunctionDerivatives
+   * Using the template version of this function is more efficieent since
+   * temporary objects are allocated on the stack whenever this is possible.
+   **/
+  template <int DerivativeOrder>
+  typename SplineTraits<BSpline, DerivativeOrder>::BasisDerivativeType
+  basisFunctionDerivatives(
+      Scalar u, Eigen::DenseIndex order = DerivativeOrder) const;
+
+  /**
+   * \brief Returns the spline degree.
+   **/
+  Eigen::DenseIndex degree() const;
+
+  /**
+   * \brief Returns the span within the knot vector in which u is falling.
+   * \param u The site for which the span is determined.
+   **/
+  Eigen::DenseIndex span(Scalar u) const;
+
+  /**
+   * \brief Computes the spang within the provided knot vector in which u is
+   *falling.
+   **/
+  static Eigen::DenseIndex Span(
+      typename SplineTraits<BSpline>::Scalar u,
+      Eigen::DenseIndex degree,
+      const typename SplineTraits<BSpline>::KnotVectorType& knots);
+
+  /**
+   * \brief Returns the spline's non-zero basis functions.
+   *
+   * The function computes and returns
+   * \f{align*}{
+   *   N_{i,p}(u), \hdots, N_{i+p+1,p}(u)
+   * \f}
+   *
+   * \param u The site at which the basis functions are computed.
+   * \param degree The degree of the underlying spline.
+   * \param knots The underlying spline's knot vector.
+   **/
+  static BasisVectorType BasisFunctions(
+      Scalar u, Eigen::DenseIndex degree, const KnotVectorType& knots);
+
+  /**
+   * \copydoc Spline::basisFunctionDerivatives
+   * \param degree The degree of the underlying spline
+   * \param knots The underlying spline's knot vector.
+   **/
+  static BasisDerivativeType BasisFunctionDerivatives(
+      const Scalar u,
+      const Eigen::DenseIndex order,
+      const Eigen::DenseIndex degree,
+      const KnotVectorType& knots);
+
+private:
+  KnotVectorType m_knots;         /*!< Knot vector. */
+  ControlPointVectorType m_ctrls; /*!< Control points. */
+
+  template <typename DerivativeType>
+  static void BasisFunctionDerivativesImpl(
+      const typename BSpline<_Scalar, _Dim, _Degree>::Scalar u,
+      const Eigen::DenseIndex order,
+      const Eigen::DenseIndex p,
+      const typename BSpline<_Scalar, _Dim, _Degree>::KnotVectorType& U,
+      DerivativeType& N_);
+};
+
+template <typename _Scalar, int _Dim, int _Degree>
+Eigen::DenseIndex BSpline<_Scalar, _Dim, _Degree>::Span(
+    typename SplineTraits<BSpline<_Scalar, _Dim, _Degree> >::Scalar u,
+    Eigen::DenseIndex degree,
+    const typename SplineTraits<BSpline<_Scalar, _Dim, _Degree> >::
+        KnotVectorType& knots)
+{
+  // Piegl & Tiller, "The NURBS Book", A2.1 (p. 68)
+  if (u <= knots(0))
+    return degree;
+  const Scalar* pos = std::upper_bound(
+      knots.data() + degree - 1, knots.data() + knots.size() - degree - 1, u);
+  return static_cast<Eigen::DenseIndex>(std::distance(knots.data(), pos) - 1);
+}
+
+template <typename _Scalar, int _Dim, int _Degree>
+typename BSpline<_Scalar, _Dim, _Degree>::BasisVectorType
+BSpline<_Scalar, _Dim, _Degree>::BasisFunctions(
+    typename BSpline<_Scalar, _Dim, _Degree>::Scalar u,
+    Eigen::DenseIndex degree,
+    const typename BSpline<_Scalar, _Dim, _Degree>::KnotVectorType& knots)
+{
+  typedef
+      typename BSpline<_Scalar, _Dim, _Degree>::BasisVectorType BasisVectorType;
+
+  const Eigen::DenseIndex p = degree;
+  const Eigen::DenseIndex i = BSpline::Span(u, degree, knots);
+
+  const KnotVectorType& U = knots;
+
+  BasisVectorType left(p + 1);
+  left(0) = Scalar(0);
+  BasisVectorType right(p + 1);
+  right(0) = Scalar(0);
+
+  Eigen::VectorBlock<BasisVectorType, Degree>(left, 1, p)
+      = u
+        - Eigen::VectorBlock<const KnotVectorType, Degree>(U, i + 1 - p, p)
+              .reverse();
+  Eigen::VectorBlock<BasisVectorType, Degree>(right, 1, p)
+      = Eigen::VectorBlock<const KnotVectorType, Degree>(U, i + 1, p) - u;
+
+  BasisVectorType N(1, p + 1);
+  N(0) = Scalar(1);
+  for (Eigen::DenseIndex j = 1; j <= p; ++j)
+  {
+    Scalar saved = Scalar(0);
+    for (Eigen::DenseIndex r = 0; r < j; r++)
+    {
+      const Scalar tmp = N(r) / (right(r + 1) + left(j - r));
+      N[r] = saved + right(r + 1) * tmp;
+      saved = left(j - r) * tmp;
+    }
+    N(j) = saved;
+  }
+  return N;
+}
+
+template <typename _Scalar, int _Dim, int _Degree>
+Eigen::DenseIndex BSpline<_Scalar, _Dim, _Degree>::degree() const
+{
+  if (_Degree == Eigen::Dynamic)
+    return m_knots.size() - m_ctrls.cols() - 1;
+  else
+    return _Degree;
+}
+
+template <typename _Scalar, int _Dim, int _Degree>
+Eigen::DenseIndex BSpline<_Scalar, _Dim, _Degree>::span(Scalar u) const
+{
+  return BSpline::Span(u, degree(), knots());
+}
+
+template <typename _Scalar, int _Dim, int _Degree>
+typename BSpline<_Scalar, _Dim, _Degree>::PointType
+BSpline<_Scalar, _Dim, _Degree>::operator()(Scalar u) const
+{
+  enum
+  {
+    Order = SplineTraits<BSpline>::OrderAtCompileTime
+  };
+
+  const Eigen::DenseIndex span = this->span(u);
+  const Eigen::DenseIndex p = degree();
+  const BasisVectorType basis_funcs = basisFunctions(u);
+
+  const Eigen::Replicate<BasisVectorType, Dimension, 1> ctrl_weights(
+      basis_funcs);
+  const Eigen::Block<const ControlPointVectorType, Dimension, Order> ctrl_pts(
+      ctrls(), 0, span - p, Dimension, p + 1);
+  return (ctrl_weights * ctrl_pts).rowwise().sum();
+}
+
+/* ---------------------------------------------------------------------------------------------
+ */
+
+template <typename SplineType, typename DerivativeType>
+void derivativesImpl(
+    const SplineType& spline,
+    typename SplineType::Scalar u,
+    Eigen::DenseIndex order,
+    DerivativeType& der)
+{
+  enum
+  {
+    Dimension = SplineTraits<SplineType>::Dimension
+  };
+  enum
+  {
+    Order = SplineTraits<SplineType>::OrderAtCompileTime
+  };
+  enum
+  {
+    DerivativeOrder = DerivativeType::ColsAtCompileTime
+  };
+
+  typedef typename SplineTraits<SplineType>::ControlPointVectorType
+      ControlPointVectorType;
+  typedef
+      typename SplineTraits<SplineType, DerivativeOrder>::BasisDerivativeType
+          BasisDerivativeType;
+  typedef typename BasisDerivativeType::ConstRowXpr BasisDerivativeRowXpr;
+
+  const Eigen::DenseIndex p = spline.degree();
+  const Eigen::DenseIndex span = spline.span(u);
+
+  const Eigen::DenseIndex n = (std::min)(p, order);
+
+  der.resize(Dimension, n + 1);
+
+  // Retrieve the basis function derivatives up to the desired order...
+  const BasisDerivativeType basis_func_ders
+      = spline.template basisFunctionDerivatives<DerivativeOrder>(u, n + 1);
+
+  // ... and perform the linear combinations of the control points.
+  for (Eigen::DenseIndex der_order = 0; der_order < n + 1; ++der_order)
+  {
+    const Eigen::Replicate<BasisDerivativeRowXpr, Dimension, 1> ctrl_weights(
+        basis_func_ders.row(der_order));
+    const Eigen::Block<const ControlPointVectorType, Dimension, Order> ctrl_pts(
+        spline.ctrls(), 0, span - p, Dimension, p + 1);
+    der.col(der_order) = (ctrl_weights * ctrl_pts).rowwise().sum();
+  }
+}
+
+template <typename _Scalar, int _Dim, int _Degree>
+typename SplineTraits<BSpline<_Scalar, _Dim, _Degree> >::DerivativeType
+BSpline<_Scalar, _Dim, _Degree>::derivatives(
+    Scalar u, Eigen::DenseIndex order) const
+{
+  typename SplineTraits<BSpline>::DerivativeType res;
+  derivativesImpl(*this, u, order, res);
+  return res;
+}
+
+template <typename _Scalar, int _Dim, int _Degree>
+template <int DerivativeOrder>
+typename SplineTraits<BSpline<_Scalar, _Dim, _Degree>,
+                      DerivativeOrder>::DerivativeType
+BSpline<_Scalar, _Dim, _Degree>::derivatives(
+    Scalar u, Eigen::DenseIndex order) const
+{
+  typename SplineTraits<BSpline, DerivativeOrder>::DerivativeType res;
+  derivativesImpl(*this, u, order, res);
+  return res;
+}
+
+template <typename _Scalar, int _Dim, int _Degree>
+typename SplineTraits<BSpline<_Scalar, _Dim, _Degree> >::BasisVectorType
+BSpline<_Scalar, _Dim, _Degree>::basisFunctions(Scalar u) const
+{
+  return BSpline::BasisFunctions(u, degree(), knots());
+}
+
+/* ---------------------------------------------------------------------------------------------
+ */
+
+template <typename _Scalar, int _Dim, int _Degree>
+template <typename DerivativeType>
+void BSpline<_Scalar, _Dim, _Degree>::BasisFunctionDerivativesImpl(
+    const typename BSpline<_Scalar, _Dim, _Degree>::Scalar u,
+    const Eigen::DenseIndex order,
+    const Eigen::DenseIndex p,
+    const typename BSpline<_Scalar, _Dim, _Degree>::KnotVectorType& U,
+    DerivativeType& N_)
+{
+  typedef BSpline<_Scalar, _Dim, _Degree> SplineType;
+  enum
+  {
+    Order = SplineTraits<SplineType>::OrderAtCompileTime
+  };
+
+  typedef typename SplineTraits<SplineType>::Scalar Scalar;
+  typedef typename SplineTraits<SplineType>::BasisVectorType BasisVectorType;
+
+  const Eigen::DenseIndex span = SplineType::Span(u, p, U);
+
+  const Eigen::DenseIndex n = (std::min)(p, order);
+
+  N_.resize(n + 1, p + 1);
+
+  BasisVectorType left = BasisVectorType::Zero(p + 1);
+  BasisVectorType right = BasisVectorType::Zero(p + 1);
+
+  Eigen::Matrix<Scalar, Order, Order> ndu(p + 1, p + 1);
+
+  Scalar saved, temp; // FIXME These were double instead of Scalar. Was there a
+                      // reason for that?
+
+  ndu(0, 0) = 1.0;
+
+  Eigen::DenseIndex j;
+  for (j = 1; j <= p; ++j)
+  {
+    left[j] = u - U[span + 1 - j];
+    right[j] = U[span + j] - u;
+    saved = 0.0;
+
+    for (Eigen::DenseIndex r = 0; r < j; ++r)
+    {
+      /* Lower triangle */
+      ndu(j, r) = right[r + 1] + left[j - r];
+      temp = ndu(r, j - 1) / ndu(j, r);
+      /* Upper triangle */
+      ndu(r, j) = static_cast<Scalar>(saved + right[r + 1] * temp);
+      saved = left[j - r] * temp;
+    }
+
+    ndu(j, j) = static_cast<Scalar>(saved);
+  }
+
+  for (j = p; j >= 0; --j)
+    N_(0, j) = ndu(j, p);
+
+  // Compute the derivatives
+  DerivativeType a(n + 1, p + 1);
+  Eigen::DenseIndex r = 0;
+  for (; r <= p; ++r)
+  {
+    Eigen::DenseIndex s1, s2;
+    s1 = 0;
+    s2 = 1; // alternate rows in array a
+    a(0, 0) = 1.0;
+
+    // Compute the k-th derivative
+    for (Eigen::DenseIndex k = 1; k <= static_cast<Eigen::DenseIndex>(n); ++k)
+    {
+      Scalar d = 0.0;
+      Eigen::DenseIndex rk, pk, j1, j2;
+      rk = r - k;
+      pk = p - k;
+
+      if (r >= k)
+      {
+        a(s2, 0) = a(s1, 0) / ndu(pk + 1, rk);
+        d = a(s2, 0) * ndu(rk, pk);
+      }
+
+      if (rk >= -1)
+        j1 = 1;
+      else
+        j1 = -rk;
+
+      if (r - 1 <= pk)
+        j2 = k - 1;
+      else
+        j2 = p - r;
+
+      for (j = j1; j <= j2; ++j)
+      {
+        a(s2, j) = (a(s1, j) - a(s1, j - 1)) / ndu(pk + 1, rk + j);
+        d += a(s2, j) * ndu(rk + j, pk);
+      }
+
+      if (r <= pk)
+      {
+        a(s2, k) = -a(s1, k - 1) / ndu(pk + 1, r);
+        d += a(s2, k) * ndu(r, pk);
+      }
+
+      N_(k, r) = static_cast<Scalar>(d);
+      j = s1;
+      s1 = s2;
+      s2 = j; // Switch rows
+    }
+  }
+
+  /* Multiply through by the correct factors */
+  /* (Eq. [2.9])                             */
+  r = p;
+  for (Eigen::DenseIndex k = 1; k <= static_cast<Eigen::DenseIndex>(n); ++k)
+  {
+    for (j = p; j >= 0; --j)
+      N_(k, j) *= r;
+    r *= p - k;
+  }
+}
+
+template <typename _Scalar, int _Dim, int _Degree>
+typename SplineTraits<BSpline<_Scalar, _Dim, _Degree> >::BasisDerivativeType
+BSpline<_Scalar, _Dim, _Degree>::basisFunctionDerivatives(
+    Scalar u, Eigen::DenseIndex order) const
+{
+  typename SplineTraits<BSpline<_Scalar, _Dim, _Degree> >::BasisDerivativeType
+      der;
+  BasisFunctionDerivativesImpl(u, order, degree(), knots(), der);
+  return der;
+}
+
+template <typename _Scalar, int _Dim, int _Degree>
+template <int DerivativeOrder>
+typename SplineTraits<BSpline<_Scalar, _Dim, _Degree>,
+                      DerivativeOrder>::BasisDerivativeType
+BSpline<_Scalar, _Dim, _Degree>::basisFunctionDerivatives(
+    Scalar u, Eigen::DenseIndex order) const
+{
+  typename SplineTraits<BSpline<_Scalar, _Dim, _Degree>,
+                        DerivativeOrder>::BasisDerivativeType der;
+  BasisFunctionDerivativesImpl(u, order, degree(), knots(), der);
+  return der;
+}
+
+template <typename _Scalar, int _Dim, int _Degree>
+typename SplineTraits<BSpline<_Scalar, _Dim, _Degree> >::BasisDerivativeType
+BSpline<_Scalar, _Dim, _Degree>::BasisFunctionDerivatives(
+    const typename BSpline<_Scalar, _Dim, _Degree>::Scalar u,
+    const Eigen::DenseIndex order,
+    const Eigen::DenseIndex degree,
+    const typename BSpline<_Scalar, _Dim, _Degree>::KnotVectorType& knots)
+{
+  typename SplineTraits<BSpline>::BasisDerivativeType der;
+  BasisFunctionDerivativesImpl(u, order, degree, knots, der);
+  return der;
+}
+
+} // namespace common
+} // namespace aikido
+
+#endif // AIKIDO_COMMON_BSPLINE_HPP_

--- a/include/aikido/common/SplineFwd.hpp
+++ b/include/aikido/common/SplineFwd.hpp
@@ -1,0 +1,172 @@
+// This file is part of Eigen, a lightweight C++ template library
+// for linear algebra.
+//
+// Copyright (C) 20010-2011 Hauke Heibel <hauke.heibel@gmail.com>
+//
+// This Source Code Form is subject to the terms of the Mozilla
+// Public License v. 2.0. If a copy of the MPL was not distributed
+// with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef AIKIDO_COMMON_SPLINEFWD_HPP_
+#define AIKIDO_COMMON_SPLINEFWD_HPP_
+
+#include <Eigen/Core>
+
+namespace aikido {
+namespace common {
+
+template <typename Scalar, int Dim, int Degree = Eigen::Dynamic>
+class BSpline;
+
+template <typename SplineType, int DerivativeOrder = Eigen::Dynamic>
+struct SplineTraits
+{
+};
+
+/**
+ * \ingroup Splines_Module
+ * \brief Compile-time attributes of the Spline class for Dynamic degree.
+ **/
+template <typename _Scalar, int _Dim, int _Degree>
+struct SplineTraits<BSpline<_Scalar, _Dim, _Degree>, Eigen::Dynamic>
+{
+  typedef _Scalar Scalar; /*!< The spline curve's scalar type. */
+  enum
+  {
+    Dimension = _Dim /*!< The spline curve's dimension. */
+  };
+  enum
+  {
+    Degree = _Degree /*!< The spline curve's degree. */
+  };
+
+  enum
+  {
+    OrderAtCompileTime
+    = _Degree == Eigen::Dynamic
+          ? Eigen::Dynamic
+          : _Degree + 1 /*!< The spline curve's order at compile-time. */
+  };
+  enum
+  {
+    NumOfDerivativesAtCompileTime = OrderAtCompileTime /*!< The number of
+                                                          derivatives defined
+                                                          for the current
+                                                          spline. */
+  };
+
+  enum
+  {
+    DerivativeMemoryLayout
+    = Dimension == 1
+          ? Eigen::RowMajor
+          : Eigen::ColMajor /*!< The derivative type's memory layout. */
+  };
+
+  /** \brief The data type used to store non-zero basis functions. */
+  typedef Eigen::Array<Scalar, 1, OrderAtCompileTime> BasisVectorType;
+
+  /** \brief The data type used to store the values of the basis function
+   * derivatives. */
+  typedef Eigen::Array<Scalar,
+                       Eigen::Dynamic,
+                       Eigen::Dynamic,
+                       Eigen::RowMajor,
+                       NumOfDerivativesAtCompileTime,
+                       OrderAtCompileTime>
+      BasisDerivativeType;
+
+  /** \brief The data type used to store the spline's derivative values. */
+  typedef Eigen::Array<Scalar,
+                       Dimension,
+                       Eigen::Dynamic,
+                       DerivativeMemoryLayout,
+                       Dimension,
+                       NumOfDerivativesAtCompileTime>
+      DerivativeType;
+
+  /** \brief The point type the spline is representing. */
+  typedef Eigen::Array<Scalar, Dimension, 1> PointType;
+
+  /** \brief The data type used to store knot vectors. */
+  typedef Eigen::Array<Scalar, 1, Eigen::Dynamic> KnotVectorType;
+
+  /** \brief The data type used to store parameter vectors. */
+  typedef Eigen::Array<Scalar, 1, Eigen::Dynamic> ParameterVectorType;
+
+  /** \brief The data type representing the spline's control points. */
+  typedef Eigen::Array<Scalar, Dimension, Eigen::Dynamic>
+      ControlPointVectorType;
+};
+
+/**
+ * \ingroup Splines_Module
+ * \brief Compile-time attributes of the Spline class for fixed degree.
+ *
+ * The traits class inherits all attributes from the SplineTraits of Dynamic
+ *degree.
+ **/
+template <typename _Scalar, int _Dim, int _Degree, int _DerivativeOrder>
+struct SplineTraits<BSpline<_Scalar, _Dim, _Degree>, _DerivativeOrder>
+    : public SplineTraits<BSpline<_Scalar, _Dim, _Degree> >
+{
+  enum
+  {
+    OrderAtCompileTime
+    = _Degree == Eigen::Dynamic
+          ? Eigen::Dynamic
+          : _Degree + 1 /*!< The spline curve's order at compile-time. */
+  };
+  enum
+  {
+    NumOfDerivativesAtCompileTime
+    = _DerivativeOrder == Eigen::Dynamic
+          ? Eigen::Dynamic
+          : _DerivativeOrder + 1 /*!< The number of
+                                    derivatives defined for
+                                    the current spline. */
+  };
+
+  enum
+  {
+    DerivativeMemoryLayout
+    = _Dim == 1 ? Eigen::RowMajor
+                : Eigen::ColMajor /*!< The derivative type's memory layout. */
+  };
+
+  /** \brief The data type used to store the values of the basis function
+   * derivatives. */
+  typedef Eigen::Array<_Scalar,
+                       Eigen::Dynamic,
+                       Eigen::Dynamic,
+                       Eigen::RowMajor,
+                       NumOfDerivativesAtCompileTime,
+                       OrderAtCompileTime>
+      BasisDerivativeType;
+
+  /** \brief The data type used to store the spline's derivative values. */
+  typedef Eigen::Array<_Scalar,
+                       _Dim,
+                       Eigen::Dynamic,
+                       DerivativeMemoryLayout,
+                       _Dim,
+                       NumOfDerivativesAtCompileTime>
+      DerivativeType;
+};
+
+/** \brief 2D float B-spline with dynamic degree. */
+typedef BSpline<float, 2> BSpline2f;
+
+/** \brief 3D float B-spline with dynamic degree. */
+typedef BSpline<float, 3> BSpline3f;
+
+/** \brief 2D double B-spline with dynamic degree. */
+typedef BSpline<double, 2> BSpline2d;
+
+/** \brief 3D double B-spline with dynamic degree. */
+typedef BSpline<double, 3> BSpline3d;
+
+} // namespace common
+} // namespace aikido
+
+#endif // AIKIDO_COMMON_SPLINEFWD_HPP_

--- a/include/aikido/common/StepSequence.hpp
+++ b/include/aikido/common/StepSequence.hpp
@@ -36,6 +36,13 @@ public:
       double startPoint = 0.0,
       double endPoint = 1.0);
 
+  /// Constructs StepSequence in Matlab's linspace() style.
+  StepSequence(
+      double startPoint,
+      double endPoint,
+      std::size_t numSteps,
+      bool includeEndpoint = true);
+
   /// Returns an iterator to the first element of the sequence.
   ///
   /// \return Iterator to the first element of the sequence.
@@ -58,12 +65,16 @@ public:
   std::size_t getLength() const;
 
 private:
-  /// Computes the total length of sequence. This is only called in the
-  /// contructor.
-  void updateLength();
+  /// Computes the total length of sequence given step size. This is only called
+  /// in the contructor.
+  void updateNumSteps();
+
+  /// Computes the step size of sequence given number of steps. This is only
+  /// called in the contructor.
+  void updateStepSize();
 
   /// Step size increments from the start point to the end point.
-  const double mStepSize;
+  double mStepSize;
 
   /// Whether the start point in the sequence will be the start point.
   const bool mIncludeStartPoint;

--- a/include/aikido/trajectory/BSpline.hpp
+++ b/include/aikido/trajectory/BSpline.hpp
@@ -188,13 +188,13 @@ public:
   std::size_t getNumDerivatives() const override;
 
   // Documentation inherited.
-  double getStartTime() const;
+  double getStartTime() const override;
 
   // Documentation inherited.
-  double getEndTime() const;
+  double getEndTime() const override;
 
   // Documentation inherited.
-  double getDuration() const;
+  double getDuration() const override;
 
   // Documentation inherited.
   void evaluate(double t, statespace::StateSpace::State* state) const override;

--- a/include/aikido/trajectory/BSpline.hpp
+++ b/include/aikido/trajectory/BSpline.hpp
@@ -166,10 +166,8 @@ public:
   /// can
   /// be different depending on \c withStartControlPoints and \c
   /// withStartControlPoints. Decrease the number by one per one option is true.
-  /// \param[in] withStartControlPoints Whether to take into account the start
-  /// control point as variable.
-  /// \param[in] withStartControlPoints Whether to take into account the end
-  /// control point as variable.
+  /// \param[in] withStartControlPoint Whether to set the start control point.
+  /// \param[in] withEndControlPoint Whether to set the end control point.
   void setControlPoints(
       std::size_t stateSpaceIndex,
       const ControlPointVectorType& controlPoints,
@@ -181,19 +179,29 @@ public:
   /// \param[in] stateSpaceIndex The index to the state space to set the start
   /// point.
   /// \param[in] value Control point value.
-  /// \param[in] withStartControlPoints Whether to take into account the start
-  /// control point as variable.
-  /// \param[in] withStartControlPoints Whether to take into account the end
-  /// control point as variable.
+  /// \param[in] withStartControlPoint Whether to set the start control point.
+  /// \param[in] withEndControlPoint Whether to set the end control point.
   void setControlPoints(
       std::size_t stateSpaceIndex,
       double value,
       bool withStartControlPoint = true,
       bool withEndControlPoint = true);
 
+  /// Returns control points of one subspace of the state space.
+  ///
+  /// \param[in] stateSpaceIndex The index to the state space to set the start
+  /// point.
+  /// \return Control points.
   const ControlPointVectorType& getControlPoints(
       std::size_t stateSpaceIndex) const;
 
+  /// Returns control points of one subspace of the state space.
+  ///
+  /// \param[in] stateSpaceIndex The index to the state space to set the start
+  /// point.
+  /// \param[in] withStartControlPoint Whether to get the start control point.
+  /// \param[in] withEndControlPoint Whether to get the end control point.
+  /// \return Control points.
   ControlPointVectorType getControlPoints(
       std::size_t stateSpaceIndex,
       bool withStartControlPoint,
@@ -228,6 +236,8 @@ public:
   virtual double computeArcLength(
       const distance::DistanceMetric& distanceMetric,
       double resolution = 0.1) const;
+  // TODO(JS): Consider adding this function to the base class as a pure virtual
+  // function.
 
 protected:
   /// Computes number of knots given degree and number of control points.

--- a/include/aikido/trajectory/BSpline.hpp
+++ b/include/aikido/trajectory/BSpline.hpp
@@ -20,15 +20,22 @@ public:
   using KnotVectorType = typename SplineType::KnotVectorType;
   using ControlPointVectorType = typename SplineType::ControlPointVectorType;
 
-  /// Constructs BSpline from control points and knots. The degree is
-  /// automatically determined by the
+  /// Constructs BSpline from control points and knots.
+  ///
+  /// The degree is automatically to be (num_knots - num_control_points - 1).
   ///
   /// \param[in] stateSpace State space this trajectory is defined in. Throw an
   /// exception if null.
   /// \param[in] knots Knots. The number of knots should be the same with the
-  /// control points.
+  /// control points. The values of knots should be monotonically increased.
+  /// Otherwise, it's undefined behavior.
   /// \param[in] controlPoints Control points. The number of control points
   /// should be the same with the control points.
+  /// \throw If \c stateSpace is null.
+  /// \throw If the size of \c knots is less than three.
+  /// \throw If the size of \c controlPoints is less than one.
+  /// \throw If the degree (size of \c knots - size of \c controlPoints - 1) is
+  /// less than zero.
   BSpline(
       statespace::ConstStateSpacePtr stateSpace,
       const KnotVectorType& knots,
@@ -40,8 +47,7 @@ public:
   /// The start and end point are the same with the first and last control
   /// points, respectively.
   ///
-  /// \param[in] stateSpace State space this trajectory is defined in. Throw an
-  /// exception if null.
+  /// \param[in] stateSpace State space this trajectory is defined in.
   /// \param[in] degree Degree of the b-spline.
   /// \param[in] controlPoints Control points. The number of control points
   /// should greater than degree. Otherwise, throw an exception.
@@ -49,6 +55,9 @@ public:
   /// first knot value.
   /// \param[in] endTime End value of the time parameter. This will be the last
   /// knot value.
+  /// \throw If \c stateSpace is null.
+  /// \throw If the number of control points is equal to or less than the
+  /// degree.
   BSpline(
       statespace::ConstStateSpacePtr stateSpace,
       std::size_t degree,
@@ -56,11 +65,18 @@ public:
       double startTime = 0.0,
       double endTime = 1.0);
 
-  /// Constructs an empty trajectory.
+  /// Constructs BSpline from the degree and the number of control points, which
+  /// are all zeros.
   ///
-  /// \param stateSpace State space this trajectory is defined in. Throw an
+  /// \param[in] stateSpace State space this trajectory is defined in. Throw an
   /// exception if null.
-  /// \param startTime Start time of the trajectory
+  /// \param[in] startTime Start time of the trajectory. This will be the first
+  /// knot value.
+  /// \param[in] endTime End value of the time parameter. This will be the last
+  /// knot value.
+  /// \throw If \c stateSpace is null.
+  /// \throw If the number of control points is equal to or less than the
+  /// degree.
   BSpline(
       statespace::ConstStateSpacePtr stateSpace,
       std::size_t degree,
@@ -106,36 +122,38 @@ public:
   /// Returns the number of control points
   std::size_t getNumControlPoints() const;
 
-  /// Sets start point of one sub space of the state space.
+  /// Sets start point of one sub space of the state space. Identical to setting
+  /// the first control point.
   ///
   /// \param[in] stateSpaceIndex The index to the state space to set the start
   /// point.
   void setStartPoint(std::size_t stateSpaceIndex, double value);
 
-  /// Sets start point. Identical to call \c
+  /// Sets start point. Identical to setting the first control point.
   /// setStartPoint(stateSpace->logMap(state)).
   ///
   /// \param[in] point Start point on the tangent space.
   void setStartPoint(const Eigen::VectorXd& point);
 
-  /// Sets start point.
+  /// Sets start point. Identical to setting the first control point.
   ///
   /// \param[in] state Start point.
   void setStartPoint(const statespace::StateSpace::State* state);
 
-  /// Sets end point of one sub space of the state space.
+  /// Sets end point of one sub space of the state space. Identical to setting
+  /// the last control point.
   ///
   /// \param[in] stateSpaceIndex The index to the state space to set the end
   /// point.
   void setEndPoint(std::size_t stateSpaceIndex, double value);
 
-  /// Sets end point. Identical to call \c
+  /// Sets end point. Identical to setting the last control point.
   /// setEndPoint(stateSpace->logMap(state)).
   ///
   /// \param[in] point End point on the tangent space.
   void setEndPoint(const Eigen::VectorXd& point);
 
-  /// Sets end point.
+  /// Sets end point. Identical to setting the last control point.
   ///
   /// \param[in] state End point.
   void setEndPoint(const statespace::StateSpace::State* state);
@@ -222,6 +240,8 @@ protected:
   /// \param[in] numControlPoints Number of the control points.
   /// \param[in] startTime Start time of the knots.
   /// \param[in] startTime End time of the knots.
+  /// \throw If the number of control points is equal to or less than the
+  /// degree.
   static KnotVectorType computeUniformKnots(
       std::size_t degree,
       std::size_t numControlPoints,

--- a/include/aikido/trajectory/BSpline.hpp
+++ b/include/aikido/trajectory/BSpline.hpp
@@ -1,0 +1,253 @@
+#ifndef AIKIDO_TRAJECTORY_BSPLIINE_HPP_
+#define AIKIDO_TRAJECTORY_BSPLIINE_HPP_
+
+#include "aikido/common/BSpline.hpp"
+#include "aikido/common/pointers.hpp"
+#include "aikido/distance/DistanceMetric.hpp"
+#include "aikido/statespace/StateSpace.hpp"
+#include "aikido/trajectory/Trajectory.hpp"
+
+namespace aikido {
+namespace trajectory {
+
+AIKIDO_DECLARE_POINTERS(BSpline)
+
+/// B-spline trajectory define in a \c StateSpace.
+class BSpline : public Trajectory
+{
+public:
+  using SplineType = common::BSpline<double, 1, Eigen::Dynamic>;
+  using KnotVectorType = typename SplineType::KnotVectorType;
+  using ControlPointVectorType = typename SplineType::ControlPointVectorType;
+
+  /// Constructs BSpline from control points and knots. The degree is
+  /// automatically determined by the
+  ///
+  /// \param[in] stateSpace State space this trajectory is defined in. Throw an
+  /// exception if null.
+  /// \param[in] knots Knots. The number of knots should be the same with the
+  /// control points.
+  /// \param[in] controlPoints Control points. The number of control points
+  /// should be the same with the control points.
+  BSpline(
+      statespace::ConstStateSpacePtr stateSpace,
+      const KnotVectorType& knots,
+      const ControlPointVectorType& controlPoints);
+
+  /// Constructs BSpline from control points where the knots are uniformly
+  /// distributed.
+  ///
+  /// The start and end point are the same with the first and last control
+  /// points, respectively.
+  ///
+  /// \param[in] stateSpace State space this trajectory is defined in. Throw an
+  /// exception if null.
+  /// \param[in] degree Degree of the b-spline.
+  /// \param[in] controlPoints Control points. The number of control points
+  /// should greater than degree. Otherwise, throw an exception.
+  /// \param[in] startTime Start value of the time parameter. This will be the
+  /// first knot value.
+  /// \param[in] endTime End value of the time parameter. This will be the last
+  /// knot value.
+  BSpline(
+      statespace::ConstStateSpacePtr stateSpace,
+      std::size_t degree,
+      const ControlPointVectorType& controlPoints,
+      double startTime = 0.0,
+      double endTime = 1.0);
+
+  /// Constructs an empty trajectory.
+  ///
+  /// \param stateSpace State space this trajectory is defined in. Throw an
+  /// exception if null.
+  /// \param startTime Start time of the trajectory
+  BSpline(
+      statespace::ConstStateSpacePtr stateSpace,
+      std::size_t degree,
+      std::size_t numControlPoints,
+      double startTime = 0.0,
+      double endTime = 1.0);
+
+  /// Copy constructor
+  ///
+  /// \param[in] other The other BSpline being copied.
+  BSpline(const BSpline& other);
+
+  /// Move constructor
+  ///
+  /// \param[in] other The other BSpline being moved.
+  BSpline(BSpline&& other);
+
+  /// Destructor
+  ~BSpline() override;
+
+  /// Copy assignment operator
+  ///
+  /// \param[in] other The other BSpline being copied.
+  BSpline& operator=(const BSpline& other);
+
+  /// Move assignment operator
+  ///
+  /// \param[in] other The other BSpline being moved.
+  BSpline& operator=(BSpline&& other);
+
+  /// Returns a clone of this BSpline.
+  std::unique_ptr<trajectory::Trajectory> clone() const;
+
+  /// Returns degree of the spline. Degree is order - 1.
+  std::size_t getDegree() const;
+
+  /// Returns order of the spline. Order is degree + 1.
+  std::size_t getOrder() const;
+
+  /// Returns the number of knots
+  std::size_t getNumKnots() const;
+
+  /// Returns the number of control points
+  std::size_t getNumControlPoints() const;
+
+  /// Sets start point of one sub space of the state space.
+  ///
+  /// \param[in] stateSpaceIndex The index to the state space to set the start
+  /// point.
+  void setStartPoint(std::size_t stateSpaceIndex, double value);
+
+  /// Sets start point. Identical to call \c
+  /// setStartPoint(stateSpace->logMap(state)).
+  ///
+  /// \param[in] point Start point on the tangent space.
+  void setStartPoint(const Eigen::VectorXd& point);
+
+  /// Sets start point.
+  ///
+  /// \param[in] state Start point.
+  void setStartPoint(const statespace::StateSpace::State* state);
+
+  /// Sets end point of one sub space of the state space.
+  ///
+  /// \param[in] stateSpaceIndex The index to the state space to set the end
+  /// point.
+  void setEndPoint(std::size_t stateSpaceIndex, double value);
+
+  /// Sets end point. Identical to call \c
+  /// setEndPoint(stateSpace->logMap(state)).
+  ///
+  /// \param[in] point End point on the tangent space.
+  void setEndPoint(const Eigen::VectorXd& point);
+
+  /// Sets end point.
+  ///
+  /// \param[in] state End point.
+  void setEndPoint(const statespace::StateSpace::State* state);
+
+  /// Sets all the control points of one subspace of the state space.
+  ///
+  /// \param[in] stateSpaceIndex The index to the state space to set the start
+  /// point.
+  /// \param[in] controlPoints Control points. The size of the control points
+  /// can
+  /// be different depending on \c withStartControlPoints and \c
+  /// withStartControlPoints. Decrease the number by one per one option is true.
+  /// \param[in] withStartControlPoints Whether to take into account the start
+  /// control point as variable.
+  /// \param[in] withStartControlPoints Whether to take into account the end
+  /// control point as variable.
+  void setControlPoints(
+      std::size_t stateSpaceIndex,
+      const ControlPointVectorType& controlPoints,
+      bool withStartControlPoint = true,
+      bool withEndControlPoint = true);
+
+  /// Sets one control point of one subspace of the state space.
+  ///
+  /// \param[in] stateSpaceIndex The index to the state space to set the start
+  /// point.
+  /// \param[in] value Control point value.
+  /// \param[in] withStartControlPoints Whether to take into account the start
+  /// control point as variable.
+  /// \param[in] withStartControlPoints Whether to take into account the end
+  /// control point as variable.
+  void setControlPoints(
+      std::size_t stateSpaceIndex,
+      double value,
+      bool withStartControlPoint = true,
+      bool withEndControlPoint = true);
+
+  const ControlPointVectorType& getControlPoints(
+      std::size_t stateSpaceIndex) const;
+
+  ControlPointVectorType getControlPoints(
+      std::size_t stateSpaceIndex,
+      bool withStartControlPoint,
+      bool withEndControlPoint) const;
+
+  // Documentation inherited.
+  statespace::ConstStateSpacePtr getStateSpace() const override;
+
+  // Documentation inherited.
+  std::size_t getNumDerivatives() const override;
+
+  // Documentation inherited.
+  double getStartTime() const;
+
+  // Documentation inherited.
+  double getEndTime() const;
+
+  // Documentation inherited.
+  double getDuration() const;
+
+  // Documentation inherited.
+  void evaluate(double t, statespace::StateSpace::State* state) const override;
+
+  // Documentation inherited.
+  void evaluateDerivative(
+      double t, int derivative, Eigen::VectorXd& tangentVector) const override;
+
+  /// Computes arc length.
+  ///
+  /// \param[in] distanceMetric Distance metric to measure the arc length.
+  /// \param[in] resolution Size of the line segments.
+  virtual double computeArcLength(
+      const distance::DistanceMetric& distanceMetric,
+      double resolution = 0.1) const;
+
+protected:
+  /// Computes number of knots given degree and number of control points.
+  static std::size_t computeNumKnots(
+      std::size_t degree, std::size_t numControlPoints);
+
+  /// Computes uniform knots.
+  ///
+  /// \param[in] degree Degree of the b-spline
+  /// \param[in] numControlPoints Number of the control points.
+  /// \param[in] startTime Start time of the knots.
+  /// \param[in] startTime End time of the knots.
+  static KnotVectorType computeUniformKnots(
+      std::size_t degree,
+      std::size_t numControlPoints,
+      double startTime = 0.0,
+      double endTime = 1.0);
+
+  /// State space.
+  statespace::ConstStateSpacePtr mStateSpace;
+
+  /// One-demensional splines.
+  std::vector<SplineType> mSplines;
+
+  /// Start time of b-spline.
+  double mStartTime;
+  // This variable can be redundant because the knots in Eigen::Spline encodes
+  // the start time. This variable is for the case of zero dimensional state
+  // space since m1DSpline will be empty in that case.
+
+  /// End time of b-spline
+  double mEndTime;
+  // This variable can be redundant because the knots in Eigen::Spline encodes
+  // the end time. This variable is for the case of zero dimensional state space
+  // since m1DSpline will be empty in that case.
+};
+
+} // namespace trajectory
+} // namespace aikido
+
+#endif // AIKIDO_TRAJECTORY_BSPLIINE_HPP_

--- a/src/common/StepSequence.cpp
+++ b/src/common/StepSequence.cpp
@@ -42,7 +42,22 @@ StepSequence::StepSequence(
     throw std::runtime_error("Step size is zero");
   }
 
-  updateLength();
+  updateNumSteps();
+}
+
+//==============================================================================
+StepSequence::StepSequence(
+    double startPoint,
+    double endPoint,
+    std::size_t numSteps,
+    bool includeEndpoint)
+  : mIncludeStartPoint(true)
+  , mIncludeEndPoint(includeEndpoint)
+  , mStartPoint(startPoint)
+  , mEndPoint(endPoint)
+  , mNumSteps(numSteps)
+{
+  updateStepSize();
 }
 
 //==============================================================================
@@ -101,7 +116,7 @@ std::size_t StepSequence::getLength() const
 }
 
 //==============================================================================
-void StepSequence::updateLength()
+void StepSequence::updateNumSteps()
 {
   const double stepRatio = (mEndPoint - mStartPoint) / mStepSize;
   const double floorStepRatio = std::floor(stepRatio);
@@ -124,6 +139,24 @@ void StepSequence::updateLength()
   {
     if (!mIncludeEndPoint && mNumSteps > 0)
       --mNumSteps;
+  }
+}
+
+//==============================================================================
+void StepSequence::updateStepSize()
+{
+  if (mNumSteps > 1u)
+  {
+    const std::size_t m = mIncludeEndPoint ? mNumSteps : mNumSteps - 1u;
+    mStepSize = (mEndPoint - mStartPoint) / m;
+  }
+  else
+  {
+    // This is unnecessary because:
+    // (1) mStepSize shouldn't be used if mNumSteps == 1
+    // (2) mStepSize shouldn't be used or just multiplied by zero if
+    // mNumSteps == 0
+    mStepSize = 0.0;
   }
 }
 

--- a/src/common/StepSequence.cpp
+++ b/src/common/StepSequence.cpp
@@ -147,7 +147,7 @@ void StepSequence::updateStepSize()
 {
   if (mNumSteps > 1u)
   {
-    const std::size_t m = mIncludeEndPoint ? mNumSteps : mNumSteps - 1u;
+    const std::size_t m = mIncludeEndPoint ? mNumSteps - 1u : mNumSteps;
     mStepSize = (mEndPoint - mStartPoint) / m;
   }
   else

--- a/src/trajectory/BSpline.cpp
+++ b/src/trajectory/BSpline.cpp
@@ -424,7 +424,7 @@ void BSpline::evaluateDerivative(
     double /*t*/, int derivative, Eigen::VectorXd& /*tangentVector*/) const
 {
   if (derivative < 1)
-    throw std::logic_error("Derivative must be positive.");
+    throw std::invalid_argument("Derivative must be positive.");
 
   // TODO(JS): Not implemented
 }

--- a/src/trajectory/BSpline.cpp
+++ b/src/trajectory/BSpline.cpp
@@ -1,0 +1,499 @@
+#include "aikido/trajectory/BSpline.hpp"
+
+#include <sstream>
+#include <Eigen/Core>
+#include <dart/common/common.hpp>
+#include "aikido/common/StepSequence.hpp"
+
+namespace aikido {
+namespace trajectory {
+
+//==============================================================================
+BSpline::BSpline(
+    statespace::ConstStateSpacePtr stateSpace,
+    const BSpline::KnotVectorType& knots,
+    const BSpline::ControlPointVectorType& controlPoints)
+  : mStateSpace(std::move(stateSpace))
+{
+  if (mStateSpace == nullptr)
+    throw std::invalid_argument("StateSpace is null.");
+
+  if (knots.size() < 4)
+  {
+    throw std::invalid_argument(
+        "Number of knots should be equal to or greater than four");
+  }
+
+  if (controlPoints.size() < 1)
+  {
+    throw std::invalid_argument(
+        "Number of control points should be equal to or greater than one");
+  }
+
+  mStartTime = knots[0];
+  mEndTime = knots[knots.size() - 1];
+
+  mSplines.reserve(mStateSpace->getDimension());
+  for (auto i = 0u; i < mStateSpace->getDimension(); ++i)
+    mSplines.emplace_back(knots, controlPoints);
+}
+
+//==============================================================================
+BSpline::BSpline(
+    statespace::ConstStateSpacePtr stateSpace,
+    std::size_t degree,
+    const BSpline::ControlPointVectorType& controlPoints,
+    double startTime,
+    double endTime)
+  : BSpline(
+        std::move(stateSpace),
+        computeUniformKnots(
+            degree,
+            static_cast<std::size_t>(controlPoints.size()),
+            startTime,
+            endTime),
+        controlPoints)
+{
+  if (static_cast<std::size_t>(controlPoints.size()) <= degree)
+  {
+    std::stringstream ss;
+    ss << "The number of control points '" << controlPoints.size()
+       << "' should be greater than the degree '" << degree << "'.";
+    throw std::invalid_argument(ss.str());
+  }
+}
+
+//==============================================================================
+BSpline::BSpline(
+    statespace::ConstStateSpacePtr stateSpace,
+    std::size_t degree,
+    std::size_t numControlPoints,
+    double startTime,
+    double endTime)
+  : BSpline(
+        std::move(stateSpace),
+        degree,
+        ControlPointVectorType::Zero(
+            static_cast<ControlPointVectorType::Index>(numControlPoints)),
+        startTime,
+        endTime)
+{
+  // Do nothing
+}
+
+//==============================================================================
+BSpline::BSpline(const BSpline& other)
+  : mStateSpace(other.mStateSpace)
+  , mSplines(other.mSplines)
+  , mStartTime(other.mStartTime)
+  , mEndTime(other.mEndTime)
+{
+  // Do nothing
+}
+
+//==============================================================================
+BSpline::BSpline(BSpline&& other)
+  : mStateSpace(std::move(other.mStateSpace))
+  , mSplines(std::move(other.mSplines))
+  , mStartTime(std::move(other.mStartTime))
+  , mEndTime(std::move(other.mEndTime))
+{
+  // Do nothing
+}
+
+//==============================================================================
+BSpline::~BSpline()
+{
+  // Do nothing
+}
+
+//==============================================================================
+BSpline& BSpline::operator=(const BSpline& other)
+{
+  BSpline newBSpline(other);
+  *this = std::move(newBSpline);
+
+  return *this;
+}
+
+//==============================================================================
+BSpline& BSpline::operator=(BSpline&& other)
+{
+  mStateSpace = std::move(other.mStateSpace);
+  mSplines = std::move(other.mSplines);
+  mStartTime = std::move(other.mStartTime);
+  mEndTime = std::move(other.mEndTime);
+
+  return *this;
+}
+
+//==============================================================================
+std::unique_ptr<Trajectory> BSpline::clone() const
+{
+  return dart::common::make_unique<BSpline>(*this);
+}
+
+//==============================================================================
+std::size_t BSpline::getDegree() const
+{
+  if (mStateSpace->getDimension() == 0u)
+    return 0; // TODO: Better idea?
+
+  assert(!mSplines.empty());
+
+  return static_cast<std::size_t>(mSplines[0].degree());
+}
+
+//==============================================================================
+std::size_t BSpline::getOrder() const
+{
+  return getDegree() + 1u;
+}
+
+//==============================================================================
+std::size_t BSpline::getNumKnots() const
+{
+  if (mStateSpace->getDimension() == 0u)
+    return 0; // TODO: Better idea?
+
+  assert(!mSplines.empty());
+
+  return static_cast<std::size_t>(mSplines[0].knots().size());
+}
+
+//==============================================================================
+std::size_t BSpline::getNumControlPoints() const
+{
+  if (mStateSpace->getDimension() == 0u)
+    return 0; // TODO: Better idea?
+
+  assert(!mSplines.empty());
+
+  return static_cast<std::size_t>(mSplines[0].ctrls().size());
+}
+
+//==============================================================================
+void BSpline::setStartPoint(std::size_t stateSpaceIndex, double value)
+{
+  mSplines[stateSpaceIndex].ctrls()[0] = value;
+}
+
+//==============================================================================
+void BSpline::setStartPoint(const Eigen::VectorXd& point)
+{
+  const auto stateSpaceDim = mStateSpace->getDimension();
+
+  if (stateSpaceDim != static_cast<std::size_t>(point.size()))
+    throw std::invalid_argument("Invalid dimension");
+
+  for (auto i = 0u; i < stateSpaceDim; ++i)
+    mSplines[i].ctrls()[0] = point[i];
+}
+
+//==============================================================================
+void BSpline::setStartPoint(const statespace::StateSpace::State* state)
+{
+  Eigen::VectorXd values;
+  mStateSpace->logMap(state, values);
+  setStartPoint(values);
+}
+
+//==============================================================================
+void BSpline::setEndPoint(std::size_t stateSpaceIndex, double value)
+{
+  // TODO: Warning
+  if (getNumControlPoints() == 0)
+    return;
+
+  const auto index
+      = static_cast<ControlPointVectorType::Index>(getNumControlPoints() - 1u);
+  mSplines[stateSpaceIndex].ctrls()[index] = value;
+}
+
+//==============================================================================
+void BSpline::setEndPoint(const Eigen::VectorXd& point)
+{
+  // TODO: Warning
+  if (getNumControlPoints() == 0)
+    return;
+
+  const auto stateSpaceDim = mStateSpace->getDimension();
+
+  if (stateSpaceDim != static_cast<std::size_t>(point.size()))
+    throw std::invalid_argument("Invalid dimension");
+
+  const auto index
+      = static_cast<ControlPointVectorType::Index>(getNumControlPoints() - 1u);
+  for (auto i = 0u; i < stateSpaceDim; ++i)
+    mSplines[i].ctrls()[index] = point[i];
+}
+
+//==============================================================================
+void BSpline::setEndPoint(const statespace::StateSpace::State* state)
+{
+  // TODO: Warning
+  if (getNumControlPoints() == 0)
+    return;
+
+  Eigen::VectorXd values;
+  mStateSpace->logMap(state, values);
+  setEndPoint(values);
+}
+
+//==============================================================================
+void BSpline::setControlPoints(
+    std::size_t stateSpaceIndex,
+    const BSpline::ControlPointVectorType& controlPoints,
+    bool withStartControlPoint,
+    bool withEndControlPoint)
+{
+  const auto numControlPoints
+      = static_cast<ControlPointVectorType::Index>(getNumControlPoints());
+
+  if (numControlPoints == 0)
+    return;
+
+  if (withStartControlPoint)
+  {
+    if (withEndControlPoint)
+    {
+      if (controlPoints.size() != numControlPoints)
+        throw std::invalid_argument("Invalid number of control points");
+
+      mSplines[stateSpaceIndex].ctrls() = controlPoints;
+    }
+    else
+    {
+      if (controlPoints.size() - 1 != numControlPoints)
+        throw std::invalid_argument("Invalid number of control points");
+
+      mSplines[stateSpaceIndex].ctrls().head(numControlPoints - 1u)
+          = controlPoints;
+    }
+  }
+  else
+  {
+    if (withEndControlPoint)
+    {
+      if (controlPoints.size() - 1 != numControlPoints)
+        throw std::invalid_argument("Invalid number of control points");
+
+      mSplines[stateSpaceIndex].ctrls().tail(numControlPoints - 1u)
+          = controlPoints;
+    }
+    else
+    {
+      if (controlPoints.size() - 2 != numControlPoints)
+        throw std::invalid_argument("Invalid number of control points");
+
+      mSplines[stateSpaceIndex].ctrls().segment(1, numControlPoints - 2u)
+          = controlPoints;
+    }
+  }
+}
+
+//==============================================================================
+void BSpline::setControlPoints(
+    std::size_t stateSpaceIndex,
+    double value,
+    bool withStartControlPoint,
+    bool withEndControlPoint)
+{
+  const auto numControlPoints
+      = static_cast<ControlPointVectorType::Index>(getNumControlPoints());
+
+  if (numControlPoints == 0)
+    return;
+
+  if (withStartControlPoint)
+  {
+    if (withEndControlPoint)
+    {
+      mSplines[stateSpaceIndex].ctrls().setConstant(value);
+    }
+    else
+    {
+      mSplines[stateSpaceIndex]
+          .ctrls()
+          .head(numControlPoints - 1)
+          .setConstant(value);
+    }
+  }
+  else
+  {
+    if (withEndControlPoint)
+    {
+      mSplines[stateSpaceIndex]
+          .ctrls()
+          .tail(numControlPoints - 1)
+          .setConstant(value);
+    }
+    else
+    {
+      mSplines[stateSpaceIndex]
+          .ctrls()
+          .segment(1, numControlPoints - 2)
+          .setConstant(value);
+    }
+  }
+}
+
+//==============================================================================
+const BSpline::ControlPointVectorType& BSpline::getControlPoints(
+    std::size_t stateSpaceIndex) const
+{
+  return mSplines[stateSpaceIndex].ctrls();
+}
+
+//==============================================================================
+BSpline::ControlPointVectorType BSpline::getControlPoints(
+    std::size_t stateSpaceIndex,
+    bool withStartControlPoint,
+    bool withEndControlPoint) const
+{
+  const auto numControlPoints
+      = static_cast<ControlPointVectorType::Index>(getNumControlPoints());
+
+  if (withStartControlPoint)
+  {
+    if (withEndControlPoint)
+    {
+      return getControlPoints(stateSpaceIndex);
+    }
+    else
+    {
+      return mSplines[stateSpaceIndex].ctrls().head(numControlPoints - 1);
+    }
+  }
+  else
+  {
+    if (withEndControlPoint)
+    {
+      return mSplines[stateSpaceIndex].ctrls().tail(numControlPoints - 1);
+    }
+    else
+    {
+      return mSplines[stateSpaceIndex].ctrls().segment(1, numControlPoints - 2);
+    }
+  }
+}
+
+//==============================================================================
+statespace::ConstStateSpacePtr BSpline::getStateSpace() const
+{
+  return mStateSpace;
+}
+
+//==============================================================================
+std::size_t BSpline::getNumDerivatives() const
+{
+  return getDegree();
+}
+
+//==============================================================================
+double BSpline::getStartTime() const
+{
+  return mStartTime;
+}
+
+//==============================================================================
+double BSpline::getEndTime() const
+{
+  return mEndTime;
+}
+
+//==============================================================================
+double BSpline::getDuration() const
+{
+  return mEndTime - mStartTime;
+}
+
+//==============================================================================
+void BSpline::evaluate(double t, statespace::StateSpace::State* state) const
+{
+  Eigen::VectorXd values(mStateSpace->getDimension());
+
+  for (auto i = 0u; i < mStateSpace->getDimension(); ++i)
+    values[i] = mSplines[i](t)[0];
+
+  mStateSpace->expMap(values, state);
+}
+
+//==============================================================================
+void BSpline::evaluateDerivative(
+    double /*t*/, int derivative, Eigen::VectorXd& /*tangentVector*/) const
+{
+  if (derivative < 1)
+    throw std::logic_error("Derivative must be positive.");
+
+  // TODO(JS): Not implemented
+}
+
+//==============================================================================
+double BSpline::computeArcLength(
+    const distance::DistanceMetric& distanceMetric, double resolution) const
+{
+  const common::StepSequence steps(
+      resolution, true, true, getStartTime(), getEndTime());
+
+  if (steps.getLength() == 0u)
+    return 0.0;
+
+  auto state0 = mStateSpace->createState();
+  auto state1 = mStateSpace->createState();
+
+  double arcLength = 0.0;
+
+  auto it = steps.begin();
+  evaluate(*it, state0);
+  for (; it != steps.end(); ++it)
+  {
+    evaluate(*it, state1);
+    arcLength += distanceMetric.distance(state0, state1);
+
+    mStateSpace->copyState(state1, state0);
+  }
+
+  return arcLength;
+}
+
+//==============================================================================
+std::size_t BSpline::computeNumKnots(
+    std::size_t degree, std::size_t numControlPoints)
+{
+  return degree + numControlPoints + 1u;
+}
+
+//==============================================================================
+BSpline::KnotVectorType BSpline::computeUniformKnots(
+    std::size_t degree,
+    std::size_t numControlPoints,
+    double startTime,
+    double endTime)
+{
+  if (numControlPoints < degree + 1u)
+  {
+    throw std::invalid_argument(
+        "Number of control points should be equal to or greater than degree + "
+        "1");
+  }
+
+  const auto numKnots = computeNumKnots(degree, numControlPoints);
+
+  KnotVectorType knots(numKnots);
+  knots.head(static_cast<ControlPointVectorType::Index>(degree))
+      .setConstant(startTime);
+  knots.tail(static_cast<ControlPointVectorType::Index>(degree))
+      .setConstant(endTime);
+
+  const common::StepSequence internalKnots(
+      startTime, endTime, numControlPoints + 1u - degree, true);
+  ControlPointVectorType::Index index = 1;
+  for (double knot : internalKnots)
+    knots[index++] = knot;
+
+  return knots;
+}
+
+} // namespace trajectory
+} // namespace aikido

--- a/src/trajectory/BSpline.cpp
+++ b/src/trajectory/BSpline.cpp
@@ -545,7 +545,8 @@ BSpline::KnotVectorType BSpline::computeUniformKnots(
   const common::StepSequence internalKnots(
       startTime, endTime, numControlPoints + 1u - degree, true);
   ControlPointVectorType::Index index = static_cast<int>(degree);
-  assert(degree + internalKnots.getLength() + degree
+  assert(
+      degree + internalKnots.getLength() + degree
       == static_cast<std::size_t>(knots.size()));
   for (double knot : internalKnots)
     knots[index++] = knot;

--- a/src/trajectory/CMakeLists.txt
+++ b/src/trajectory/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(sources
+  BSpline.cpp
   Interpolated.cpp
   Spline.cpp
 )

--- a/tests/trajectory/CMakeLists.txt
+++ b/tests/trajectory/CMakeLists.txt
@@ -7,3 +7,8 @@ aikido_add_test(test_SplineTrajectory test_SplineTrajectory.cpp)
 target_link_libraries(test_SplineTrajectory
   "${PROJECT_NAME}_trajectory"
   "${PROJECT_NAME}_statespace")
+
+aikido_add_test(test_BSpline test_BSpline.cpp)
+target_link_libraries(test_BSpline
+  "${PROJECT_NAME}_trajectory"
+  "${PROJECT_NAME}_statespace")

--- a/tests/trajectory/test_BSpline.cpp
+++ b/tests/trajectory/test_BSpline.cpp
@@ -32,16 +32,12 @@ protected:
 
 TEST_F(BSplineTest, addSegment_NegativeDurationThrows)
 {
-  EXPECT_THROW(
-      BSpline(mStateSpace, 2, 3, 1.0, 0.5),
-      std::invalid_argument);
+  EXPECT_THROW(BSpline(mStateSpace, 2, 3, 1.0, 0.5), std::invalid_argument);
 }
 
 TEST_F(BSplineTest, addSegment_ZeroDurationThrows)
 {
-  EXPECT_THROW(
-      BSpline(mStateSpace, 2, 3, 0.5, 0.5),
-      std::invalid_argument);
+  EXPECT_THROW(BSpline(mStateSpace, 2, 3, 0.5, 0.5), std::invalid_argument);
 }
 
 TEST_F(BSplineTest, addSegment_IncorrectDimension_Throws)
@@ -50,9 +46,7 @@ TEST_F(BSplineTest, addSegment_IncorrectDimension_Throws)
 
   BSpline trajectory(mStateSpace, 2, 3);
 
-  EXPECT_THROW(
-      { trajectory.setStartPoint(vec); },
-      std::invalid_argument);
+  EXPECT_THROW({ trajectory.setStartPoint(vec); }, std::invalid_argument);
 }
 
 TEST_F(BSplineTest, getStateSpace)
@@ -101,7 +95,6 @@ TEST_F(BSplineTest, evaluate_IsEmpty_Throws)
   EXPECT_THROW({ trajectory.evaluate(3., state); }, std::logic_error);
 }
 
-
 TEST_F(BSplineTest, evaluate_EvaluateStart_ReturnsStart)
 {
   Eigen::Vector2d start(1., 1.);
@@ -130,4 +123,3 @@ TEST_F(BSplineTest, evaluate_EvaluateEnd_ReturnsEnd)
   trajectory.evaluate(1., state);
   EXPECT_TRUE(end.isApprox(state.getValue()));
 }
-

--- a/tests/trajectory/test_BSpline.cpp
+++ b/tests/trajectory/test_BSpline.cpp
@@ -58,27 +58,21 @@ TEST_F(BSplineTest, getStateSpace)
 
 TEST_F(BSplineTest, getNumDerivatives_IsEmpty_ReturnsZero)
 {
-  BSpline trajectory(mStateSpace, 2, 3);
+  BSpline trajectory(mStateSpace, 0, 3);
 
-  EXPECT_EQ(0, trajectory.getNumDerivatives());
+  EXPECT_EQ(0u, trajectory.getNumDerivatives());
 }
 
 TEST_F(BSplineTest, getStartTime)
 {
-  BSpline trajectory(mStateSpace, 2, 3, 3.);
-  EXPECT_DOUBLE_EQ(3., trajectory.getStartTime());
+  BSpline trajectory(mStateSpace, 2, 3, 3.0, 4.0);
+  EXPECT_DOUBLE_EQ(3.0, trajectory.getStartTime());
 }
 
 TEST_F(BSplineTest, getEndTime_IsNotEmpty_ReturnsEndTime)
 {
-  BSpline trajectory(mStateSpace, 2, 3, 3., 7.);
+  BSpline trajectory(mStateSpace, 2, 3, 3.0, 7.0);
   EXPECT_DOUBLE_EQ(7., trajectory.getEndTime());
-}
-
-TEST_F(BSplineTest, getDuration_IsEmpty_ReturnsZero)
-{
-  BSpline trajectory(mStateSpace, 2, 3);
-  EXPECT_DOUBLE_EQ(0., trajectory.getDuration());
 }
 
 TEST_F(BSplineTest, getDuration_IsNotEmpty_ReturnsDuration)
@@ -87,12 +81,12 @@ TEST_F(BSplineTest, getDuration_IsNotEmpty_ReturnsDuration)
   EXPECT_DOUBLE_EQ(4., trajectory.getDuration());
 }
 
-TEST_F(BSplineTest, evaluate_IsEmpty_Throws)
+TEST_F(BSplineTest, evaluate_OutOfDuration_Throws)
 {
   BSpline trajectory(mStateSpace, 2, 3);
 
   auto state = mStateSpace->createState();
-  EXPECT_THROW({ trajectory.evaluate(3., state); }, std::logic_error);
+  EXPECT_THROW({ trajectory.evaluate(3., state); }, std::invalid_argument);
 }
 
 TEST_F(BSplineTest, evaluate_EvaluateStart_ReturnsStart)
@@ -109,17 +103,18 @@ TEST_F(BSplineTest, evaluate_EvaluateStart_ReturnsStart)
 
 TEST_F(BSplineTest, evaluate_EvaluateEnd_ReturnsEnd)
 {
-  Eigen::Vector2d start(1., 1.);
-  Eigen::Vector2d end(2., 2.);
+  Eigen::Vector2d start(1.0, 1.0);
+  Eigen::Vector2d end(2.0, 2.0);
 
   BSpline trajectory(mStateSpace, 2, 3);
   trajectory.setStartPoint(start);
   trajectory.setEndPoint(end);
 
   auto state = mStateSpace->createState();
-  trajectory.evaluate(0., state);
+
+  trajectory.evaluate(0.0, state);
   EXPECT_TRUE(start.isApprox(state.getValue()));
 
-  trajectory.evaluate(1., state);
+  trajectory.evaluate(1.0, state);
   EXPECT_TRUE(end.isApprox(state.getValue()));
 }

--- a/tests/trajectory/test_BSpline.cpp
+++ b/tests/trajectory/test_BSpline.cpp
@@ -1,0 +1,133 @@
+#include <gtest/gtest.h>
+#include <aikido/statespace/Rn.hpp>
+#include <aikido/trajectory/BSpline.hpp>
+
+using namespace aikido::statespace;
+using aikido::trajectory::BSpline;
+using Eigen::Matrix2d;
+using Eigen::Vector2d;
+
+static const Vector2d START_VALUE(1., 2.);
+
+class BSplineTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    mStateSpace = std::make_shared<R2>();
+
+    mStartState = static_cast<R2::State*>(mStateSpace->allocateState());
+    mStateSpace->setValue(mStartState, START_VALUE);
+  }
+
+  void TearDown() override
+  {
+    mStateSpace->freeState(mStartState);
+  }
+
+  std::shared_ptr<R2> mStateSpace;
+  R2::State* mStartState;
+  std::shared_ptr<BSpline> mTrajectory;
+};
+
+TEST_F(BSplineTest, addSegment_NegativeDurationThrows)
+{
+  EXPECT_THROW(
+      BSpline(mStateSpace, 2, 3, 1.0, 0.5),
+      std::invalid_argument);
+}
+
+TEST_F(BSplineTest, addSegment_ZeroDurationThrows)
+{
+  EXPECT_THROW(
+      BSpline(mStateSpace, 2, 3, 0.5, 0.5),
+      std::invalid_argument);
+}
+
+TEST_F(BSplineTest, addSegment_IncorrectDimension_Throws)
+{
+  Eigen::Vector3d vec(1.0, 1.0, 1.0);
+
+  BSpline trajectory(mStateSpace, 2, 3);
+
+  EXPECT_THROW(
+      { trajectory.setStartPoint(vec); },
+      std::invalid_argument);
+}
+
+TEST_F(BSplineTest, getStateSpace)
+{
+  BSpline trajectory(mStateSpace, 2, 3);
+
+  EXPECT_EQ(mStateSpace, trajectory.getStateSpace());
+}
+
+TEST_F(BSplineTest, getNumDerivatives_IsEmpty_ReturnsZero)
+{
+  BSpline trajectory(mStateSpace, 2, 3);
+
+  EXPECT_EQ(0, trajectory.getNumDerivatives());
+}
+
+TEST_F(BSplineTest, getStartTime)
+{
+  BSpline trajectory(mStateSpace, 2, 3, 3.);
+  EXPECT_DOUBLE_EQ(3., trajectory.getStartTime());
+}
+
+TEST_F(BSplineTest, getEndTime_IsNotEmpty_ReturnsEndTime)
+{
+  BSpline trajectory(mStateSpace, 2, 3, 3., 7.);
+  EXPECT_DOUBLE_EQ(7., trajectory.getEndTime());
+}
+
+TEST_F(BSplineTest, getDuration_IsEmpty_ReturnsZero)
+{
+  BSpline trajectory(mStateSpace, 2, 3);
+  EXPECT_DOUBLE_EQ(0., trajectory.getDuration());
+}
+
+TEST_F(BSplineTest, getDuration_IsNotEmpty_ReturnsDuration)
+{
+  BSpline trajectory(mStateSpace, 2, 3, 3., 7.);
+  EXPECT_DOUBLE_EQ(4., trajectory.getDuration());
+}
+
+TEST_F(BSplineTest, evaluate_IsEmpty_Throws)
+{
+  BSpline trajectory(mStateSpace, 2, 3);
+
+  auto state = mStateSpace->createState();
+  EXPECT_THROW({ trajectory.evaluate(3., state); }, std::logic_error);
+}
+
+
+TEST_F(BSplineTest, evaluate_EvaluateStart_ReturnsStart)
+{
+  Eigen::Vector2d start(1., 1.);
+  BSpline trajectory(mStateSpace, 2, 3);
+  trajectory.setStartPoint(start);
+
+  auto state = mStateSpace->createState();
+
+  trajectory.evaluate(0., state);
+  EXPECT_TRUE(start.isApprox(state.getValue()));
+}
+
+TEST_F(BSplineTest, evaluate_EvaluateEnd_ReturnsEnd)
+{
+  Eigen::Vector2d start(1., 1.);
+  Eigen::Vector2d end(2., 2.);
+
+  BSpline trajectory(mStateSpace, 2, 3);
+  trajectory.setStartPoint(start);
+  trajectory.setEndPoint(end);
+
+  auto state = mStateSpace->createState();
+  trajectory.evaluate(0., state);
+  EXPECT_TRUE(start.isApprox(state.getValue()));
+
+  trajectory.evaluate(1., state);
+  EXPECT_TRUE(end.isApprox(state.getValue()));
+}
+


### PR DESCRIPTION
(This is a work-in-progress pull request to get early feedback.)

This PR adds `trajectory::BSpline`, implementation of B-spline trajectory, and necessary classes in `common` namespace.

Unlike `trajectory::Spline`, `trajectory::BSpline` guarantees class `C^k` continuity (`k - 1` times differentiable) over the whole trajectory where `k` is the order of B-spline.

`Eigen::Spline` (renamed to `aikido::common::BSpline`) and `Eigen::SplineTraits` are copied into AIKIDO code base with some modifications. The motivation of the adjustment is that Eigen's B-spline module doesn't allow changing control points after construction while we need this feature for trajectory optimization, which we will introduce soon.

Unit tests will be added before merging this PR.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
