### PR TITLE
Add SequenceConfigurationToConfigurationMetaPlanner

### DIFF
--- a/include/aikido/planner/ConfigurationToConfigurationPlanner.hpp
+++ b/include/aikido/planner/ConfigurationToConfigurationPlanner.hpp
@@ -8,6 +8,8 @@
 namespace aikido {
 namespace planner {
 
+AIKIDO_DECLARE_POINTERS(ConfigurationToConfigurationPlanner)
+
 /// Base planner class for ConfigurationToConfiguration planning problem.
 class ConfigurationToConfigurationPlanner
   : public SingleProblemPlanner<

--- a/include/aikido/planner/SequenceConfigurationToConfigurationMetaPlanner.hpp
+++ b/include/aikido/planner/SequenceConfigurationToConfigurationMetaPlanner.hpp
@@ -1,19 +1,20 @@
 #ifndef AIKIDO_PLANNER_SEQUENCECONFIGURATIONTOCONFIGURATIONMETAPLANNER_HPP_
 #define AIKIDO_PLANNER_SEQUENCECONFIGURATIONTOCONFIGURATIONMETAPLANNER_HPP_
 
-#include "aikido/planner/SequenceMetaPlanner.hpp"
 #include "aikido/planner/ConfigurationToConfigurationPlanner.hpp"
+#include "aikido/planner/SequenceMetaPlanner.hpp"
 
 namespace aikido {
 namespace planner {
 
-/// A meta planner that solves ConfigurationToConfiguration using the sub planners one-by-one
-/// sequentially and returns the first successfully planned trajectory.
-class SequenceConfigurationToConfigurationMetaPlanner :
-	public SequenceMetaPlanner, public ConfigurationToConfigurationPlanner
+/// A meta planner that solves ConfigurationToConfiguration using the sub
+/// planners one-by-one sequentially and returns the first successfully planned
+/// trajectory.
+class SequenceConfigurationToConfigurationMetaPlanner
+  : public SequenceMetaPlanner
+  , public ConfigurationToConfigurationPlanner
 {
 public:
-
   /// Constructs given list of planners.
   ///
   /// \param[in] stateSpace State space that this planner associated with.
@@ -28,9 +29,8 @@ public:
   // Documentation inherited.
   // trajectory::TrajectoryPtr plan(
   //     const Problem& problem, Result* result = nullptr) override;
-   trajectory::TrajectoryPtr plan(
-      const SolvableProblem& problem, Result* result = nullptr)
-      override;
+  trajectory::TrajectoryPtr plan(
+      const SolvableProblem& problem, Result* result = nullptr) override;
 };
 
 } // namespace planner

--- a/include/aikido/planner/SequenceConfigurationToConfigurationMetaPlanner.hpp
+++ b/include/aikido/planner/SequenceConfigurationToConfigurationMetaPlanner.hpp
@@ -1,0 +1,39 @@
+#ifndef AIKIDO_PLANNER_SEQUENCECONFIGURATIONTOCONFIGURATIONMETAPLANNER_HPP_
+#define AIKIDO_PLANNER_SEQUENCECONFIGURATIONTOCONFIGURATIONMETAPLANNER_HPP_
+
+#include "aikido/planner/SequenceMetaPlanner.hpp"
+#include "aikido/planner/ConfigurationToConfigurationPlanner.hpp"
+
+namespace aikido {
+namespace planner {
+
+/// A meta planner that solves ConfigurationToConfiguration using the sub planners one-by-one
+/// sequentially and returns the first successfully planned trajectory.
+class SequenceConfigurationToConfigurationMetaPlanner :
+	public SequenceMetaPlanner, public ConfigurationToConfigurationPlanner
+{
+public:
+
+  /// Constructs given list of planners.
+  ///
+  /// \param[in] stateSpace State space that this planner associated with.
+  /// \param[in] planners Planners to be used by this planner.
+  /// \param[in] rng RNG that planner uses. If nullptr, a default is created.
+  /// \throw If any of \c planners are not ConfigurationToConfigurationPlanner.
+  SequenceConfigurationToConfigurationMetaPlanner(
+      statespace::ConstStateSpacePtr stateSpace,
+      const std::vector<PlannerPtr>& planners = std::vector<PlannerPtr>(),
+      common::RNG* rng = nullptr);
+
+  // Documentation inherited.
+  // trajectory::TrajectoryPtr plan(
+  //     const Problem& problem, Result* result = nullptr) override;
+   trajectory::TrajectoryPtr plan(
+      const SolvableProblem& problem, Result* result = nullptr)
+      override;
+};
+
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_SEQUENCECONFIGURATIONTOCONFIGURATIONMETAPLANNER_HPP_

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -8,9 +8,10 @@ set(sources
   PlanningResult.cpp
   Problem.cpp
   RankedMetaPlanner.cpp
+  SequenceConfigurationToConfigurationMetaPlanner.cpp
+  SequenceMetaPlanner.cpp
   SnapConfigurationToConfigurationPlanner.cpp
   SnapPlanner.cpp
-  SequenceMetaPlanner.cpp
   World.cpp
   WorldStateSaver.cpp
   dart/ConfigurationToConfiguration.cpp

--- a/src/planner/SequenceConfigurationToConfigurationMetaPlanner.cpp
+++ b/src/planner/SequenceConfigurationToConfigurationMetaPlanner.cpp
@@ -1,0 +1,33 @@
+#include "aikido/planner/SequenceConfigurationToConfigurationMetaPlanner.hpp"
+
+namespace aikido {
+namespace planner {
+
+//==============================================================================
+SequenceConfigurationToConfigurationMetaPlanner::SequenceConfigurationToConfigurationMetaPlanner(
+    statespace::ConstStateSpacePtr stateSpace,
+    const std::vector<PlannerPtr>& planners,
+    common::RNG* rng)
+  : SequenceMetaPlanner(stateSpace, std::move(planners))
+  , ConfigurationToConfigurationPlanner(stateSpace, std::move(rng))
+{
+  for (auto planner : mPlanners)
+  {
+    auto castedPlanner = std::dynamic_pointer_cast<ConfigurationToConfigurationPlannerPtr>(planner);
+
+    if (!castedPlanner)
+      throw std::invalid_argument("One of the planners is not ConfigurationToConfigurationPlanner.");
+  }
+}
+
+
+// //==============================================================================
+trajectory::TrajectoryPtr SequenceConfigurationToConfigurationMetaPlanner::plan(
+    const SolvableProblem& problem, Result* result)
+{
+  return SequenceMetaPlanner::plan(problem, result);
+}
+
+
+} // namespace planner
+} // namespace aikido

--- a/src/planner/SequenceConfigurationToConfigurationMetaPlanner.cpp
+++ b/src/planner/SequenceConfigurationToConfigurationMetaPlanner.cpp
@@ -4,22 +4,25 @@ namespace aikido {
 namespace planner {
 
 //==============================================================================
-SequenceConfigurationToConfigurationMetaPlanner::SequenceConfigurationToConfigurationMetaPlanner(
-    statespace::ConstStateSpacePtr stateSpace,
-    const std::vector<PlannerPtr>& planners,
-    common::RNG* rng)
+SequenceConfigurationToConfigurationMetaPlanner::
+    SequenceConfigurationToConfigurationMetaPlanner(
+        statespace::ConstStateSpacePtr stateSpace,
+        const std::vector<PlannerPtr>& planners,
+        common::RNG* rng)
   : SequenceMetaPlanner(stateSpace, std::move(planners))
   , ConfigurationToConfigurationPlanner(stateSpace, std::move(rng))
 {
   for (auto planner : mPlanners)
   {
-    auto castedPlanner = std::dynamic_pointer_cast<ConfigurationToConfigurationPlannerPtr>(planner);
+    auto castedPlanner
+        = std::dynamic_pointer_cast<ConfigurationToConfigurationPlannerPtr>(
+            planner);
 
     if (!castedPlanner)
-      throw std::invalid_argument("One of the planners is not ConfigurationToConfigurationPlanner.");
+      throw std::invalid_argument(
+          "One of the planners is not ConfigurationToConfigurationPlanner.");
   }
 }
-
 
 // //==============================================================================
 trajectory::TrajectoryPtr SequenceConfigurationToConfigurationMetaPlanner::plan(
@@ -27,7 +30,6 @@ trajectory::TrajectoryPtr SequenceConfigurationToConfigurationMetaPlanner::plan(
 {
   return SequenceMetaPlanner::plan(problem, result);
 }
-
 
 } // namespace planner
 } // namespace aikido


### PR DESCRIPTION
This PR adds `SequenceConfigurationToConfigurationMetaPlanner`, in preparation for #467.

SequenceConfigurationToConfigurationMetaPlanner takes a list of `ConfigurationToConfigurationPlanner` and use them in sequence to solve a `ConfigurationToConfiguration` problem.

While a generic  `SequenceMetaPlanner` can be used to serve this purpose, we need this planner to be of type `ConfigurationToConfigurationPlanner` in order to be used by PlannerAdapter `ConfigurationToConfiguration_to_ConfigurationToTSR`. 

Later, we may want to make a templated `SequenceMetaPlanner<T>`, but I'd leave it as a future TODO as it adds complexity.

[Explain how this pull request was tested.]
TODO. I will test after the initial PR review. 

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
