### PR TITLE
Fix compilation error (maybe only on Trusty?)

### DIFF
--- a/src/robot/util.cpp
+++ b/src/robot/util.cpp
@@ -437,7 +437,7 @@ trajectory::TrajectoryPtr planToEndEffectorOffset(
       std::chrono::duration<double>(timelimit));
 
   if (traj)
-    return traj;
+    return std::move(traj);
 
   return planToEndEffectorOffsetByCRRT(
       space,


### PR DESCRIPTION
@planc509 was having this compilation error, which may have been introduced in [#499](https://github.com/personalrobotics/aikido/pull/499/files#diff-aa512357e2a323b6efdea83791638706L442). I have the same issue on my Trusty machine.

@gilwoolee @jslee02 do you remember why this change was made? (We should be deprecating this function anyway, so maybe it doesn't matter...)

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [ ] Format code with `make format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change