### PR TITLE
Fix toR1JointTrajectory(Intepolated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 
   * Added B-spline trajectory: [#453](https://github.com/personalrobotics/aikido/pull/453)
   * Added trajectory utility functions: [#462](https://github.com/personalrobotics/aikido/pull/462)
+  * Fixes toR1JointTrajectory to copy Waypoints with their time information: [#508](https://github.com/personalrobotics/aikido/pull/510)
 
 * Planner
 

--- a/src/trajectory/util.cpp
+++ b/src/trajectory/util.cpp
@@ -322,7 +322,7 @@ UniqueInterpolatedPtr toR1JointTrajectory(const Interpolated& trajectory)
   // Add the first waypoint
   space->logMap(trajectory.getWaypoint(0), sourceVector);
   rSpace->expMap(sourceVector, sourceState);
-  rTrajectory->addWaypoint(0, sourceState);
+  rTrajectory->addWaypoint(trajectory.getWaypointTime(0), sourceState);
 
   auto tangentState = rSpace->createState();
   auto targetState = rSpace->createState();
@@ -337,7 +337,7 @@ UniqueInterpolatedPtr toR1JointTrajectory(const Interpolated& trajectory)
     rSpace->expMap(tangentVector, tangentState);
     rSpace->compose(sourceState, tangentState, targetState);
 
-    rTrajectory->addWaypoint(i + 1, targetState);
+    rTrajectory->addWaypoint(trajectory.getWaypointTime(i + 1), targetState);
     rSpace->logMap(targetState, sourceVector);
   }
 


### PR DESCRIPTION
This PR fixes `toR1JointTrajectory(Interpolated)` to use `getWaypointTime()` when copying a waypoint to r1JointTrajectory.

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
