### PR TITLE
nominal configuration ranker uses scoped state

### DIFF
--- a/include/aikido/distance/NominalConfigurationRanker.hpp
+++ b/include/aikido/distance/NominalConfigurationRanker.hpp
@@ -24,9 +24,8 @@ public:
   NominalConfigurationRanker(
       statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
       ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton,
-      std::vector<double> weights = std::vector<double>(),
-      const statespace::CartesianProduct::State* nominalConfiguration
-      = nullptr);
+      std::vector<double> weights,
+      statespace::CartesianProduct::ScopedState nominalConfiguration);
 
 protected:
   /// Returns cost as distance from the Nominal Configuration.
@@ -35,7 +34,7 @@ protected:
       const override;
 
   /// Nominal configuration used when evaluating a given configuration.
-  const statespace::dart::MetaSkeletonStateSpace::State* mNominalConfiguration;
+  statespace::dart::MetaSkeletonStateSpace::ScopedState mNominalConfiguration;
 };
 
 } // namespace distance

--- a/src/distance/NominalConfigurationRanker.cpp
+++ b/src/distance/NominalConfigurationRanker.cpp
@@ -11,15 +11,17 @@ NominalConfigurationRanker::NominalConfigurationRanker(
     ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
     ConstMetaSkeletonPtr metaSkeleton,
     std::vector<double> weights,
-    const statespace::CartesianProduct::State* nominalConfiguration)
+    statespace::CartesianProduct::ScopedState nominalConfiguration)
   : ConfigurationRanker(
         std::move(metaSkeletonStateSpace), std::move(metaSkeleton), weights)
-  , mNominalConfiguration(nominalConfiguration)
+  , mNominalConfiguration(std::move(nominalConfiguration))
 {
-  if (!mNominalConfiguration)
-    mNominalConfiguration
-        = mMetaSkeletonStateSpace->getScopedStateFromMetaSkeleton(
-            mMetaSkeleton.get());
+  // do nothing
+  //
+  //if (!mNominalConfiguration)
+  //  mNominalConfiguration
+  //      = mMetaSkeletonStateSpace->getScopedStateFromMetaSkeleton(
+  //          mMetaSkeleton.get());
 }
 
 //==============================================================================

--- a/src/distance/NominalConfigurationRanker.cpp
+++ b/src/distance/NominalConfigurationRanker.cpp
@@ -17,11 +17,6 @@ NominalConfigurationRanker::NominalConfigurationRanker(
   , mNominalConfiguration(std::move(nominalConfiguration))
 {
   // do nothing
-  //
-  //if (!mNominalConfiguration)
-  //  mNominalConfiguration
-  //      = mMetaSkeletonStateSpace->getScopedStateFromMetaSkeleton(
-  //          mMetaSkeleton.get());
 }
 
 //==============================================================================

--- a/src/planner/dart/ConfigurationToConfiguration_to_ConfigurationToTSR.cpp
+++ b/src/planner/dart/ConfigurationToConfiguration_to_ConfigurationToTSR.cpp
@@ -101,7 +101,7 @@ ConfigurationToConfiguration_to_ConfigurationToTSR::plan(
         mMetaSkeletonStateSpace,
         mMetaSkeleton,
         std::vector<double>(),
-        nominalState);
+        std::move(nominalState));
   }
 
   // Goal state

--- a/src/robot/util.cpp
+++ b/src/robot/util.cpp
@@ -235,7 +235,7 @@ trajectory::TrajectoryPtr planToTSR(
     auto nominalState = space->createState();
     space->copyState(startState, nominalState);
     configurationRanker = std::make_shared<const NominalConfigurationRanker>(
-        space, metaSkeleton, std::vector<double>(), nominalState);
+        space, metaSkeleton, std::vector<double>(), std::move(nominalState));
   }
 
   while (snapSamples < maxSnapSamples && generator->canSample())


### PR DESCRIPTION
Nominal Configuration Ranker maintains the nominal config as a scoped state.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
