### PR TITLE
Change NominalConfigurationRanker to store ScopedState

### DIFF
--- a/include/aikido/distance/NominalConfigurationRanker.hpp
+++ b/include/aikido/distance/NominalConfigurationRanker.hpp
@@ -17,16 +17,26 @@ public:
   ///
   /// \param[in] metaSkeletonStateSpace Statespace of the skeleton.
   /// \param[in] metaSkeleton Metaskeleton of the robot.
+  /// \param[in] nominalConfiguration Nominal configuration.
   /// \param[in] weights Weights over the joints to compute distance.
   /// Defaults to unit vector.
-  /// \param[in] nominalConfiguration Nominal configuration. The current
-  /// configuration of \c metaSkeleton is considered if set to \c nullptr.
   NominalConfigurationRanker(
       statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
       ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton,
-      std::vector<double> weights = std::vector<double>(),
-      const statespace::CartesianProduct::State* nominalConfiguration
-      = nullptr);
+      const statespace::CartesianProduct::State* nominalConfiguration,
+      std::vector<double> weights = std::vector<double>());
+
+  /// Constructor. The current configuration of \c metaSkeleton is
+  /// considered as the nominal configuration.
+  ///
+  /// \param[in] metaSkeletonStateSpace Statespace of the skeleton.
+  /// \param[in] metaSkeleton Metaskeleton of the robot.
+  /// \param[in] weights Weights over the joints to compute distance.
+  /// Defaults to unit vector.
+  NominalConfigurationRanker(
+      statespace::dart::ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
+      ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton,
+      std::vector<double> weights = std::vector<double>());
 
 protected:
   /// Returns cost as distance from the Nominal Configuration.
@@ -35,7 +45,7 @@ protected:
       const override;
 
   /// Nominal configuration used when evaluating a given configuration.
-  const statespace::dart::MetaSkeletonStateSpace::State* mNominalConfiguration;
+  const statespace::dart::MetaSkeletonStateSpace::ScopedState mNominalConfiguration;
 };
 
 } // namespace distance

--- a/include/aikido/distance/NominalConfigurationRanker.hpp
+++ b/include/aikido/distance/NominalConfigurationRanker.hpp
@@ -45,7 +45,8 @@ protected:
       const override;
 
   /// Nominal configuration used when evaluating a given configuration.
-  const statespace::dart::MetaSkeletonStateSpace::ScopedState mNominalConfiguration;
+  const statespace::dart::MetaSkeletonStateSpace::ScopedState
+      mNominalConfiguration;
 };
 
 } // namespace distance

--- a/src/distance/NominalConfigurationRanker.cpp
+++ b/src/distance/NominalConfigurationRanker.cpp
@@ -10,16 +10,27 @@ using ::dart::dynamics::ConstMetaSkeletonPtr;
 NominalConfigurationRanker::NominalConfigurationRanker(
     ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
     ConstMetaSkeletonPtr metaSkeleton,
-    std::vector<double> weights,
-    const statespace::CartesianProduct::State* nominalConfiguration)
+    const statespace::CartesianProduct::State* nominalConfiguration,
+    std::vector<double> weights)
   : ConfigurationRanker(
         std::move(metaSkeletonStateSpace), std::move(metaSkeleton), weights)
-  , mNominalConfiguration(nominalConfiguration)
+  , mNominalConfiguration(
+    mMetaSkeletonStateSpace->cloneState(nominalConfiguration))
 {
-  if (!mNominalConfiguration)
-    mNominalConfiguration
-        = mMetaSkeletonStateSpace->getScopedStateFromMetaSkeleton(
-            mMetaSkeleton.get());
+  // Do nothing
+}
+
+//==============================================================================
+NominalConfigurationRanker::NominalConfigurationRanker(
+    ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
+    ConstMetaSkeletonPtr metaSkeleton,
+    std::vector<double> weights)
+: ConfigurationRanker(
+      std::move(metaSkeletonStateSpace), std::move(metaSkeleton), weights)
+, mNominalConfiguration(mMetaSkeletonStateSpace->getScopedStateFromMetaSkeleton(
+          mMetaSkeleton.get()))
+{
+ // Do nothing
 }
 
 //==============================================================================

--- a/src/distance/NominalConfigurationRanker.cpp
+++ b/src/distance/NominalConfigurationRanker.cpp
@@ -15,7 +15,7 @@ NominalConfigurationRanker::NominalConfigurationRanker(
   : ConfigurationRanker(
         std::move(metaSkeletonStateSpace), std::move(metaSkeleton), weights)
   , mNominalConfiguration(
-    mMetaSkeletonStateSpace->cloneState(nominalConfiguration))
+        mMetaSkeletonStateSpace->cloneState(nominalConfiguration))
 {
   // Do nothing
 }
@@ -25,12 +25,13 @@ NominalConfigurationRanker::NominalConfigurationRanker(
     ConstMetaSkeletonStateSpacePtr metaSkeletonStateSpace,
     ConstMetaSkeletonPtr metaSkeleton,
     std::vector<double> weights)
