### PR TITLE
Fix segment fault on 32-bit machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
   * Changed interface for TrajectoryPostProcessor: [#341](https://github.com/personalrobotics/aikido/pull/341)
   * Planning calls with InverseKinematicsSampleable constraints explicitly set MetaSkeleton to solve IK with: [#379](https://github.com/personalrobotics/aikido/pull/379)
   * Added a kinodynamic timer that generates a time-optimal smooth trajectory without completely stopping at each waypoint: [#443](https://github.com/personalrobotics/aikido/pull/443)
+  * Fix segment fault on 32 bit machine in vector-field planner: [#459](https://github.com/personalrobotics/aikido/pull/459)
 
 * Robot
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
   * Changed interface for TrajectoryPostProcessor: [#341](https://github.com/personalrobotics/aikido/pull/341)
   * Planning calls with InverseKinematicsSampleable constraints explicitly set MetaSkeleton to solve IK with: [#379](https://github.com/personalrobotics/aikido/pull/379)
   * Added a kinodynamic timer that generates a time-optimal smooth trajectory without completely stopping at each waypoint: [#443](https://github.com/personalrobotics/aikido/pull/443)
-  * Fixed segment fault on 32 bit machine in vector-field planner: [#459](https://github.com/personalrobotics/aikido/pull/459)
+  * Fixed segmentation fault on 32-bit machines in vector-field planner: [#459](https://github.com/personalrobotics/aikido/pull/459)
 
 * Robot
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
   * Changed interface for TrajectoryPostProcessor: [#341](https://github.com/personalrobotics/aikido/pull/341)
   * Planning calls with InverseKinematicsSampleable constraints explicitly set MetaSkeleton to solve IK with: [#379](https://github.com/personalrobotics/aikido/pull/379)
   * Added a kinodynamic timer that generates a time-optimal smooth trajectory without completely stopping at each waypoint: [#443](https://github.com/personalrobotics/aikido/pull/443)
-  * Fix segment fault on 32 bit machine in vector-field planner: [#459](https://github.com/personalrobotics/aikido/pull/459)
+  * Fixed segment fault on 32 bit machine in vector-field planner: [#459](https://github.com/personalrobotics/aikido/pull/459)
 
 * Robot
 

--- a/src/planner/vectorfield/detail/VectorFieldIntegrator.cpp
+++ b/src/planner/vectorfield/detail/VectorFieldIntegrator.cpp
@@ -58,16 +58,10 @@ VectorFieldIntegrator::VectorFieldIntegrator(
   , mDimension(mVectorField->getStateSpace()->getDimension())
   , mTimelimit(timelimit)
   , mConstraintCheckResolution(checkConstraintResolution)
-  , mState(mVectorField->getStateSpace()->allocateState())
+  , mState(mVectorField->getStateSpace()->createState())
   , mLastEvaluationTime(0.0)
 {
   // Do Nothing
-}
-
-//==============================================================================
-VectorFieldIntegrator::~VectorFieldIntegrator()
-{
-  mVectorField->getStateSpace()->freeState(mState);
 }
 
 //==============================================================================

--- a/src/planner/vectorfield/detail/VectorFieldIntegrator.cpp
+++ b/src/planner/vectorfield/detail/VectorFieldIntegrator.cpp
@@ -54,13 +54,20 @@ VectorFieldIntegrator::VectorFieldIntegrator(
     double checkConstraintResolution)
   : mVectorField(vectorField)
   , mConstraint(collisionFreeConstraint)
+  , mCacheIndex(-1)
+  , mDimension(mVectorField->getStateSpace()->getDimension())
   , mTimelimit(timelimit)
   , mConstraintCheckResolution(checkConstraintResolution)
+  , mState(mVectorField->getStateSpace()->allocateState())
+  , mLastEvaluationTime(0.0)
 {
-  mCacheIndex = -1;
-  mLastEvaluationTime = 0.0;
-  mDimension = mVectorField->getStateSpace()->getDimension();
-  mState = mVectorField->getStateSpace()->createState();
+  // Do Nothing
+}
+
+//==============================================================================
+VectorFieldIntegrator::~VectorFieldIntegrator()
+{
+  mVectorField->getStateSpace()->freeState(mState);
 }
 
 //==============================================================================

--- a/src/planner/vectorfield/detail/VectorFieldIntegrator.cpp
+++ b/src/planner/vectorfield/detail/VectorFieldIntegrator.cpp
@@ -61,7 +61,7 @@ VectorFieldIntegrator::VectorFieldIntegrator(
   , mState(mVectorField->getStateSpace()->createState())
   , mLastEvaluationTime(0.0)
 {
-  // Do Nothing
+  // Do nothing
 }
 
 //==============================================================================

--- a/src/planner/vectorfield/detail/VectorFieldIntegrator.hpp
+++ b/src/planner/vectorfield/detail/VectorFieldIntegrator.hpp
@@ -57,9 +57,6 @@ public:
       double timelimit,
       double checkConstraintResolution);
 
-  /// Destructor.
-  virtual ~VectorFieldIntegrator();
-
   /// Called before doing integration.
   ///
   void start();
@@ -118,7 +115,7 @@ protected:
   double mConstraintCheckResolution;
 
   /// Current state in integration
-  aikido::statespace::StateSpace::State* mState;
+  aikido::statespace::StateSpace::ScopedState mState;
 
   /// Last evaluation time in checking trajectory
   double mLastEvaluationTime;

--- a/src/planner/vectorfield/detail/VectorFieldIntegrator.hpp
+++ b/src/planner/vectorfield/detail/VectorFieldIntegrator.hpp
@@ -57,6 +57,9 @@ public:
       double timelimit,
       double checkConstraintResolution);
 
+  /// Destructor.
+  virtual ~VectorFieldIntegrator();
+
   /// Called before doing integration.
   ///
   void start();

--- a/tests/planner/vectorfield/test_VectorFieldPlanner.cpp
+++ b/tests/planner/vectorfield/test_VectorFieldPlanner.cpp
@@ -334,7 +334,7 @@ TEST_F(VectorFieldPlannerTest, PlanToEndEffectorOffsetTest)
   double initialStepSize = 0.001;
   double jointLimitTolerance = 1e-3;
   double constraintCheckResolution = 1e-3;
-  std::chrono::duration<double> timelimit(10.0);
+  std::chrono::duration<double> timelimit(60.0);
 
   // Create problem.
   auto offsetProblem = ConfigurationToEndEffectorOffset(
@@ -455,7 +455,7 @@ TEST_F(VectorFieldPlannerTest, PlanToEndEffectorPoseTest)
   double r = 1.0;
   double jointLimitTolerance = 1e-3;
   double constraintCheckResolution = 1e-3;
-  std::chrono::duration<double> timelimit(5.);
+  std::chrono::duration<double> timelimit(60.);
 
   mSkel->setPositions(mStartConfig);
 

--- a/tests/planner/vectorfield/test_VectorFieldPlanner.cpp
+++ b/tests/planner/vectorfield/test_VectorFieldPlanner.cpp
@@ -331,9 +331,9 @@ TEST_F(VectorFieldPlannerTest, PlanToEndEffectorOffsetTest)
 
   double positionTolerance = 0.01;
   double angularTolerance = 0.15;
-  double initialStepSize = 0.001;
+  double initialStepSize = 0.01;
   double jointLimitTolerance = 1e-3;
-  double constraintCheckResolution = 1e-3;
+  double constraintCheckResolution = 1e-2;
   std::chrono::duration<double> timelimit(60.0);
 
   // Create problem.
@@ -453,9 +453,9 @@ TEST_F(VectorFieldPlannerTest, PlanToEndEffectorPoseTest)
   double poseErrorTolerance = 0.01;
   double initialStepSize = 0.05;
   double r = 1.0;
-  double jointLimitTolerance = 1e-3;
-  double constraintCheckResolution = 1e-3;
-  std::chrono::duration<double> timelimit(60.);
+  double jointLimitTolerance = 1e-2;
+  double constraintCheckResolution = 1e-2;
+  std::chrono::duration<double> timelimit(300.);
 
   mSkel->setPositions(mStartConfig);
 


### PR DESCRIPTION
This PR fixes the last issue left in #365 
I have tested it on 32-bit machine. 

The previous code uses `createState()` of a state space to a `State` raw point, which causes problem in ownership and thus memory leak. 
The timilimit in the unit test is increased for successul rate.

***

**Before creating a pull request**

- [ ] Document new methods and classes (N/A)
- [x] Format code with `make format` 

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change (N/A)
