### PR TITLE
Weighted configuration ranker

### DIFF
--- a/include/aikido/distance/ConfigurationRanker.hpp
+++ b/include/aikido/distance/ConfigurationRanker.hpp
@@ -20,19 +20,12 @@ public:
   ///
   /// \param[in] metaSkeletonStateSpace Statespace of the skeleton.
   /// \param[in] metaSkeleton Metaskeleton of the robot.
-  ConfigurationRanker(
-      statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
-      ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton);
-
-  /// Constructor
-  ///
-  /// \param[in] metaSkeletonStateSpace Statespace of the skeleton.
-  /// \param[in] metaSkeleton Metaskeleton of the robot.
   /// \param[in] weights Weights over the joints to compute distance.
+  /// Defaults to unit vector.
   ConfigurationRanker(
       statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
       ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton,
-      std::vector<double> weights);
+      std::vector<double> weights = std::vector<double>());
 
   /// Destructor
   virtual ~ConfigurationRanker() = default;

--- a/include/aikido/distance/ConfigurationRanker.hpp
+++ b/include/aikido/distance/ConfigurationRanker.hpp
@@ -24,6 +24,16 @@ public:
       statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
       ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton);
 
+  /// Constructor
+  ///
+  /// \param[in] metaSkeletonStateSpace Statespace of the skeleton.
+  /// \param[in] metaSkeleton Metaskeleton of the robot.
+  /// \param[in] weights Weights over the joints to compute distance.
+  ConfigurationRanker(
+      statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
+      ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton,
+      std::vector<double> weights);
+
   /// Destructor
   virtual ~ConfigurationRanker() = default;
 

--- a/include/aikido/distance/JointAvoidanceConfigurationRanker.hpp
+++ b/include/aikido/distance/JointAvoidanceConfigurationRanker.hpp
@@ -20,7 +20,20 @@ public:
       statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
       ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton);
 
+  /// Constructor
+  ///
+  /// \param[in] metaSkeletonStateSpace Statespace of the skeleton.
+  /// \param[in] metaSkeleton Metaskeleton of the robot.
+  /// \param[in] weights Weights over joints to compute distance.
+  JointAvoidanceConfigurationRanker(
+      statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
+      ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton,
+      std::vector<double> weights);
+
 protected:
+  /// Set limits appropriately to account for infinite limits.
+  void setupJointLimits();
+
   /// Returns cost as negative of distance from position limits.
   double evaluateConfiguration(
       const statespace::dart::MetaSkeletonStateSpace::State* solution)

--- a/include/aikido/distance/JointAvoidanceConfigurationRanker.hpp
+++ b/include/aikido/distance/JointAvoidanceConfigurationRanker.hpp
@@ -16,19 +16,12 @@ public:
   ///
   /// \param[in] metaSkeletonStateSpace Statespace of the skeleton.
   /// \param[in] metaSkeleton Metaskeleton of the robot.
-  JointAvoidanceConfigurationRanker(
-      statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
-      ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton);
-
-  /// Constructor
-  ///
-  /// \param[in] metaSkeletonStateSpace Statespace of the skeleton.
-  /// \param[in] metaSkeleton Metaskeleton of the robot.
   /// \param[in] weights Weights over joints to compute distance.
+  /// Defaults to unit vector.
   JointAvoidanceConfigurationRanker(
       statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
       ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton,
-      std::vector<double> weights);
+      std::vector<double> weights = std::vector<double>());
 
 protected:
   /// Set limits appropriately to account for infinite limits.

--- a/include/aikido/distance/NominalConfigurationRanker.hpp
+++ b/include/aikido/distance/NominalConfigurationRanker.hpp
@@ -23,6 +23,20 @@ public:
       const statespace::CartesianProduct::State* nominalConfiguration
       = nullptr);
 