-: ConfigurationRanker(
-      std::move(metaSkeletonStateSpace), std::move(metaSkeleton), weights)
-, mNominalConfiguration(mMetaSkeletonStateSpace->getScopedStateFromMetaSkeleton(
-          mMetaSkeleton.get()))
+  : ConfigurationRanker(
+        std::move(metaSkeletonStateSpace), std::move(metaSkeleton), weights)
+  , mNominalConfiguration(
+        mMetaSkeletonStateSpace->getScopedStateFromMetaSkeleton(
+            mMetaSkeleton.get()))
 {
- // Do nothing
+  // Do nothing
 }
 
 //==============================================================================

--- a/src/planner/dart/ConfigurationToConfiguration_to_ConfigurationToTSR.cpp
+++ b/src/planner/dart/ConfigurationToConfiguration_to_ConfigurationToTSR.cpp
@@ -100,7 +100,6 @@ ConfigurationToConfiguration_to_ConfigurationToTSR::plan(
     configurationRanker = std::make_shared<const NominalConfigurationRanker>(
         mMetaSkeletonStateSpace,
         mMetaSkeleton,
-        std::vector<double>(),
         nominalState);
   }
 

--- a/src/planner/dart/ConfigurationToConfiguration_to_ConfigurationToTSR.cpp
+++ b/src/planner/dart/ConfigurationToConfiguration_to_ConfigurationToTSR.cpp
@@ -98,9 +98,7 @@ ConfigurationToConfiguration_to_ConfigurationToTSR::plan(
     auto nominalState = mMetaSkeletonStateSpace->createState();
     mMetaSkeletonStateSpace->copyState(startState, nominalState);
     configurationRanker = std::make_shared<const NominalConfigurationRanker>(
-        mMetaSkeletonStateSpace,
-        mMetaSkeleton,
-        nominalState);
+        mMetaSkeletonStateSpace, mMetaSkeleton, nominalState);
   }
 
   // Goal state

--- a/src/robot/util.cpp
+++ b/src/robot/util.cpp
@@ -235,7 +235,7 @@ trajectory::TrajectoryPtr planToTSR(
     auto nominalState = space->createState();
     space->copyState(startState, nominalState);
     configurationRanker = std::make_shared<const NominalConfigurationRanker>(
-        space, metaSkeleton, std::vector<double>(), nominalState);
+        space, metaSkeleton, nominalState);
   }
 
   while (snapSamples < maxSnapSamples && generator->canSample())

--- a/tests/distance/test_NominalConfigurationRanker.cpp
+++ b/tests/distance/test_NominalConfigurationRanker.cpp
@@ -157,6 +157,18 @@ TEST_F(NominalConfigurationRankerTest, GivenNominalConfigurationOrderTest)
     mStateSpace->convertStateToPositions(states[i], rankedState);
     EXPECT_EIGEN_EQUAL(rankedState, jointPositions[i], EPS);
   }
+
+  // Change the nominalState
+  nominalConfiguration = Eigen::Vector2d(0.0, 0.0);
+  mStateSpace->convertPositionsToState(nominalConfiguration, nominalState);
+
+  // The ranking should state the same
+  ranker.rankConfigurations(states);
+  for (std::size_t i = 0; i < states.size(); ++i)
+  {
+    mStateSpace->convertStateToPositions(states[i], rankedState);
+    EXPECT_EIGEN_EQUAL(rankedState, jointPositions[i], EPS);
+  }
 }
 
 TEST_F(NominalConfigurationRankerTest, WeightedOrderTest)

--- a/tests/distance/test_NominalConfigurationRanker.cpp
+++ b/tests/distance/test_NominalConfigurationRanker.cpp
@@ -83,6 +83,10 @@ TEST_F(NominalConfigurationRankerTest, Constructor)
           mStateSpace, mManipulator, wrongDimensionWeights),
       std::invalid_argument);
 
+  auto nominalState = mStateSpace->getScopedStateFromMetaSkeleton(mManipulator.get());
+  NominalConfigurationRanker rankerZero(mStateSpace, mManipulator, nominalState);
+  DART_UNUSED(rankerZero);
+
   NominalConfigurationRanker rankerOne(mStateSpace, mManipulator);
   DART_UNUSED(rankerOne);
 
@@ -91,7 +95,7 @@ TEST_F(NominalConfigurationRankerTest, Constructor)
   DART_UNUSED(rankerTwo);
 }
 
