### PR TITLE
Add CartesianProductMetaSkeletonStateSpace

### DIFF
--- a/include/aikido/statespace/CartesianProduct.hpp
+++ b/include/aikido/statespace/CartesianProduct.hpp
@@ -7,6 +7,8 @@
 namespace aikido {
 namespace statespace {
 
+AIKIDO_DECLARE_POINTERS(CartesianProduct)
+
 // Defined in detail/CartesianProduct.hpp
 template <class>
 class CompoundStateHandle;

--- a/include/aikido/statespace/dart/CartesianProductMetaSkeletonStateSpace.hpp
+++ b/include/aikido/statespace/dart/CartesianProductMetaSkeletonStateSpace.hpp
@@ -10,10 +10,13 @@ namespace dart {
 
 AIKIDO_DECLARE_POINTERS(CartesianProductMetaSkeletonStateSpace)
 
-/// \c StateSpace of a DART \c MetaSkeleton with artificially created state space.
-/// It is a CartesianProduct but has access to the original MetaSkeletonStateSpace.
-/// This class is necessary when a different state space from MetaSkeletonStateSpace
-/// needs to be used, e.g. for the control of SO2 joint..
+/// \c StateSpace of a DART \c MetaSkeleton with artificially created state
+/// space.
+/// It is a CartesianProduct but has access to the original
+/// MetaSkeletonStateSpace.
+/// This class is necessary when a different state space from
+/// MetaSkeletonStateSpace
+/// needs to be used, e.g. for the control of SO2 joint.
 class CartesianProductMetaSkeletonStateSpace : public CartesianProduct
 {
 public:
@@ -21,8 +24,8 @@ public:
   /// \param[in] subspaces vector of subspaces
   /// \param[in] metaSkeletonStateSpace
   explicit CartesianProductMetaSkeletonStateSpace(
-    std::vector<ConstStateSpacePtr> subspaces,
-    ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace);
+      std::vector<ConstStateSpacePtr> subspaces,
+      ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace);
 
   /// \return MetaSkeletonStateSpace associated with this statespace.
   ConstMetaSkeletonStateSpacePtr getMetaSkeletonStateSpace() const;

--- a/include/aikido/statespace/dart/CartesianProductMetaSkeletonStateSpace.hpp
+++ b/include/aikido/statespace/dart/CartesianProductMetaSkeletonStateSpace.hpp
@@ -21,7 +21,7 @@ class CartesianProductMetaSkeletonStateSpace : public CartesianProduct
 {
 public:
   /// Constructor.
-  /// \param[in] subspaces vector of subspaces
+  /// \param[in] subspaces Vector of subspaces
   /// \param[in] metaSkeletonStateSpace
   explicit CartesianProductMetaSkeletonStateSpace(
       std::vector<ConstStateSpacePtr> subspaces,

--- a/include/aikido/statespace/dart/CartesianProductMetaSkeletonStateSpace.hpp
+++ b/include/aikido/statespace/dart/CartesianProductMetaSkeletonStateSpace.hpp
@@ -22,7 +22,7 @@ class CartesianProductMetaSkeletonStateSpace : public CartesianProduct
 public:
   /// Constructor.
   /// \param[in] subspaces Vector of subspaces
-  /// \param[in] metaSkeletonStateSpace
+  /// \param[in] metaSkeletonStateSpace Original metaskeletonStateSpace
   explicit CartesianProductMetaSkeletonStateSpace(
       std::vector<ConstStateSpacePtr> subspaces,
       ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace);

--- a/include/aikido/statespace/dart/CartesianProductMetaSkeletonStateSpace.hpp
+++ b/include/aikido/statespace/dart/CartesianProductMetaSkeletonStateSpace.hpp
@@ -1,0 +1,38 @@
+#ifndef AIKIDO_STATESPACE_DART_CARTESIANPRODUCTMETASKELETONSTATESPACE_HPP_
+#define AIKIDO_STATESPACE_DART_CARTESIANPRODUCTMETASKELETONSTATESPACE_HPP_
+
+#include "aikido/statespace/CartesianProduct.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
+
+namespace aikido {
+namespace statespace {
+namespace dart {
+
+AIKIDO_DECLARE_POINTERS(CartesianProductMetaSkeletonStateSpace)
+
+/// \c StateSpace of a DART \c MetaSkeleton with artificially created state space.
+/// It is a CartesianProduct but has access to the original MetaSkeletonStateSpace.
+/// This class is necessary when a different state space from MetaSkeletonStateSpace
+/// needs to be used, e.g. for the control of SO2 joint..
+class CartesianProductMetaSkeletonStateSpace : public CartesianProduct
+{
+public:
+  /// Constructor.
+  /// \param[in] subspaces vector of subspaces
+  /// \param[in] metaSkeletonStateSpace
+  explicit CartesianProductMetaSkeletonStateSpace(
+    std::vector<ConstStateSpacePtr> subspaces,
+    ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace);
+
+  /// \return MetaSkeletonStateSpace associated with this statespace.
+  ConstMetaSkeletonStateSpacePtr getMetaSkeletonStateSpace() const;
+
+private:
+  ConstMetaSkeletonStateSpacePtr mMetaSkeletonStateSpace;
+};
+
+} // namespace dart
+} // namespace statespace
+} // namespace aikido
+
+#endif

--- a/src/control/KinematicSimulationTrajectoryExecutor.cpp
+++ b/src/control/KinematicSimulationTrajectoryExecutor.cpp
@@ -52,12 +52,12 @@ void KinematicSimulationTrajectoryExecutor::validate(
   if (mValidatedTrajectories.find(traj) != mValidatedTrajectories.end())
     return;
 
-  auto space = std::dynamic_pointer_cast<const MetaSkeletonStateSpace>(
+  const auto space = std::dynamic_pointer_cast<const MetaSkeletonStateSpace>(
       traj->getStateSpace());
 
   if (!space)
   {
-    auto cpSpace = std::dynamic_pointer_cast<const CartesianProductMetaSkeletonStateSpace>(
+    const auto cpSpace = std::dynamic_pointer_cast<const CartesianProductMetaSkeletonStateSpace>(
       traj->getStateSpace());
 
     if (cpSpace)
@@ -176,7 +176,7 @@ void KinematicSimulationTrajectoryExecutor::step(
   if (executionTime < 0)
     return;
 
-  auto cpSpace = std::dynamic_pointer_cast<const CartesianProductMetaSkeletonStateSpace>(
+  const auto cpSpace = std::dynamic_pointer_cast<const CartesianProductMetaSkeletonStateSpace>(
         mTraj->getStateSpace());
 
   if (!cpSpace)

--- a/src/control/KinematicSimulationTrajectoryExecutor.cpp
+++ b/src/control/KinematicSimulationTrajectoryExecutor.cpp
@@ -57,8 +57,9 @@ void KinematicSimulationTrajectoryExecutor::validate(
 
   if (!space)
   {
-    const auto cpSpace = std::dynamic_pointer_cast<const CartesianProductMetaSkeletonStateSpace>(
-      traj->getStateSpace());
+    const auto cpSpace = std::
+        dynamic_pointer_cast<const CartesianProductMetaSkeletonStateSpace>(
+            traj->getStateSpace());
 
     if (cpSpace)
     {
@@ -70,8 +71,9 @@ void KinematicSimulationTrajectoryExecutor::validate(
         if (!r1)
         {
           std::stringstream message;
-          message << "Trajectory is not in a MetaSkeletonStateSpace"
-          << " or in CartesianProductMetaSkeletonStateSpace of R1 spaces.";
+          message
+              << "Trajectory is not in a MetaSkeletonStateSpace"
+              << " or in CartesianProductMetaSkeletonStateSpace of R1 spaces.";
           throw std::invalid_argument(message.str());
         }
       }
@@ -80,7 +82,7 @@ void KinematicSimulationTrajectoryExecutor::validate(
     {
       std::stringstream message;
       message << "Trajectory is not in a MetaSkeletonStateSpace"
-      << "nor in CartesianProductMetaSkeletonStateSpace.";
+              << "nor in CartesianProductMetaSkeletonStateSpace.";
       throw std::invalid_argument(message.str());
     }
   }
@@ -117,17 +119,19 @@ std::future<void> KinematicSimulationTrajectoryExecutor::execute(
 
     if (!mStateSpace)
     {
-      auto cpSpace = std::dynamic_pointer_cast<const CartesianProductMetaSkeletonStateSpace>(
-        mTraj->getStateSpace());
+      auto cpSpace = std::
+          dynamic_pointer_cast<const CartesianProductMetaSkeletonStateSpace>(
+              mTraj->getStateSpace());
       if (!cpSpace)
         throw std::invalid_argument("Invalid");
       mStateSpace = std::dynamic_pointer_cast<const MetaSkeletonStateSpace>(
-        cpSpace->getMetaSkeletonStateSpace());
+          cpSpace->getMetaSkeletonStateSpace());
     }
 
     if (!mStateSpace)
       throw std::invalid_argument(
-        "Statespace needs to be either MetaSkeletonStateSpace or CartesianProduct.");
+          "Statespace needs to be either MetaSkeletonStateSpace or "
+          "CartesianProduct.");
 
     mInProgress = true;
     mExecutionStartTime = std::chrono::system_clock::now();
@@ -176,8 +180,9 @@ void KinematicSimulationTrajectoryExecutor::step(
   if (executionTime < 0)
     return;
 
-  const auto cpSpace = std::dynamic_pointer_cast<const CartesianProductMetaSkeletonStateSpace>(
-        mTraj->getStateSpace());
+  const auto cpSpace
+      = std::dynamic_pointer_cast<const CartesianProductMetaSkeletonStateSpace>(
+          mTraj->getStateSpace());
 
   if (!cpSpace)
   {

--- a/src/control/KinematicSimulationTrajectoryExecutor.cpp
+++ b/src/control/KinematicSimulationTrajectoryExecutor.cpp
@@ -2,8 +2,12 @@
 #include <dart/common/Console.hpp>
 #include <dart/common/StlHelpers.hpp>
 #include "aikido/control/TrajectoryRunningException.hpp"
+#include "aikido/statespace/Rn.hpp"
+#include "aikido/statespace/dart/CartesianProductMetaSkeletonStateSpace.hpp"
 
 using aikido::statespace::dart::MetaSkeletonStateSpace;
+using aikido::statespace::dart::CartesianProductMetaSkeletonStateSpace;
+using aikido::statespace::R1;
 
 namespace aikido {
 namespace control {
@@ -48,18 +52,44 @@ void KinematicSimulationTrajectoryExecutor::validate(
   if (mValidatedTrajectories.find(traj) != mValidatedTrajectories.end())
     return;
 
-  const auto space = std::dynamic_pointer_cast<const MetaSkeletonStateSpace>(
+  auto space = std::dynamic_pointer_cast<const MetaSkeletonStateSpace>(
       traj->getStateSpace());
 
   if (!space)
   {
-    throw std::invalid_argument(
-        "Trajectory is not in a MetaSkeletonStateSpace.");
-  }
+    auto cpSpace = std::dynamic_pointer_cast<const CartesianProductMetaSkeletonStateSpace>(
+      traj->getStateSpace());
 
-  // TODO: Delete this line once the skeleton is locked by isCompatible
-  std::lock_guard<std::mutex> lock(mSkeleton->getMutex());
-  space->checkIfContained(mSkeleton.get());
+    if (cpSpace)
+    {
+      // Check that all joints are R1 state spaces.
+      for (std::size_t i = 0; i < cpSpace->getNumSubspaces(); ++i)
+      {
+        auto subSpace = cpSpace->getSubspace(i);
+        auto r1 = std::dynamic_pointer_cast<const R1>(subSpace);
+        if (!r1)
+        {
+          std::stringstream message;
+          message << "Trajectory is not in a MetaSkeletonStateSpace"
+          << " or in CartesianProductMetaSkeletonStateSpace of R1 spaces.";
+          throw std::invalid_argument(message.str());
+        }
+      }
+    }
+    else
+    {
+      std::stringstream message;
+      message << "Trajectory is not in a MetaSkeletonStateSpace"
+      << "nor in CartesianProductMetaSkeletonStateSpace.";
+      throw std::invalid_argument(message.str());
+    }
+  }
+  else
+  {
+    // TODO: Delete this line once the skeleton is locked by isCompatible
+    std::lock_guard<std::mutex> lock(mSkeleton->getMutex());
+    space->checkIfContained(mSkeleton.get());
+  }
 
   mValidatedTrajectories.emplace(traj);
 }
@@ -84,6 +114,21 @@ std::future<void> KinematicSimulationTrajectoryExecutor::execute(
     mTraj = std::move(traj);
     mStateSpace = std::dynamic_pointer_cast<const MetaSkeletonStateSpace>(
         mTraj->getStateSpace());
+
+    if (!mStateSpace)
+    {
+      auto cpSpace = std::dynamic_pointer_cast<const CartesianProductMetaSkeletonStateSpace>(
+        mTraj->getStateSpace());
+      if (!cpSpace)
+        throw std::invalid_argument("Invalid");
+      mStateSpace = std::dynamic_pointer_cast<const MetaSkeletonStateSpace>(
+        cpSpace->getMetaSkeletonStateSpace());
+    }
+
+    if (!mStateSpace)
+      throw std::invalid_argument(
+        "Statespace needs to be either MetaSkeletonStateSpace or CartesianProduct.");
+
     mInProgress = true;
     mExecutionStartTime = std::chrono::system_clock::now();
     mMetaSkeleton = mStateSpace->getControlledMetaSkeleton(mSkeleton);
@@ -131,10 +176,25 @@ void KinematicSimulationTrajectoryExecutor::step(
   if (executionTime < 0)
     return;
 
-  auto state = mStateSpace->createState();
-  mTraj->evaluate(executionTime, state);
+  auto cpSpace = std::dynamic_pointer_cast<const CartesianProductMetaSkeletonStateSpace>(
+        mTraj->getStateSpace());
 
-  mStateSpace->setState(mMetaSkeleton.get(), state);
+  if (!cpSpace)
+  {
+    auto state = mStateSpace->createState();
+    mTraj->evaluate(executionTime, state);
+    mStateSpace->setState(mMetaSkeleton.get(), state);
+  }
+  else
+  {
+    auto state = cpSpace->createState();
+    mTraj->evaluate(executionTime, state);
+
+    // Convert to position vector and then set the metaskeleton.
+    Eigen::VectorXd tangent;
+    cpSpace->logMap(state, tangent);
+    mMetaSkeleton->setPositions(tangent);
+  }
 
   // Check if trajectory has completed.
   if (executionTime >= mTraj->getEndTime())

--- a/src/planner/kunzretimer/KunzRetimer.cpp
+++ b/src/planner/kunzretimer/KunzRetimer.cpp
@@ -24,7 +24,8 @@ namespace kunzretimer {
 namespace detail {
 //==============================================================================
 std::unique_ptr<Path> convertToKunzPath(
-    const aikido::trajectory::Interpolated& traj, double maxDeviation,
+    const aikido::trajectory::Interpolated& traj,
+    double maxDeviation,
     statespace::ConstStateSpacePtr& outputStateSpace)
 {
   auto stateSpace = traj.getStateSpace();
@@ -57,7 +58,8 @@ std::unique_ptr<Path> convertToKunzPath(
 
 //==============================================================================
 std::unique_ptr<Path> convertToKunzPath(
-    const aikido::trajectory::Spline& traj, double maxDeviation,
+    const aikido::trajectory::Spline& traj,
+    double maxDeviation,
     statespace::ConstStateSpacePtr& outputStateSpace)
 {
   auto stateSpace = traj.getStateSpace();
@@ -180,11 +182,12 @@ std::unique_ptr<aikido::trajectory::Spline> computeKunzTiming(
 
   ConstStateSpacePtr outputStateSpace;
   auto path = detail::convertToKunzPath(
-    inputTrajectory, maxDeviation, outputStateSpace);
+      inputTrajectory, maxDeviation, outputStateSpace);
 
   Trajectory trajectory(*path, maxVelocity, maxAcceleration, timeStep);
 
-  return detail::convertToSpline(trajectory, outputStateSpace, timeStep, startTime);
+  return detail::convertToSpline(
+      trajectory, outputStateSpace, timeStep, startTime);
 }
 
 //==============================================================================
@@ -221,11 +224,12 @@ std::unique_ptr<aikido::trajectory::Spline> computeKunzTiming(
 
   ConstStateSpacePtr outputStateSpace;
   auto path = detail::convertToKunzPath(
-    inputTrajectory, maxDeviation, outputStateSpace);
+      inputTrajectory, maxDeviation, outputStateSpace);
 
   Trajectory trajectory(*path, maxVelocity, maxAcceleration, timeStep);
 
-  return detail::convertToSpline(trajectory, outputStateSpace, timeStep, startTime);
+  return detail::convertToSpline(
+      trajectory, outputStateSpace, timeStep, startTime);
 }
 
 //==============================================================================

--- a/src/statespace/CMakeLists.txt
+++ b/src/statespace/CMakeLists.txt
@@ -7,6 +7,7 @@ set(sources
   SO2.cpp
   SO3.cpp
   GeodesicInterpolator.cpp
+  dart/CartesianProductMetaSkeletonStateSpace.cpp
   dart/JointStateSpace.cpp
   dart/JointStateSpaceHelpers.cpp
   dart/MetaSkeletonStateSpace.cpp

--- a/src/statespace/dart/CartesianProductMetaSkeletonStateSpace.cpp
+++ b/src/statespace/dart/CartesianProductMetaSkeletonStateSpace.cpp
@@ -1,0 +1,25 @@
+#include "aikido/statespace/dart/CartesianProductMetaSkeletonStateSpace.hpp"
+
+namespace aikido {
+namespace statespace {
+namespace dart {
+
+//==============================================================================
+CartesianProductMetaSkeletonStateSpace::CartesianProductMetaSkeletonStateSpace(
+  std::vector<ConstStateSpacePtr> subspaces,
+  ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace)
+: CartesianProduct(std::move(subspaces))
+, mMetaSkeletonStateSpace(std::move(metaSkeletonStateSpace))
+{
+  // do nothing.
+}
+
+//==============================================================================
+ConstMetaSkeletonStateSpacePtr CartesianProductMetaSkeletonStateSpace::getMetaSkeletonStateSpace() const
+{
+  return mMetaSkeletonStateSpace;
+}
+
+} // namespace dart
+} // namespace statespace
+} // namespace aikido

--- a/src/statespace/dart/CartesianProductMetaSkeletonStateSpace.cpp
+++ b/src/statespace/dart/CartesianProductMetaSkeletonStateSpace.cpp
@@ -6,16 +6,17 @@ namespace dart {
 
 //==============================================================================
 CartesianProductMetaSkeletonStateSpace::CartesianProductMetaSkeletonStateSpace(
-  std::vector<ConstStateSpacePtr> subspaces,
-  ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace)
-: CartesianProduct(std::move(subspaces))
-, mMetaSkeletonStateSpace(std::move(metaSkeletonStateSpace))
+    std::vector<ConstStateSpacePtr> subspaces,
+    ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace)
+  : CartesianProduct(std::move(subspaces))
+  , mMetaSkeletonStateSpace(std::move(metaSkeletonStateSpace))
 {
   // do nothing.
 }
 
 //==============================================================================
-ConstMetaSkeletonStateSpacePtr CartesianProductMetaSkeletonStateSpace::getMetaSkeletonStateSpace() const
+ConstMetaSkeletonStateSpacePtr
+CartesianProductMetaSkeletonStateSpace::getMetaSkeletonStateSpace() const
 {
   return mMetaSkeletonStateSpace;
 }

--- a/src/trajectory/util.cpp
+++ b/src/trajectory/util.cpp
@@ -12,17 +12,21 @@
 #include "aikido/statespace/Rn.hpp"
 #include "aikido/statespace/SO2.hpp"
 #include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
+#include "aikido/statespace/dart/CartesianProductMetaSkeletonStateSpace.hpp"
+
 #include "aikido/trajectory/Interpolated.hpp"
 
 using aikido::statespace::R;
 using aikido::statespace::R1;
 using aikido::statespace::SO2;
 using aikido::statespace::CartesianProduct;
+using aikido::statespace::CartesianProductPtr;
 using aikido::statespace::ConstStateSpacePtr;
 using aikido::statespace::GeodesicInterpolator;
 using aikido::statespace::StateSpacePtr;
 using aikido::statespace::dart::MetaSkeletonStateSpace;
 using aikido::statespace::dart::MetaSkeletonStateSpacePtr;
+using aikido::statespace::dart::CartesianProductMetaSkeletonStateSpace;
 using dart::common::make_unique;
 
 using Eigen::Vector2d;
@@ -383,7 +387,16 @@ aikido::trajectory::ConstInterpolatedPtr toR1JointTrajectory(
   for (std::size_t i = 0; i < space->getDimension(); ++i)
     subspaces.emplace_back(std::make_shared<const R1>());
 
-  auto rSpace = std::make_shared<CartesianProduct>(subspaces);
+  // rSpace needs to contain metaSkeletonStateSpace
+  // if the original space is MetaSkeletonStateSpace.
+  CartesianProductPtr rSpace;
+  auto metaSkeletonStateSpace = std::dynamic_pointer_cast<const MetaSkeletonStateSpace>(space);
+  if (metaSkeletonStateSpace)
+    rSpace = std::make_shared<CartesianProductMetaSkeletonStateSpace>(
+      subspaces, metaSkeletonStateSpace);
+  else
+    rSpace = std::make_shared<CartesianProduct>(subspaces);
+
   auto rInterpolator = std::make_shared<GeodesicInterpolator>(rSpace);
   auto rTrajectory = std::make_shared<Interpolated>(rSpace, rInterpolator);
 

--- a/src/trajectory/util.cpp
+++ b/src/trajectory/util.cpp
@@ -11,8 +11,8 @@
 #include "aikido/statespace/CartesianProduct.hpp"
 #include "aikido/statespace/Rn.hpp"
 #include "aikido/statespace/SO2.hpp"
-#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
 #include "aikido/statespace/dart/CartesianProductMetaSkeletonStateSpace.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
 
 #include "aikido/trajectory/Interpolated.hpp"
 
@@ -390,10 +390,11 @@ aikido::trajectory::ConstInterpolatedPtr toR1JointTrajectory(
   // rSpace needs to contain metaSkeletonStateSpace
   // if the original space is MetaSkeletonStateSpace.
   CartesianProductPtr rSpace;
-  auto metaSkeletonStateSpace = std::dynamic_pointer_cast<const MetaSkeletonStateSpace>(space);
+  auto metaSkeletonStateSpace
+      = std::dynamic_pointer_cast<const MetaSkeletonStateSpace>(space);
   if (metaSkeletonStateSpace)
     rSpace = std::make_shared<CartesianProductMetaSkeletonStateSpace>(
-      subspaces, metaSkeletonStateSpace);
+        subspaces, metaSkeletonStateSpace);
   else
     rSpace = std::make_shared<CartesianProduct>(subspaces);
 

--- a/tests/trajectory/test_util.cpp
+++ b/tests/trajectory/test_util.cpp
@@ -1,15 +1,14 @@
 #include <tuple>
 #include <dart/dart.hpp>
 #include <gtest/gtest.h>
-#include <aikido/statespace/GeodesicInterpolator.hpp>
-#include <aikido/statespace/SO2.hpp>
-#include <aikido/statespace/Rn.hpp>
 #include <aikido/statespace/CartesianProduct.hpp>
+#include <aikido/statespace/GeodesicInterpolator.hpp>
+#include <aikido/statespace/Rn.hpp>
+#include <aikido/statespace/SO2.hpp>
 #include <aikido/statespace/dart/MetaSkeletonStateSpace.hpp>
 
 #include <aikido/trajectory/Interpolated.hpp>
 #include <aikido/trajectory/util.hpp>
-
 
 using std::shared_ptr;
 using std::make_shared;
@@ -59,7 +58,7 @@ TEST_F(TrajectoryConversionTest, SuccessfulConversionToR1)
 
   // Add waypoints
   Eigen::VectorXd stateVector(stateSpace->getDimension());
-  
+
   stateVector << 3.0;
   auto s1 = stateSpace->createState();
   stateSpace->convertPositionsToState(stateVector, s1);
@@ -78,7 +77,8 @@ TEST_F(TrajectoryConversionTest, SuccessfulConversionToR1)
   // Convert the trajectory.
   ConstStateSpacePtr outputStateSpace;
   outputStateSpace = std::move(stateSpace);
-  auto convertedTrajectory = toR1JointTrajectory(outputStateSpace, *(trajectory.get()));
+  auto convertedTrajectory
+      = toR1JointTrajectory(outputStateSpace, *(trajectory.get()));
 
   // // Test the states in the interpolated trajectory.
   std::vector<aikido::statespace::ConstStateSpacePtr> subspaces;
@@ -92,7 +92,7 @@ TEST_F(TrajectoryConversionTest, SuccessfulConversionToR1)
   EXPECT_EQ(3, convertedTrajectory->getNumWaypoints());
 
   Eigen::VectorXd testVector(convertedTrajectory->getNumWaypoints());
-  testVector << 3.0, M_PI, 2*M_PI - 3.0;
+  testVector << 3.0, M_PI, 2 * M_PI - 3.0;
   for (std::size_t i = 0; i < convertedTrajectory->getNumWaypoints(); ++i)
   {
     auto sstate = convertedTrajectory->getWaypoint(i);
@@ -100,7 +100,8 @@ TEST_F(TrajectoryConversionTest, SuccessfulConversionToR1)
     EXPECT_EQ(stateVector(0), testVector(i));
   }
   auto sstate = outputStateSpace->createState();
-  convertedTrajectory->evaluate(convertedTrajectory->getDuration()*0.75, sstate);
+  convertedTrajectory->evaluate(
+      convertedTrajectory->getDuration() * 0.75, sstate);
   outputStateSpace->logMap(sstate, stateVector);
-  EXPECT_EQ(stateVector(0), (testVector(2) + testVector(1))/2.0);
+  EXPECT_EQ(stateVector(0), (testVector(2) + testVector(1)) / 2.0);
 }


### PR DESCRIPTION
This PR adds `CartesianProductMetaSkeletonStateSpace` under dart space and modifies `KinematicSimulationTrajectoryExecutor` to take both `CartesianProductMetaSkeletonStateSpace` and `MetaSkeletonStateSpace`. This is necessary to execute R1 trajectories in simulation.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