+  /// Constructor
+  ///
+  /// \param[in] metaSkeletonStateSpace Statespace of the skeleton.
+  /// \param[in] metaSkeleton Metaskeleton of the robot.
+  /// \param[in] weights Weights over the joints to compute distance.
+  /// \param[in] nominalConfiguration Nominal configuration. The current
+  /// configuration of \c metaSkeleton is considered if set to \c nullptr.
+  NominalConfigurationRanker(
+      statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
+      ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton,
+      std::vector<double> weights,
+      const statespace::CartesianProduct::State* nominalConfiguration
+      = nullptr);
+
 protected:
   /// Returns cost as distance from the Nominal Configuration.
   double evaluateConfiguration(

--- a/include/aikido/distance/NominalConfigurationRanker.hpp
+++ b/include/aikido/distance/NominalConfigurationRanker.hpp
@@ -15,25 +15,14 @@ public:
   ///
   /// \param[in] metaSkeletonStateSpace Statespace of the skeleton.
   /// \param[in] metaSkeleton Metaskeleton of the robot.
-  /// \param[in] nominalConfiguration Nominal configuration. The current
-  /// configuration of \c metaSkeleton is considered if set to \c nullptr.
-  NominalConfigurationRanker(
-      statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
-      ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton,
-      const statespace::CartesianProduct::State* nominalConfiguration
-      = nullptr);
-
-  /// Constructor
-  ///
-  /// \param[in] metaSkeletonStateSpace Statespace of the skeleton.
-  /// \param[in] metaSkeleton Metaskeleton of the robot.
   /// \param[in] weights Weights over the joints to compute distance.
+  /// Defaults to unit vector.
   /// \param[in] nominalConfiguration Nominal configuration. The current
   /// configuration of \c metaSkeleton is considered if set to \c nullptr.
   NominalConfigurationRanker(
       statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
       ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton,
-      std::vector<double> weights,
+      std::vector<double> weights = std::vector<double>(),
       const statespace::CartesianProduct::State* nominalConfiguration
       = nullptr);
 

--- a/src/distance/ConfigurationRanker.cpp
+++ b/src/distance/ConfigurationRanker.cpp
@@ -1,3 +1,5 @@
+#include <dart/common/StlHelpers.hpp>
+
 #include "aikido/distance/ConfigurationRanker.hpp"
 
 namespace aikido {
@@ -5,6 +7,7 @@ namespace distance {
 
 using statespace::dart::ConstMetaSkeletonStateSpacePtr;
 using statespace::dart::MetaSkeletonStateSpace;
+using dart::common::make_unique;
 using ::dart::dynamics::ConstMetaSkeletonPtr;
 
 //==============================================================================
@@ -23,6 +26,48 @@ ConfigurationRanker::ConfigurationRanker(
   mDistanceMetric = createDistanceMetricFor(
       std::dynamic_pointer_cast<const statespace::CartesianProduct>(
           mMetaSkeletonStateSpace));
+}
+
+//==============================================================================
+ConfigurationRanker::ConfigurationRanker(
+    ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
+    ConstMetaSkeletonPtr metaSkeleton,
+    std::vector<double> weights)
+  : mMetaSkeletonStateSpace(std::move(metaSkeletonStateSpace))
+  , mMetaSkeleton(std::move(metaSkeleton))
+{
+  if (!mMetaSkeletonStateSpace)
+    throw std::invalid_argument("MetaSkeletonStateSpace is nullptr.");
+
+  if (!mMetaSkeleton)
+    throw std::invalid_argument("MetaSkeleton is nullptr.");
+
+  if (mMetaSkeletonStateSpace->getDimension() != weights.size())
+    throw std::invalid_argument("Weights should have the same dimension as the MetaSkeletonStateSpace.");
+
+  for (std::size_t i = 0; i < weights.size(); ++i)
+  {
+    if (weights[i] < 0)
+      throw std::invalid_argument("Weights should all be non-negative.");
+  }
+
+  // Create a temporary statespace to setup distance metric with weights.
+  auto _sspace = std::dynamic_pointer_cast<statespace::CartesianProduct>(
+          std::const_pointer_cast<MetaSkeletonStateSpace>(
+              mMetaSkeletonStateSpace));
+  
+  std::vector<std::pair<DistanceMetricPtr, double>> metrics;
+  metrics.reserve(_sspace->getNumSubspaces());
+
+  for (std::size_t i = 0; i < _sspace->getNumSubspaces(); ++i)
+  {
+    auto subspace = _sspace->getSubspace<>(i);
+    auto metric = createDistanceMetric(std::move(subspace));
+    metrics.emplace_back(std::make_pair(std::move(metric), weights[i]));
+  }
+
+  mDistanceMetric = make_unique<CartesianProductWeighted>(
+      std::move(_sspace), std::move(metrics));
 }
 
 //==============================================================================

--- a/src/distance/ConfigurationRanker.cpp
+++ b/src/distance/ConfigurationRanker.cpp
@@ -13,24 +13,6 @@ using ::dart::dynamics::ConstMetaSkeletonPtr;
 //==============================================================================
 ConfigurationRanker::ConfigurationRanker(
     ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
-    ConstMetaSkeletonPtr metaSkeleton)
-  : mMetaSkeletonStateSpace(std::move(metaSkeletonStateSpace))
-  , mMetaSkeleton(std::move(metaSkeleton))
-{
-  if (!mMetaSkeletonStateSpace)
-    throw std::invalid_argument("MetaSkeletonStateSpace is nullptr.");
-
-  if (!mMetaSkeleton)
-    throw std::invalid_argument("MetaSkeleton is nullptr.");
-
-  mDistanceMetric = createDistanceMetricFor(
-      std::dynamic_pointer_cast<const statespace::CartesianProduct>(
-          mMetaSkeletonStateSpace));
-}
-
-//==============================================================================
-ConfigurationRanker::ConfigurationRanker(
-    ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
     ConstMetaSkeletonPtr metaSkeleton,
     std::vector<double> weights)
   : mMetaSkeletonStateSpace(std::move(metaSkeletonStateSpace))
@@ -42,15 +24,21 @@ ConfigurationRanker::ConfigurationRanker(
   if (!mMetaSkeleton)
     throw std::invalid_argument("MetaSkeleton is nullptr.");
 
-  if (mMetaSkeletonStateSpace->getDimension() != weights.size())
-    throw std::invalid_argument(
-        "Weights should have the same dimension as the "
-        "MetaSkeletonStateSpace.");
-
-  for (std::size_t i = 0; i < weights.size(); ++i)
+  if (weights.size() != 0)
   {
-    if (weights[i] < 0)
-      throw std::invalid_argument("Weights should all be non-negative.");
+    for (std::size_t i = 0; i < weights.size(); ++i)
+    {
+      if (weights[i] < 0)
+        throw std::invalid_argument("Weights should all be non-negative.");
+    }
+  }
+  else
+  {
+    weights.resize(mMetaSkeletonStateSpace->getDimension());
+    for (std::size_t i = 0; i < weights.size(); ++i)
+    {
+      weights[i] = 1;
+    } 
   }
 
   // Create a temporary statespace to setup distance metric with weights.

--- a/src/distance/ConfigurationRanker.cpp
+++ b/src/distance/ConfigurationRanker.cpp
@@ -43,7 +43,9 @@ ConfigurationRanker::ConfigurationRanker(
     throw std::invalid_argument("MetaSkeleton is nullptr.");
 
   if (mMetaSkeletonStateSpace->getDimension() != weights.size())
-    throw std::invalid_argument("Weights should have the same dimension as the MetaSkeletonStateSpace.");
+    throw std::invalid_argument(
+        "Weights should have the same dimension as the "
+        "MetaSkeletonStateSpace.");
 
   for (std::size_t i = 0; i < weights.size(); ++i)
   {
@@ -53,9 +55,8 @@ ConfigurationRanker::ConfigurationRanker(
 
   // Create a temporary statespace to setup distance metric with weights.
   auto _sspace = std::dynamic_pointer_cast<statespace::CartesianProduct>(
-          std::const_pointer_cast<MetaSkeletonStateSpace>(
-              mMetaSkeletonStateSpace));
-  
+      std::const_pointer_cast<MetaSkeletonStateSpace>(mMetaSkeletonStateSpace));
+
   std::vector<std::pair<DistanceMetricPtr, double>> metrics;
   metrics.reserve(_sspace->getNumSubspaces());
 

--- a/src/distance/JointAvoidanceConfigurationRanker.cpp
+++ b/src/distance/JointAvoidanceConfigurationRanker.cpp
@@ -9,18 +9,6 @@ using ::dart::dynamics::ConstMetaSkeletonPtr;
 //==============================================================================
 JointAvoidanceConfigurationRanker::JointAvoidanceConfigurationRanker(
     ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
-    ConstMetaSkeletonPtr metaSkeleton)
-  : ConfigurationRanker(
-        std::move(metaSkeletonStateSpace), std::move(metaSkeleton))
-  , mLowerLimitsState(mMetaSkeletonStateSpace->createState())
-  , mUpperLimitsState(mMetaSkeletonStateSpace->createState())
-{
-  setupJointLimits();
-}
-
-//==============================================================================
-JointAvoidanceConfigurationRanker::JointAvoidanceConfigurationRanker(
-    ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
     ConstMetaSkeletonPtr metaSkeleton,
     std::vector<double> weights)
   : ConfigurationRanker(

--- a/src/distance/JointAvoidanceConfigurationRanker.cpp
+++ b/src/distance/JointAvoidanceConfigurationRanker.cpp
@@ -15,6 +15,25 @@ JointAvoidanceConfigurationRanker::JointAvoidanceConfigurationRanker(
   , mLowerLimitsState(mMetaSkeletonStateSpace->createState())
   , mUpperLimitsState(mMetaSkeletonStateSpace->createState())
 {
+  setupJointLimits();
+}
+
+//==============================================================================
+JointAvoidanceConfigurationRanker::JointAvoidanceConfigurationRanker(
+    ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
+    ConstMetaSkeletonPtr metaSkeleton,
+    std::vector<double> weights)
+  : ConfigurationRanker(
+        std::move(metaSkeletonStateSpace), std::move(metaSkeleton), weights)
+  , mLowerLimitsState(mMetaSkeletonStateSpace->createState())
+  , mUpperLimitsState(mMetaSkeletonStateSpace->createState())
+{
+  setupJointLimits();
+}
+
+//==============================================================================
+void JointAvoidanceConfigurationRanker::setupJointLimits()
+{
   auto lowerLimits = mMetaSkeleton->getPositionLowerLimits();
   auto upperLimits = mMetaSkeleton->getPositionUpperLimits();
 

--- a/src/distance/NominalConfigurationRanker.cpp
+++ b/src/distance/NominalConfigurationRanker.cpp
@@ -10,21 +10,6 @@ using ::dart::dynamics::ConstMetaSkeletonPtr;
 NominalConfigurationRanker::NominalConfigurationRanker(
     ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
     ConstMetaSkeletonPtr metaSkeleton,
-    const statespace::CartesianProduct::State* nominalConfiguration)
-  : ConfigurationRanker(
-        std::move(metaSkeletonStateSpace), std::move(metaSkeleton))
-  , mNominalConfiguration(nominalConfiguration)
-{
-  if (!mNominalConfiguration)
-    mNominalConfiguration
-        = mMetaSkeletonStateSpace->getScopedStateFromMetaSkeleton(
-            mMetaSkeleton.get());
-}
-
-//==============================================================================
-NominalConfigurationRanker::NominalConfigurationRanker(
-    ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
-    ConstMetaSkeletonPtr metaSkeleton,
     std::vector<double> weights,
     const statespace::CartesianProduct::State* nominalConfiguration)
   : ConfigurationRanker(

--- a/src/distance/NominalConfigurationRanker.cpp
+++ b/src/distance/NominalConfigurationRanker.cpp
@@ -22,6 +22,22 @@ NominalConfigurationRanker::NominalConfigurationRanker(
 }
 
 //==============================================================================
+NominalConfigurationRanker::NominalConfigurationRanker(
+    ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
+    ConstMetaSkeletonPtr metaSkeleton,
+    std::vector<double> weights,
+    const statespace::CartesianProduct::State* nominalConfiguration)
+  : ConfigurationRanker(
+        std::move(metaSkeletonStateSpace), std::move(metaSkeleton), weights)
+  , mNominalConfiguration(nominalConfiguration)
+{
+  if (!mNominalConfiguration)
+    mNominalConfiguration
+        = mMetaSkeletonStateSpace->getScopedStateFromMetaSkeleton(
+            mMetaSkeleton.get());
+}
+
+//==============================================================================
 double NominalConfigurationRanker::evaluateConfiguration(
     const statespace::dart::MetaSkeletonStateSpace::State* solution) const
 {

--- a/tests/distance/test_JointAvoidanceConfigurationRanker.cpp
+++ b/tests/distance/test_JointAvoidanceConfigurationRanker.cpp
@@ -82,19 +82,22 @@ TEST_F(JointAvoidanceConfigurationRankerTest, Constructor)
 
   std::vector<double> negativeWeights{-1, 0};
   EXPECT_THROW(
-      JointAvoidanceConfigurationRanker(mStateSpace, mManipulator, negativeWeights),
+      JointAvoidanceConfigurationRanker(
+          mStateSpace, mManipulator, negativeWeights),
       std::invalid_argument);
 
   std::vector<double> wrongDimensionWeights{1};
   EXPECT_THROW(
-      JointAvoidanceConfigurationRanker(mStateSpace, mManipulator, wrongDimensionWeights),
+      JointAvoidanceConfigurationRanker(
+          mStateSpace, mManipulator, wrongDimensionWeights),
       std::invalid_argument);
 
   JointAvoidanceConfigurationRanker rankerOne(mStateSpace, mManipulator);
   DART_UNUSED(rankerOne);
 
   std::vector<double> goodWeights{1, 2};
-  JointAvoidanceConfigurationRanker rankerTwo(mStateSpace, mManipulator, goodWeights);
+  JointAvoidanceConfigurationRanker rankerTwo(
+      mStateSpace, mManipulator, goodWeights);
   DART_UNUSED(rankerTwo);
 }
 

--- a/tests/distance/test_JointAvoidanceConfigurationRanker.cpp
+++ b/tests/distance/test_JointAvoidanceConfigurationRanker.cpp
@@ -86,12 +86,6 @@ TEST_F(JointAvoidanceConfigurationRankerTest, Constructor)
           mStateSpace, mManipulator, negativeWeights),
       std::invalid_argument);
 
-  std::vector<double> wrongDimensionWeights{1};
-  EXPECT_THROW(
-      JointAvoidanceConfigurationRanker(
-          mStateSpace, mManipulator, wrongDimensionWeights),
-      std::invalid_argument);
-
   JointAvoidanceConfigurationRanker rankerOne(mStateSpace, mManipulator);
   DART_UNUSED(rankerOne);
 

--- a/tests/distance/test_JointAvoidanceConfigurationRanker.cpp
+++ b/tests/distance/test_JointAvoidanceConfigurationRanker.cpp
@@ -80,8 +80,22 @@ TEST_F(JointAvoidanceConfigurationRankerTest, Constructor)
       JointAvoidanceConfigurationRanker(mStateSpace, nullptr),
       std::invalid_argument);
 
-  JointAvoidanceConfigurationRanker ranker(mStateSpace, mManipulator);
-  DART_UNUSED(ranker);
+  std::vector<double> negativeWeights{-1, 0};
+  EXPECT_THROW(
+      JointAvoidanceConfigurationRanker(mStateSpace, mManipulator, negativeWeights),
+      std::invalid_argument);
+
+  std::vector<double> wrongDimensionWeights{1};
+  EXPECT_THROW(
+      JointAvoidanceConfigurationRanker(mStateSpace, mManipulator, wrongDimensionWeights),
+      std::invalid_argument);
+
+  JointAvoidanceConfigurationRanker rankerOne(mStateSpace, mManipulator);
+  DART_UNUSED(rankerOne);
+
+  std::vector<double> goodWeights{1, 2};
+  JointAvoidanceConfigurationRanker rankerTwo(mStateSpace, mManipulator, goodWeights);
+  DART_UNUSED(rankerTwo);
 }
 
 TEST_F(JointAvoidanceConfigurationRankerTest, OrderTest)
@@ -99,6 +113,35 @@ TEST_F(JointAvoidanceConfigurationRankerTest, OrderTest)
   }
 
   JointAvoidanceConfigurationRanker ranker(mStateSpace, mManipulator);
+  ranker.rankConfigurations(states);
+
+  Eigen::VectorXd rankedState(2);
+  jointPositions[0] = Eigen::Vector2d(0.3, 0.1);
+  jointPositions[1] = Eigen::Vector2d(0.2, 0.1);
+  jointPositions[2] = Eigen::Vector2d(0.1, 0.4);
+  for (std::size_t i = 0; i < states.size(); ++i)
+  {
+    mStateSpace->convertStateToPositions(states[i], rankedState);
+    EXPECT_EIGEN_EQUAL(rankedState, jointPositions[i], EPS);
+  }
+}
+
+TEST_F(JointAvoidanceConfigurationRankerTest, WeightedOrderTest)
+{
+  std::vector<Eigen::Vector2d> jointPositions{Eigen::Vector2d(0.3, 0.1),
+                                              Eigen::Vector2d(0.1, 0.4),
+                                              Eigen::Vector2d(0.2, 0.1)};
+
+  std::vector<aikido::statespace::CartesianProduct::ScopedState> states;
+  for (std::size_t i = 0; i < jointPositions.size(); ++i)
+  {
+    auto state = mStateSpace->createState();
+    mStateSpace->convertPositionsToState(jointPositions[i], state);
+    states.emplace_back(state.clone());
+  }
+
+  std::vector<double> weights{10, 1};
+  JointAvoidanceConfigurationRanker ranker(mStateSpace, mManipulator, weights);
   ranker.rankConfigurations(states);
 
   Eigen::VectorXd rankedState(2);

--- a/tests/distance/test_NominalConfigurationRanker.cpp
+++ b/tests/distance/test_NominalConfigurationRanker.cpp
@@ -67,31 +67,25 @@ protected:
 TEST_F(NominalConfigurationRankerTest, Constructor)
 {
   EXPECT_THROW(
-      NominalConfigurationRanker(nullptr, mManipulator, nullptr),
+      NominalConfigurationRanker(nullptr, mManipulator),
       std::invalid_argument);
 
   EXPECT_THROW(
-      NominalConfigurationRanker(mStateSpace, nullptr, nullptr),
+      NominalConfigurationRanker(mStateSpace, nullptr),
       std::invalid_argument);
 
   std::vector<double> negativeWeights{-1, 0};
   EXPECT_THROW(
       NominalConfigurationRanker(
-          mStateSpace, mManipulator, negativeWeights, nullptr),
+          mStateSpace, mManipulator, negativeWeights),
       std::invalid_argument);
 
-  std::vector<double> wrongDimensionWeights{1};
-  EXPECT_THROW(
-      NominalConfigurationRanker(
-          mStateSpace, mManipulator, wrongDimensionWeights, nullptr),
-      std::invalid_argument);
-
-  NominalConfigurationRanker rankerOne(mStateSpace, mManipulator, nullptr);
+  NominalConfigurationRanker rankerOne(mStateSpace, mManipulator);
   DART_UNUSED(rankerOne);
 
   std::vector<double> goodWeights{1, 2};
   NominalConfigurationRanker rankerTwo(
-      mStateSpace, mManipulator, goodWeights, nullptr);
+      mStateSpace, mManipulator, goodWeights);
   DART_UNUSED(rankerTwo);
 }
 
@@ -112,8 +106,7 @@ TEST_F(NominalConfigurationRankerTest, OrderTest)
   mManipulator->setPositions(Eigen::Vector2d(0.0, 0.0));
   NominalConfigurationRanker ranker(
       mStateSpace,
-      mManipulator,
-      mStateSpace->getScopedStateFromMetaSkeleton(mManipulator.get()));
+      mManipulator);
   ranker.rankConfigurations(states);
 
   Eigen::VectorXd rankedState(2);

--- a/tests/distance/test_NominalConfigurationRanker.cpp
+++ b/tests/distance/test_NominalConfigurationRanker.cpp
@@ -74,8 +74,22 @@ TEST_F(NominalConfigurationRankerTest, Constructor)
       NominalConfigurationRanker(mStateSpace, nullptr, nullptr),
       std::invalid_argument);
 
-  NominalConfigurationRanker ranker(mStateSpace, mManipulator, nullptr);
-  DART_UNUSED(ranker);
+  std::vector<double> negativeWeights{-1, 0};
+  EXPECT_THROW(
+      NominalConfigurationRanker(mStateSpace, mManipulator, negativeWeights, nullptr),
+      std::invalid_argument);
+
+  std::vector<double> wrongDimensionWeights{1};
+  EXPECT_THROW(
+      NominalConfigurationRanker(mStateSpace, mManipulator, wrongDimensionWeights, nullptr),
+      std::invalid_argument);
+
+  NominalConfigurationRanker rankerOne(mStateSpace, mManipulator, nullptr);
+  DART_UNUSED(rankerOne);
+
+  std::vector<double> goodWeights{1, 2};
+  NominalConfigurationRanker rankerTwo(mStateSpace, mManipulator, goodWeights, nullptr);
+  DART_UNUSED(rankerTwo);
 }
 
 TEST_F(NominalConfigurationRankerTest, OrderTest)
