### PR TITLE
The compiler definition DART_HAVE_VOXEL is used instead of DART_HAS_V……

### DIFF
--- a/src/perception/CMakeLists.txt
+++ b/src/perception/CMakeLists.txt
@@ -77,9 +77,11 @@ target_link_libraries("${PROJECT_NAME}_perception"
 target_compile_options("${PROJECT_NAME}_perception"
   PUBLIC ${AIKIDO_CXX_STANDARD_FLAGS}
 )
-target_compile_definitions("${PROJECT_NAME}_perception"
-  PUBLIC DART_HAS_VOXELGRIDSHAPE
-)
+if(DART_HAS_VOXELGRIDSHAPE)
+  target_compile_definitions("${PROJECT_NAME}_perception"
+    PUBLIC DART_HAS_VOXELGRIDSHAPE
+  )
+endif()
 
 add_component(${PROJECT_NAME} perception)
 add_component_targets(${PROJECT_NAME} perception "${PROJECT_NAME}_perception")

--- a/src/perception/CMakeLists.txt
+++ b/src/perception/CMakeLists.txt
@@ -78,7 +78,7 @@ target_compile_options("${PROJECT_NAME}_perception"
   PUBLIC ${AIKIDO_CXX_STANDARD_FLAGS}
 )
 target_compile_definitions("${PROJECT_NAME}_perception"
-  PRIVATE DART_HAVE_VOXELGRIDSHAPE
+  PUBLIC DART_HAS_VOXELGRIDSHAPE
 )
 
 add_component(${PROJECT_NAME} perception)


### PR DESCRIPTION
Classes/Functions defined in voxel grid perception module header file are invisible due to DART_HAVE_VOXEL instead of DART_HAS_VOXEL was set.
The compiler definition DART_HAVE_VOXEL is used instead of DART_HAS_VOXEL. Also, the variable should be public since it is used in the header file for Voxel module.
