### PR TITLE
Bugfix in InteractiveMarkerViewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
   * Fixed bug of not joining Viewer threads when stopping auto-update: [#463](https://github.com/personalrobotics/aikido/pull/463)
   * Fixed bug of not passing full file path to RViz when MeshShape is used: [#518](https://github.com/personalrobotics/aikido/pull/518)
   * Merged WorldInteractiveMarkerViewer into InteractiveMarkerViewer, removing the former: [#520](https://github.com/personalrobotics/aikido/pull/520)
+  * Fixed bug of not removing SkeletonMarkers of skeletons removed from the associated World: [#560](https://github.com/personalrobotics/aikido/pull/560)
 
 * IO
 

--- a/src/rviz/InteractiveMarkerViewer.cpp
+++ b/src/rviz/InteractiveMarkerViewer.cpp
@@ -85,7 +85,7 @@ void InteractiveMarkerViewer::updateSkeletonMarkers()
   {
     // If there is no underlying world and the skeleton exists,
     // update the corresponding marker.
-    if (!mWorld && it->first) 
+    if (!mWorld && it->first)
     {
       std::unique_lock<std::mutex> skeleton_lock(
           it->first->getMutex(), std::try_to_lock);


### PR DESCRIPTION
If the viewer has an underlying world, skeleton markers corresponding to skeletons in the world that have been removed continued to be visualized. When the world removes the skeleton, the `SkeletonPtr` is non-nullptr and therefore the control did not reach the line that erases the marker from the map. This PR reorganizes the code for correction.

Tested via `herb3_demos` scripts for addition, deletion and updates to skeletons.

@brianhou: As a side: I wonder if we should re-introduce the `WorldInteractiveMarkerViewer`, not in its previous state but just to reimplement the `updateSkeletonMarkers()` function to have fewer if conditions.  

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
