### PR TITLE
Fix convertShape to use getMeshPath

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 [Describe this pull request. Link to relevant GitHub issues, if any.]
 
+[Explain how this pull request was tested.]
+
 ***
 
 **Before creating a pull request**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 * RViz
 
   * Fixed bug of not joining Viewer threads when stopping auto-update: [#463](https://github.com/personalrobotics/aikido/pull/463)
+  * Fixed bug of not passing raw file path to RViz when MeshShape is used: [#518](https://github.com/personalrobotics/aikido/pull/518)
 
 * IO
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 * RViz
 
   * Fixed bug of not joining Viewer threads when stopping auto-update: [#463](https://github.com/personalrobotics/aikido/pull/463)
-  * Fixed bug of not passing raw file path to RViz when MeshShape is used: [#518](https://github.com/personalrobotics/aikido/pull/518)
+  * Fixed bug of not passing full file path to RViz when MeshShape is used: [#518](https://github.com/personalrobotics/aikido/pull/518)
 
 * IO
 

--- a/src/rviz/shape_conversions.cpp
+++ b/src/rviz/shape_conversions.cpp
@@ -193,7 +193,7 @@ bool convertShape(
   marker->scale = convertEigenToROSVector3(shape.getScale());
 
   const aiScene* scene = shape.getMesh();
-  const std::string& meshUri = shape.getMeshUri();
+  const std::string& meshUri = shape.getMeshPath();
   if (!meshUri.empty())
   {
     marker->type = Marker::MESH_RESOURCE;

--- a/src/rviz/shape_conversions.cpp
+++ b/src/rviz/shape_conversions.cpp
@@ -194,7 +194,7 @@ bool convertShape(
 
   const aiScene* scene = shape.getMesh();
   const std::string& meshPath = shape.getMeshPath();
-  if (!meshUri.empty())
+  if (!meshPath.empty())
   {
     marker->type = Marker::MESH_RESOURCE;
     marker->mesh_resource = meshUri;

--- a/src/rviz/shape_conversions.cpp
+++ b/src/rviz/shape_conversions.cpp
@@ -193,7 +193,7 @@ bool convertShape(
   marker->scale = convertEigenToROSVector3(shape.getScale());
 
   const aiScene* scene = shape.getMesh();
-  const std::string& meshUri = shape.getMeshPath();
+  const std::string& meshPath = shape.getMeshPath();
   if (!meshUri.empty())
   {
     marker->type = Marker::MESH_RESOURCE;

--- a/src/rviz/shape_conversions.cpp
+++ b/src/rviz/shape_conversions.cpp
@@ -197,7 +197,7 @@ bool convertShape(
   if (!meshPath.empty())
   {
     marker->type = Marker::MESH_RESOURCE;
-    marker->mesh_resource = meshUri;
+    marker->mesh_resource = meshPath;
     marker->mesh_use_embedded_materials = true;
     return true;
   }


### PR DESCRIPTION
This PR fixes `rviz::convertShape(MeshShape...)` method to use `getMeshPath` instead of `getMeshUri` for `meshUri`.
When a mesh is loaded via MeshShape, `convertShape(MeshShape...)` gets called. Since `meshUri` is used by Rviz, it has to be a raw filepath, which is not the case when using `getMeshUri`.

This was never an issue with Herb or Ada because we use `urdfLoader` and it constructs AssimpMesh, which doesn't call this function. It was discovered while @vinitha910  was trying to load cozmo mesh directly using raw filepaths. 

It has been tested by constructing cozmo with MeshShapes and visualizing it in Rviz through aikido InteractiveViewer.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
