### PR TITLE
Enable -fext-numeric-literals on compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Fixed bug in StepSequence::getMaxSteps(): [#305](https://github.com/personalrobotics/aikido/pull/305)
   * Fixed bug in StepSequence iterator: [#320](https://github.com/personalrobotics/aikido/pull/320)
   * Cleaned up doxygen errors: [#357](https://github.com/personalrobotics/aikido/pull/357)
+  * Fixed bug in compiling with Boost 1.58 on Kinetic + Xenial: [#490](https://github.com/personalrobotics/aikido/pull/490)
 
 * Distance
 

--- a/cmake/CompilerSettings.cmake
+++ b/cmake/CompilerSettings.cmake
@@ -15,6 +15,8 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     )
   endif()
 
+  # Adding -fext-numeric-literals based on
+  # https://svn.boost.org/trac10/ticket/9240.
   set(AIKIDO_CXX_STANDARD_FLAGS -std=c++11 -fext-numeric-literals)
 
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/cmake/CompilerSettings.cmake
+++ b/cmake/CompilerSettings.cmake
@@ -15,7 +15,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     )
   endif()
 
-  set(AIKIDO_CXX_STANDARD_FLAGS -std=c++11)
+  set(AIKIDO_CXX_STANDARD_FLAGS -std=c++11 -fext-numeric-literals)
 
   add_compile_options(-Wall -Wextra -Wpedantic)
   if(TREAT_WARNINGS_AS_ERRORS)


### PR DESCRIPTION
This PR fixes the build issue in xenial + boost 1.58 + kinetic + dart 6.7.2 of
```
/usr/include/boost/math/constants/constants.hpp:277:3: error: unable to find numeric literal operator 'operator""Q'
```
It adds a compiler option.

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [ ] Format code with `make format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
