### PR TITLE
Set start state to state space before creating vector field

### DIFF
--- a/src/planner/vectorfield/VectorFieldPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldPlanner.cpp
@@ -160,6 +160,8 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
       metaskeleton, MetaSkeletonStateSaver::Options::POSITIONS);
   DART_UNUSED(saver);
 
+  stateSpace->setState(metaskeleton.get(), &startState);
+
   auto vectorfield
       = dart::common::make_aligned_shared<MoveEndEffectorOffsetVectorField>(
           stateSpace,
@@ -179,7 +181,6 @@ std::unique_ptr<aikido::trajectory::Spline> planToEndEffectorOffset(
   compoundConstraint->addConstraint(
       constraint::dart::createTestableBounds(stateSpace));
 
-  stateSpace->setState(metaskeleton.get(), &startState);
   return followVectorField(
       *vectorfield,
       startState,


### PR DESCRIPTION
This is only one line change so I did not create an issue.

In creating `MoveEndEffectorOffsetVectorField`, `mStartPose` is initialized from the current end-effector pose. https://github.com/personalrobotics/aikido/blob/master/src/planner/vectorfield/MoveEndEffectorOffsetVectorField.cpp#L32
We shall update the position of metaSkeleton before creating the vector field so that the start pose of the planning matches `mStartPose`. If not, it might start with a big deviation when the given `startState` is very different with current state of meta skeleton.

This is a fix to #426 

***

**Before creating a pull request**

- [ ] Document new methods and classes (N/A)
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md` (N/A)
- [ ] Add unit test(s) for this change (N/A)
