### PR TITLE
Make code formatting script as a CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,36 +49,6 @@ if(CODECOV)
 endif()
 
 #==============================================================================
-# Automatic code formatting setup
-#
-define_property(GLOBAL PROPERTY CODE_FORMATTING_SOURCES
-  BRIEF_DOCS "Source files that are automatically formatted by clang-format."
-  FULL_DOCS "Source files that are automatically formatted by clang-format."
-)
-
-function(format_add_sources)
-  foreach(source ${ARGN})
-    if(IS_ABSOLUTE "${source}")
-      set(source_abs "${source}")
-    else()
-      get_filename_component(source_abs
-        "${CMAKE_CURRENT_LIST_DIR}/${source}" ABSOLUTE)
-    endif()
-    if(EXISTS "${source_abs}")
-      set_property(GLOBAL APPEND PROPERTY CODE_FORMATTING_SOURCES "${source_abs}")
-    else()
-      message(FATAL_ERROR
-        "Source file '${source}' does not exist at absolute path"
-        " '${source_abs}'. This should never happen. Did you recently delete"
-        " this file or modify 'CMAKE_CURRENT_LIST_DIR'")
-    endif()
-  endforeach()
-endfunction()
-
-file(GLOB_RECURSE aikido_headers "${CMAKE_SOURCE_DIR}/include/*.hpp")
-format_add_sources(${aikido_headers})
-
-#==============================================================================
 # Helper functions.
 #
 function(aikido_space_delimit output_variable input_list)
@@ -108,6 +78,7 @@ include(Components)
 initialize_component_helpers(aikido)
 include(CMakePackageConfigHelpers)
 include(FindPkgConfig)
+include(ClangFormat)
 
 find_package(Boost REQUIRED COMPONENTS filesystem)
 
@@ -143,6 +114,7 @@ find_package(ompl REQUIRED)
 # CompilerSettings optionally requires a custon CMake option
 # TREAT_WARNINGS_AS_ERRORS.
 include(CompilerSettings)
+
 
 #==============================================================================
 # Libraries and unit tests.
@@ -280,46 +252,16 @@ endif()
 #===============================================================================
 # Automatic code formatting using clang-format.
 #
-find_program(
-  CLANG_FORMAT_EXECUTABLE
-  NAMES clang-format-3.8
-)
 # We only support one specific ClangFormat version because different versions
 # result in different code formatting with the same configuration. ClangFormat
 # 3.8 is chosen since it's the latest version supported by Ubuntu Trusty.
 
-if (CLANG_FORMAT_EXECUTABLE)
-  get_property(formatting_files GLOBAL PROPERTY CODE_FORMATTING_SOURCES)
-  list(LENGTH formatting_files formatting_files_length)
+clang_format_setup_version(3.8)
 
-  if (formatting_files)
-    add_custom_target(format
-        COMMAND ${CMAKE_COMMAND} -E echo "Formatting code style of"
-            "${formatting_files_length} files... "
-        COMMAND ${CLANG_FORMAT_EXECUTABLE} -style=file -i ${formatting_files}
-        COMMAND ${CMAKE_COMMAND} -E echo "Done."
-        DEPENDS ${CLANG_FORMAT_EXECUTABLE}
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    )
-    add_custom_target(check-format
-        COMMAND ${CMAKE_COMMAND} -E echo "Checking code style of"
-            "${formatting_files_length} files... "
-        COMMAND ${CMAKE_SOURCE_DIR}/tools/check_format.sh
-            ${CLANG_FORMAT_EXECUTABLE} ${formatting_files}
-        COMMAND ${CMAKE_COMMAND} -E echo "Done."
-        DEPENDS ${CLANG_FORMAT_EXECUTABLE}
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    )
-  else()
-    add_custom_target(format
-        COMMAND ${CMAKE_COMMAND} -E echo "No file to format code style."
-    )
-    add_custom_target(check-format
-        COMMAND ${CMAKE_COMMAND} -E echo "No file to check code style."
-    )
-  endif()
-else()
-  message(STATUS "Looking for clang-format - NOT found, please install clang-format to enable automatic code formatting")
+if (CLANG_FORMAT_EXECUTABLE)
+  clang_format_add_sources(${aikido_headers})
+
+  clang_format_add_targets()
 endif()
 
 #==============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,6 @@ find_package(ompl REQUIRED)
 # TREAT_WARNINGS_AS_ERRORS.
 include(CompilerSettings)
 
-
 #==============================================================================
 # Libraries and unit tests.
 #
@@ -256,7 +255,7 @@ endif()
 # result in different code formatting with the same configuration. ClangFormat
 # 3.8 is chosen since it's the latest version supported by Ubuntu Trusty.
 
