### PR TITLE
BugFix: Van der Corput - consider span for resolution check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Cleaned up doxygen errors: [#357](https://github.com/personalrobotics/aikido/pull/357)
   * Fixed bug in compiling with Boost 1.58 on Kinetic + Xenial: [#490](https://github.com/personalrobotics/aikido/pull/490)
   * Fixed bug in Interpolated::addWaypoint(): [#483](https://github.com/personalrobotics/aikido/pull/483)
+  * Fixed bug in VanDerCorput sequence generator in handling non-unit Span: [#552](https://github.com/personalrobotics/aikido/pull/552)
 
 * Distance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   * Cleaned up doxygen errors: [#357](https://github.com/personalrobotics/aikido/pull/357)
   * Fixed bug in compiling with Boost 1.58 on Kinetic + Xenial: [#490](https://github.com/personalrobotics/aikido/pull/490)
   * Fixed bug in Interpolated::addWaypoint(): [#483](https://github.com/personalrobotics/aikido/pull/483)
-  * Fixed bug in VanDerCorput sequence generator in handling non-unit Span: [#552](https://github.com/personalrobotics/aikido/pull/552)
+  * Fixed bug in VanDerCorput sequence generator to handle non-unit span: [#552](https://github.com/personalrobotics/aikido/pull/552)
 
 * Distance
 

--- a/src/common/VanDerCorput.cpp
+++ b/src/common/VanDerCorput.cpp
@@ -45,12 +45,12 @@ pair<double, double> VanDerCorput::operator[](int n) const
     if (n == 0)
     {
       val_res.first = 0.0;
-      val_res.second = mSpan;
+      val_res.second = 1.0;
     }
     else if (n == 1)
     {
       val_res.first = 1.0;
-      val_res.second = mSpan;
+      val_res.second = 1.0;
     }
     else
     {
@@ -60,12 +60,12 @@ pair<double, double> VanDerCorput::operator[](int n) const
   else if (mIncludeStartpoint && n == 0)
   {
     val_res.first = 0.0;
-    val_res.second = mSpan;
+    val_res.second = 1.0;
   }
   else if (mIncludeEndpoint && n == 0)
   {
     val_res.first = 1.0;
-    val_res.second = mSpan;
+    val_res.second = 1.0;
   }
   else
   {
@@ -80,6 +80,7 @@ pair<double, double> VanDerCorput::operator[](int n) const
   }
 
   val_res.first *= mSpan;
+  val_res.second *= mSpan;
   return val_res;
 }
 
@@ -164,7 +165,7 @@ void VanDerCorput::const_iterator::increment()
   {
     ++mN;
     mCurr = (*mSeq)[mN];
-    if (mCurr.second*mSeq->mSpan <= mSeq->mMinResolution)
+    if (mCurr.second <= mSeq->mMinResolution)
     {
       mFinalIter = true;
     }

--- a/src/common/VanDerCorput.cpp
+++ b/src/common/VanDerCorput.cpp
@@ -164,7 +164,7 @@ void VanDerCorput::const_iterator::increment()
   {
     ++mN;
     mCurr = (*mSeq)[mN];
-    if (mCurr.second <= mSeq->mMinResolution)
+    if (mCurr.second*mSeq->mSpan <= mSeq->mMinResolution)
     {
       mFinalIter = true;
     }

--- a/tests/common/test_VanDerCorput.cpp
+++ b/tests/common/test_VanDerCorput.cpp
@@ -99,16 +99,13 @@ TEST(VanDerCorput, FirstNineIteratorValuesWithEndpoints)
   EXPECT_DOUBLE_EQ(7. / 8, *itr);
 }
 
-TEST(VanDerCorput, ScaleProperlyOverSpan)
+TEST(VanDerCorput, ScaleProperlyOverSpanWithResolution)
 {
-  VanDerCorput vdc{2};
-  EXPECT_DOUBLE_EQ(2.0 / 2, vdc[0].first);
-  EXPECT_DOUBLE_EQ(2.0 / 4, vdc[1].first);
-  EXPECT_DOUBLE_EQ(6.0 / 4, vdc[2].first);
-  EXPECT_DOUBLE_EQ(2.0 / 8, vdc[3].first);
-  EXPECT_DOUBLE_EQ(10. / 8, vdc[4].first);
-  EXPECT_DOUBLE_EQ(6.0 / 8, vdc[5].first);
-  EXPECT_DOUBLE_EQ(14. / 8, vdc[6].first);
+  VanDerCorput vdc{2, false, false, 0.5};
+  EXPECT_EQ(vdc.getLength(), 3);
+  EXPECT_DOUBLE_EQ(1.0, vdc[0].first);
+  EXPECT_DOUBLE_EQ(0.5, vdc[1].first);
+  EXPECT_DOUBLE_EQ(1.5, vdc[2].first);
 }
 
 TEST(VanDerCorput, ScaleProperlyOverSpanWithEndpoints)

--- a/tests/common/test_VanDerCorput.cpp
+++ b/tests/common/test_VanDerCorput.cpp
@@ -99,13 +99,16 @@ TEST(VanDerCorput, FirstNineIteratorValuesWithEndpoints)
   EXPECT_DOUBLE_EQ(7. / 8, *itr);
 }
 
-TEST(VanDerCorput, ScaleProperlyOverSpanWithResolution)
+TEST(VanDerCorput, ScaleProperlyOverSpan)
 {
-  VanDerCorput vdc{2, false, false, 0.5};
-  EXPECT_EQ(vdc.getLength(), 3);
-  EXPECT_DOUBLE_EQ(1.0, vdc[0].first);
-  EXPECT_DOUBLE_EQ(0.5, vdc[1].first);
-  EXPECT_DOUBLE_EQ(1.5, vdc[2].first);
+  VanDerCorput vdc{2};
+  EXPECT_DOUBLE_EQ(2.0 / 2, vdc[0].first);
+  EXPECT_DOUBLE_EQ(2.0 / 4, vdc[1].first);
+  EXPECT_DOUBLE_EQ(6.0 / 4, vdc[2].first);
+  EXPECT_DOUBLE_EQ(2.0 / 8, vdc[3].first);
+  EXPECT_DOUBLE_EQ(10. / 8, vdc[4].first);
+  EXPECT_DOUBLE_EQ(6.0 / 8, vdc[5].first);
+  EXPECT_DOUBLE_EQ(14. / 8, vdc[6].first);
 }
 
 TEST(VanDerCorput, ScaleProperlyOverSpanWithEndpoints)
@@ -212,4 +215,38 @@ TEST(VanDerCorput, IterationEndsWhenMinimumResolutionReached)
   }
   EXPECT_EQ(7, iterations);
   EXPECT_EQ(7, vdc_0_125.getLength());
+}
+
+TEST(VanDerCorput, ScaleAndIterateProperlyOverSpanWithResolution)
+{
+  // Check that with a non-unit span, iteration stops appropriately.
+  VanDerCorput vdc{2, false, false, 0.25};
+  int iterations = 0;
+  EXPECT_NO_THROW({
+    for (VanDerCorput::const_iterator itr = vdc.begin(); itr != vdc.end();
+         ++itr)
+    {
+      ++iterations;
+    }
+  });
+  EXPECT_EQ(7, iterations);
+  EXPECT_EQ(7, vdc.getLength());
+
+  // Check that with a non-unit span, the vdc values are correct.
+  EXPECT_DOUBLE_EQ(1.00, vdc[0].first);
+  EXPECT_DOUBLE_EQ(0.50, vdc[1].first);
+  EXPECT_DOUBLE_EQ(1.50, vdc[2].first);
+  EXPECT_DOUBLE_EQ(0.25, vdc[3].first);
+  EXPECT_DOUBLE_EQ(1.25, vdc[4].first);
+  EXPECT_DOUBLE_EQ(0.75, vdc[5].first);
+  EXPECT_DOUBLE_EQ(1.75, vdc[6].first);
+
+  // Check that with a non-unit span, the resolution is computed correctly.
+  EXPECT_DOUBLE_EQ(1.00, vdc[0].second);
+  EXPECT_DOUBLE_EQ(1.00, vdc[1].second);
+  EXPECT_DOUBLE_EQ(0.50, vdc[2].second);
+  EXPECT_DOUBLE_EQ(0.50, vdc[3].second);
+  EXPECT_DOUBLE_EQ(0.50, vdc[4].second);
+  EXPECT_DOUBLE_EQ(0.50, vdc[5].second);
+  EXPECT_DOUBLE_EQ(0.25, vdc[6].second);
 }


### PR DESCRIPTION
Expected behavior for VDC with resolution `0.5`:
1. If an edge is of length(span) 1, output is `0, 0.5, 1`.
2. If the edge is of length(span) 2, output is `0, 0.5, 1.0, 1.5, 2.0`.

Current behavior generates sequence for [0,1] and multiplies with length thus giving
1. `0, 0.5, 1.0`
2. `0, 1.0, 2.0`

We have been using Van der Corput sequence only for interpolated trajectories with [0, 1] time so it was not an issue.

This PR introduces a test that fails with the current master and proposes a fix.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