-TEST_F(NominalConfigurationRankerTest, OrderTest)
+TEST_F(NominalConfigurationRankerTest, CurrentNominalConfigurationOrderTest)
 {
   std::vector<Eigen::Vector2d> jointPositions{Eigen::Vector2d(0.3, 0.3),
                                               Eigen::Vector2d(0.1, 0.1),
@@ -113,6 +117,39 @@ TEST_F(NominalConfigurationRankerTest, OrderTest)
   jointPositions[0] = Eigen::Vector2d(0.1, 0.1);
   jointPositions[1] = Eigen::Vector2d(0.2, 0.2);
   jointPositions[2] = Eigen::Vector2d(0.3, 0.3);
+  for (std::size_t i = 0; i < states.size(); ++i)
+  {
+    mStateSpace->convertStateToPositions(states[i], rankedState);
+    EXPECT_EIGEN_EQUAL(rankedState, jointPositions[i], EPS);
+  }
+}
+
+TEST_F(NominalConfigurationRankerTest, GivenNominalConfigurationOrderTest)
+{
+  std::vector<Eigen::Vector2d> jointPositions{Eigen::Vector2d(0.3, 0.3),
+                                              Eigen::Vector2d(0.1, 0.1),
+                                              Eigen::Vector2d(0.2, 0.2)};
+
+  auto nominalState = mStateSpace->createState();
+  Eigen::Vector2d nominalConfiguration(0.3, 0.3);
+  mStateSpace->convertPositionsToState(nominalConfiguration, nominalState);
+
+  std::vector<aikido::statespace::CartesianProduct::ScopedState> states;
+  for (std::size_t i = 0; i < jointPositions.size(); ++i)
+  {
+    auto state = mStateSpace->createState();
+    mStateSpace->convertPositionsToState(jointPositions[i], state);
+    states.emplace_back(state.clone());
+  }
+
+  mManipulator->setPositions(Eigen::Vector2d(0.0, 0.0));
+  NominalConfigurationRanker ranker(mStateSpace, mManipulator, nominalState);
+  ranker.rankConfigurations(states);
+
+  Eigen::VectorXd rankedState(2);
+  jointPositions[0] = Eigen::Vector2d(0.3, 0.3);
+  jointPositions[1] = Eigen::Vector2d(0.2, 0.2);
+  jointPositions[2] = Eigen::Vector2d(0.1, 0.1);
   for (std::size_t i = 0; i < states.size(); ++i)
   {
     mStateSpace->convertStateToPositions(states[i], rankedState);

--- a/tests/distance/test_NominalConfigurationRanker.cpp
+++ b/tests/distance/test_NominalConfigurationRanker.cpp
@@ -74,22 +74,20 @@ TEST_F(NominalConfigurationRankerTest, Constructor)
 
   std::vector<double> negativeWeights{-1, 0};
   EXPECT_THROW(
-      NominalConfigurationRanker(
-          mStateSpace, mManipulator, negativeWeights, nullptr),
+      NominalConfigurationRanker(mStateSpace, mManipulator, negativeWeights),
       std::invalid_argument);
 
   std::vector<double> wrongDimensionWeights{1};
   EXPECT_THROW(
       NominalConfigurationRanker(
-          mStateSpace, mManipulator, wrongDimensionWeights, nullptr),
+          mStateSpace, mManipulator, wrongDimensionWeights),
       std::invalid_argument);
 
   NominalConfigurationRanker rankerOne(mStateSpace, mManipulator);
   DART_UNUSED(rankerOne);
 
   std::vector<double> goodWeights{1, 2};
-  NominalConfigurationRanker rankerTwo(
-      mStateSpace, mManipulator, goodWeights, nullptr);
+  NominalConfigurationRanker rankerTwo(mStateSpace, mManipulator, goodWeights);
   DART_UNUSED(rankerTwo);
 }
 
@@ -138,11 +136,8 @@ TEST_F(NominalConfigurationRankerTest, WeightedOrderTest)
 
   mManipulator->setPositions(Eigen::Vector2d(0.0, 0.0));
   std::vector<double> weights{10, 1};
-  NominalConfigurationRanker ranker(
-      mStateSpace,
-      mManipulator,
-      weights,
-      mStateSpace->getScopedStateFromMetaSkeleton(mManipulator.get()));
+  NominalConfigurationRanker ranker(mStateSpace, mManipulator, weights);
+
   ranker.rankConfigurations(states);
 
   Eigen::VectorXd rankedState(2);

--- a/tests/distance/test_NominalConfigurationRanker.cpp
+++ b/tests/distance/test_NominalConfigurationRanker.cpp
@@ -83,8 +83,10 @@ TEST_F(NominalConfigurationRankerTest, Constructor)
           mStateSpace, mManipulator, wrongDimensionWeights),
       std::invalid_argument);
 
-  auto nominalState = mStateSpace->getScopedStateFromMetaSkeleton(mManipulator.get());
-  NominalConfigurationRanker rankerZero(mStateSpace, mManipulator, nominalState);
+  auto nominalState
+      = mStateSpace->getScopedStateFromMetaSkeleton(mManipulator.get());
+  NominalConfigurationRanker rankerZero(
+      mStateSpace, mManipulator, nominalState);
   DART_UNUSED(rankerZero);
 
   NominalConfigurationRanker rankerOne(mStateSpace, mManipulator);


### PR DESCRIPTION
This fixes the bug in NominalConfigurationRanker, which keeps a pointer to a state that may become cleared out.

I tested this in `ada_demos` and printed `mNominalConfiguration` in `evaluateConfiguration` to see that it matches the value passed to the constructor.

Resolves #515.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