-clang_format_setup_version(3.8)
+clang_format_setup(VERSION 3.8)
 
 if (CLANG_FORMAT_EXECUTABLE)
   clang_format_add_sources(${aikido_headers})

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,0 +1,79 @@
+function(clang_format_setup)
+  find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format)
+  if(NOT CLANG_FORMAT_EXECUTABLE)
+    message(STATUS "Looking for clang-format - NOT found, please install "
+      "clang-format to enable automatic code formatting."
+    )
+    return()
+  endif()
+
+  message(STATUS "Found clang-format.")
+endfunction()
+
+function(clang_format_setup_version clang_version)
+  find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format-${clang_version})
+  if(NOT CLANG_FORMAT_EXECUTABLE)
+    message(STATUS "Looking for clang-format-${clang_version} - NOT found,"
+      "please install to enable automatic code formatting."
+    )
+    return()
+  endif()
+
+  message(STATUS "Found clang-format-${clang_version}.")
+endfunction()
+
+#===============================================================================
+function(_property_add property_name)
+  get_property(is_defined GLOBAL PROPERTY ${property_name} DEFINED)
+  if(NOT is_defined)
+    define_property(GLOBAL PROPERTY ${property_name}
+      BRIEF_DOCS "${property_name}"
+      FULL_DOCS "Global properties for ${property_name}"
+    )
+  endif()
+  foreach(item ${ARGN})
+    set_property(GLOBAL APPEND PROPERTY ${property_name} "${item}")
+  endforeach()
+endfunction()
+
+#===============================================================================
+function(clang_format_add_sources)
+  foreach(source ${ARGN})
+    if(IS_ABSOLUTE "${source}")
+      set(source_abs "${source}")
+    else()
+      get_filename_component(source_abs
+        "${CMAKE_CURRENT_LIST_DIR}/${source}" ABSOLUTE)
+    endif()
+    if(EXISTS "${source_abs}")
+      _property_add(CLANG_FORMAT_FORMAT_FILES "${source_abs}")
+    else()
+      message(FATAL_ERROR
+        "Source file '${source}' does not exist at absolute path"
+        " '${source_abs}'. This should never happen. Did you recently delete"
+        " this file or modify 'CMAKE_CURRENT_LIST_DIR'")
+    endif()
+  endforeach()
+endfunction()
+
+#===============================================================================
+function(clang_format_add_targets)
+  get_property(formatting_files GLOBAL PROPERTY CLANG_FORMAT_FORMAT_FILES)
+  list(LENGTH formatting_files formatting_files_length)
+  message(STATUS "Formatting on ${formatting_files_length} source files.")
+
+  add_custom_target(format
+    COMMAND ${CMAKE_COMMAND} -E echo "Formatting ${formatting_files_length} files..."
+    COMMAND ${CLANG_FORMAT_EXECUTABLE} -style=file -i ${formatting_files}
+    COMMAND ${CMAKE_COMMAND} -E echo "Done."
+    DEPENDS ${CLANG_FORMAT_EXECUTABLE}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+  add_custom_target(check-format
+    COMMAND ${CMAKE_COMMAND} -E echo "Checking ${formatting_files_length} files..."
+    COMMAND ${CMAKE_SOURCE_DIR}/tools/check_format.sh ${CLANG_FORMAT_EXECUTABLE} ${formatting_files}
+    COMMAND ${CMAKE_COMMAND} -E echo "Done."
+    DEPENDS ${CLANG_FORMAT_EXECUTABLE}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+endfunction()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -43,4 +43,4 @@ endif()
 add_component(${PROJECT_NAME} common)
 add_component_targets(${PROJECT_NAME} common "${PROJECT_NAME}_common")
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})

--- a/src/constraint/CMakeLists.txt
+++ b/src/constraint/CMakeLists.txt
@@ -50,4 +50,4 @@ add_component(${PROJECT_NAME} constraint)
 add_component_targets(${PROJECT_NAME} constraint "${PROJECT_NAME}_constraint")
 add_component_dependencies(${PROJECT_NAME} constraint common statespace)
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})

--- a/src/control/CMakeLists.txt
+++ b/src/control/CMakeLists.txt
@@ -23,6 +23,6 @@ add_component(${PROJECT_NAME} control)
 add_component_targets(${PROJECT_NAME} control "${PROJECT_NAME}_control")
 add_component_dependencies(${PROJECT_NAME} control statespace trajectory)
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})
 
 add_subdirectory("ros") # Dependencies: control, statespace, trajectory

--- a/src/control/ros/CMakeLists.txt
+++ b/src/control/ros/CMakeLists.txt
@@ -65,4 +65,4 @@ add_component(${PROJECT_NAME} control_ros)
 add_component_targets(${PROJECT_NAME} control_ros "${PROJECT_NAME}_control_ros")
 add_component_dependencies(${PROJECT_NAME} control_ros control statespace trajectory)
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})

--- a/src/distance/CMakeLists.txt
+++ b/src/distance/CMakeLists.txt
@@ -27,4 +27,4 @@ add_component(${PROJECT_NAME} distance)
 add_component_targets(${PROJECT_NAME} distance "${PROJECT_NAME}_distance")
 add_component_dependencies(${PROJECT_NAME} distance statespace)
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -69,4 +69,4 @@ add_component(${PROJECT_NAME} io)
 add_component_targets(${PROJECT_NAME} io "${PROJECT_NAME}_io")
 add_component_dependencies(${PROJECT_NAME} io common)
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})

