### PR TITLE
Only add python subdirectory if building aikidopy.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,9 @@ add_custom_target(headers SOURCES ${aikido_headers})
 
 add_subdirectory("src")
 
-add_subdirectory("python")
+if(BUILD_AIKIDOPY)
+  add_subdirectory("python")
+endif()
 
 enable_testing()
 add_subdirectory("tests" EXCLUDE_FROM_ALL)


### PR DESCRIPTION
I noticed this because 

```
CMake Error at .../aikido/python/aikidopy/CMakeLists.txt:8 (execute_process):
  Syntax error in cmake code at

    .../aikido/python/aikidopy/CMakeLists.txt:9

  when parsing string

    from distutils.sysconfig import get_python_lib;\
    print(get_python_lib(plat_specific=True, prefix=''))

  syntax error, unexpected cal_SYMBOL, expecting $end (103)
```

It seems that these line breaks might not be supported by lower versions of CMake? So we might want to change that as well.

```
$ cmake --version
cmake version 2.8.12.2
```

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [ ] Format code with `make format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
