### PR TITLE
Enable planner_ompl for OMPL (>= 1.2.1) + Boost (>= 1.61.1)

### DIFF
--- a/src/planner/ompl/CMakeLists.txt
+++ b/src/planner/ompl/CMakeLists.txt
@@ -1,10 +1,12 @@
 if(CMAKE_COMPILER_IS_GNUCXX)
   if(OMPL_VERSION VERSION_GREATER 1.2.0 OR OMPL_VERSION VERSION_EQUAL 1.2.0)
-    message(STATUS "OMPL planners are disabled for OMPL (>=1.2.0) + GCC. "
-        "For details, please see: "
-        " https://github.com/personalrobotics/aikido/issues/363"
-    )
-    return()
+    if(Boost_VERSION VERSION_LESS 1.65.1)
+      message(STATUS "OMPL planners are disabled for OMPL (>=1.2.0) + GCC. "
+          "For details, please see: "
+          " https://github.com/personalrobotics/aikido/issues/363"
+      )
+      return()
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
It seems OMPL (>= 1.2.1) with an old version of Boost causes the segfault described in #363. This PR enables building `planner_ompl` for Boost (>= 1.61.1). One caveat is that this combination hasn't been tested against an old version of the compiler. At least, this enables `planner_ompl` on Ubuntu Bionic, which works well.