--- a/src/perception/CMakeLists.txt
+++ b/src/perception/CMakeLists.txt
@@ -88,4 +88,4 @@ add_component(${PROJECT_NAME} perception)
 add_component_targets(${PROJECT_NAME} perception "${PROJECT_NAME}_perception")
 add_component_dependencies(${PROJECT_NAME} perception io)
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -56,7 +56,7 @@ add_component_dependencies(${PROJECT_NAME} planner
   trajectory
 )
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})
 
 add_subdirectory("ompl")        # [constraint], [distance], [statespace], [trajectory], dart, ompl
 add_subdirectory("parabolic")   # [external], [common], [trajectory], [statespace], dart

--- a/src/planner/kunzretimer/CMakeLists.txt
+++ b/src/planner/kunzretimer/CMakeLists.txt
@@ -28,4 +28,4 @@ add_component_dependencies(${PROJECT_NAME} planner_kunzretimer
   trajectory
 )
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})

--- a/src/planner/ompl/CMakeLists.txt
+++ b/src/planner/ompl/CMakeLists.txt
@@ -56,4 +56,4 @@ add_component_dependencies(${PROJECT_NAME} planner_ompl
   trajectory
 )
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})

--- a/src/planner/parabolic/CMakeLists.txt
+++ b/src/planner/parabolic/CMakeLists.txt
@@ -31,4 +31,4 @@ add_component_dependencies(${PROJECT_NAME} planner_parabolic
   trajectory
 )
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})

--- a/src/planner/vectorfield/CMakeLists.txt
+++ b/src/planner/vectorfield/CMakeLists.txt
@@ -42,4 +42,4 @@ add_component_dependencies(${PROJECT_NAME} planner_vectorfield
   planner
 )
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})

--- a/src/robot/CMakeLists.txt
+++ b/src/robot/CMakeLists.txt
@@ -60,4 +60,4 @@ add_component_dependencies(${PROJECT_NAME} robot
   trajectory
 )
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -75,4 +75,4 @@ add_component_dependencies(${PROJECT_NAME} rviz
 
 # Intentionally omit tests for or_rviz. It's not clear how to test a viewer.
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})

--- a/src/statespace/CMakeLists.txt
+++ b/src/statespace/CMakeLists.txt
@@ -33,4 +33,4 @@ target_compile_options("${PROJECT_NAME}_statespace"
 add_component(${PROJECT_NAME} statespace)
 add_component_targets(${PROJECT_NAME} statespace "${PROJECT_NAME}_statespace")
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})

--- a/src/trajectory/CMakeLists.txt
+++ b/src/trajectory/CMakeLists.txt
@@ -19,4 +19,4 @@ add_component(${PROJECT_NAME} trajectory)
 add_component_targets(${PROJECT_NAME} trajectory "${PROJECT_NAME}_trajectory")
 add_component_dependencies(${PROJECT_NAME} trajectory common statespace)
 
-format_add_sources(${sources})
+clang_format_add_sources(${sources})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ function(aikido_add_test target_name)
   target_link_libraries("${target_name}" gtest gtest_main)
 
   set_property(GLOBAL APPEND PROPERTY AIKIDO_TESTS "${target_name}")
-  format_add_sources(${ARGN})
+  clang_format_add_sources(${ARGN})
 endfunction()
 
 # Add helper scripts to the include path.
@@ -34,4 +34,4 @@ add_subdirectory("planner")
 add_subdirectory("statespace")
 add_subdirectory("trajectory")
 
-format_add_sources(eigen_tests.hpp)
+clang_format_add_sources(eigen_tests.hpp)

--- a/tests/constraint/CMakeLists.txt
+++ b/tests/constraint/CMakeLists.txt
@@ -139,7 +139,7 @@ aikido_add_test(test_RejectionSampleable
 target_link_libraries(test_RejectionSampleable
   "${PROJECT_NAME}_constraint")
 
-format_add_sources(
+clang_format_add_sources(
   MockConstraints.hpp
   PolynomialConstraint.cpp
   PolynomialConstraint.hpp

--- a/tests/planner/ompl/CMakeLists.txt
+++ b/tests/planner/ompl/CMakeLists.txt
@@ -29,4 +29,4 @@ target_link_libraries(test_StateSampler "${PROJECT_NAME}_planner_ompl")
 aikido_add_test(test_ValidityChecker test_ValidityChecker.cpp)
 target_link_libraries(test_ValidityChecker "${PROJECT_NAME}_planner_ompl")
 
-format_add_sources(OMPLTestHelpers.hpp)
+clang_format_add_sources(OMPLTestHelpers.hpp)


### PR DESCRIPTION
Solve issue #232 

Added CMake module for Clang Format based on the one from Chimera. Can specify requested clang-format version.

***

**Before creating a pull request**

- [ n/a ] Document new methods and classes
- [ x ] Format code with `make format`

**Before merging a pull request**

- [ n/a ] Set version target by selecting a milestone on the right side
- [ n/a ] Summarize this change in `CHANGELOG.md`
- [ n/a ] Add unit test(s) for this change