@@ -103,6 +117,40 @@ TEST_F(NominalConfigurationRankerTest, OrderTest)
   jointPositions[0] = Eigen::Vector2d(0.1, 0.1);
   jointPositions[1] = Eigen::Vector2d(0.2, 0.2);
   jointPositions[2] = Eigen::Vector2d(0.3, 0.3);
+  for (std::size_t i = 0; i < states.size(); ++i)
+  {
+    mStateSpace->convertStateToPositions(states[i], rankedState);
+    EXPECT_EIGEN_EQUAL(rankedState, jointPositions[i], EPS);
+  }
+}
+
+TEST_F(NominalConfigurationRankerTest, WeightedOrderTest)
+{
+  std::vector<Eigen::Vector2d> jointPositions{Eigen::Vector2d(0.2, 0.5),
+                                              Eigen::Vector2d(0.1, 0.6),
+                                              Eigen::Vector2d(0.5, 0.1)};
+
+  std::vector<aikido::statespace::CartesianProduct::ScopedState> states;
+  for (std::size_t i = 0; i < jointPositions.size(); ++i)
+  {
+    auto state = mStateSpace->createState();
+    mStateSpace->convertPositionsToState(jointPositions[i], state);
+    states.emplace_back(state.clone());
+  }
+
+  mManipulator->setPositions(Eigen::Vector2d(0.0, 0.0));
+  std::vector<double> weights{10, 1};
+  NominalConfigurationRanker ranker(
+      mStateSpace,
+      mManipulator,
+      weights,
+      mStateSpace->getScopedStateFromMetaSkeleton(mManipulator.get()));
+  ranker.rankConfigurations(states);
+
+  Eigen::VectorXd rankedState(2);
+  jointPositions[0] = Eigen::Vector2d(0.1, 0.6);
+  jointPositions[1] = Eigen::Vector2d(0.2, 0.5);
+  jointPositions[2] = Eigen::Vector2d(0.5, 0.1);
   for (std::size_t i = 0; i < states.size(); ++i)
   {
     mStateSpace->convertStateToPositions(states[i], rankedState);

--- a/tests/distance/test_NominalConfigurationRanker.cpp
+++ b/tests/distance/test_NominalConfigurationRanker.cpp
@@ -76,19 +76,22 @@ TEST_F(NominalConfigurationRankerTest, Constructor)
 
   std::vector<double> negativeWeights{-1, 0};
   EXPECT_THROW(
-      NominalConfigurationRanker(mStateSpace, mManipulator, negativeWeights, nullptr),
+      NominalConfigurationRanker(
+          mStateSpace, mManipulator, negativeWeights, nullptr),
       std::invalid_argument);
 
   std::vector<double> wrongDimensionWeights{1};
   EXPECT_THROW(
-      NominalConfigurationRanker(mStateSpace, mManipulator, wrongDimensionWeights, nullptr),
+      NominalConfigurationRanker(
+          mStateSpace, mManipulator, wrongDimensionWeights, nullptr),
       std::invalid_argument);
 
   NominalConfigurationRanker rankerOne(mStateSpace, mManipulator, nullptr);
   DART_UNUSED(rankerOne);
 
   std::vector<double> goodWeights{1, 2};
-  NominalConfigurationRanker rankerTwo(mStateSpace, mManipulator, goodWeights, nullptr);
+  NominalConfigurationRanker rankerTwo(
+      mStateSpace, mManipulator, goodWeights, nullptr);
   DART_UNUSED(rankerTwo);
 }
 


### PR DESCRIPTION
Allow to set weights for distance computation in configuration ranking

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
