### PR TITLE
Add ConfigurationToTSRwithTrajectoryConstraint

### DIFF
--- a/include/aikido/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.hpp
+++ b/include/aikido/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.hpp
@@ -3,9 +3,9 @@
 
 #include "aikido/planner/dart/ConfigurationToTSRPlanner.hpp"
 #include "aikido/planner/dart/ConfigurationToTSRwithTrajectoryConstraint.hpp"
+#include "aikido/robot/util.hpp"
 #include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
 #include "aikido/trajectory/Trajectory.hpp"
-#include "aikido/robot/util.hpp"
 
 namespace aikido {
 namespace planner {

--- a/include/aikido/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.hpp
+++ b/include/aikido/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.hpp
@@ -1,0 +1,58 @@
+#ifndef AIKIDO_PLANNER_DART_CRRTCONFIGURATIONTOTSRWITHTRAJECTORYCONSTRAINTPLANNER_HPP_
+#define AIKIDO_PLANNER_DART_CRRTCONFIGURATIONTOTSRWITHTRAJECTORYCONSTRAINTPLANNER_HPP_
+
+#include "aikido/planner/dart/ConfigurationToTSRPlanner.hpp"
+#include "aikido/planner/dart/ConfigurationToTSRwithTrajectoryConstraint.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
+#include "aikido/trajectory/Trajectory.hpp"
+#include "aikido/robot/util.hpp"
+
+namespace aikido {
+namespace planner {
+namespace dart {
+
+class CRRTConfigurationToTSRwithTrajectoryConstraintPlanner
+  : public dart::SingleProblemPlanner<
+        CRRTConfigurationToTSRwithTrajectoryConstraintPlanner,
+        ConfigurationToTSRwithTrajectoryConstraint>
+{
+public:
+  // Expose the implementation of Planner::plan(const Problem&, Result*) in
+  // SingleProblemPlanner. Note that plan() of the base class takes Problem
+  // while the virtual function defined in this class takes SolvableProblem,
+  // which is simply ConfigurationToTSR.
+  using SingleProblemPlanner::plan;
+
+  /// Constructor
+  ///
+  /// \param[in] stateSpace State space that this planner associated with.
+  /// \param[in] metaSkeleton MetaSkeleton to use for planning.
+  /// \param[in] timelimit Timelimit for planning.
+  /// \param[in] crrtParameters CRRT planner parameters.
+  /// \param[in] configurationRanker Ranker for goalTSR.
+  CRRTConfigurationToTSRwithTrajectoryConstraintPlanner(
+      statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+      ::dart::dynamics::MetaSkeletonPtr metaSkeleton,
+      double timelimit,
+      robot::util::CRRTPlannerParameters crrtParameters);
+
+  /// Solves \c problem returning the result to \c result.
+  ///
+  /// \param[in] problem Planning problem to be solved by the planner.
+  /// \param[out] result Result of planning procedure.
+  trajectory::TrajectoryPtr plan(
+      const SolvableProblem& problem, Result* result = nullptr);
+  // Note: SolvableProblem is defined in SingleProblemPlanner.
+
+protected:
+  const robot::util::CRRTPlannerParameters mCRRTParameters;
+
+  // Planning timelimit
+  const double mTimelimit;
+};
+
+} // namespace dart
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_DART_CRRTCONFIGURATIONTOTSRWITHTRAJECTORYCONSTRAINTPLANNER_HPP_

--- a/include/aikido/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.hpp
+++ b/include/aikido/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.hpp
@@ -29,20 +29,15 @@ public:
   /// \param[in] metaSkeleton MetaSkeleton to use for planning.
   /// \param[in] timelimit Timelimit for planning.
   /// \param[in] crrtParameters CRRT planner parameters.
-  /// \param[in] configurationRanker Ranker for goalTSR.
   CRRTConfigurationToTSRwithTrajectoryConstraintPlanner(
       statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
       ::dart::dynamics::MetaSkeletonPtr metaSkeleton,
       double timelimit,
       robot::util::CRRTPlannerParameters crrtParameters);
 
-  /// Solves \c problem returning the result to \c result.
-  ///
-  /// \param[in] problem Planning problem to be solved by the planner.
-  /// \param[out] result Result of planning procedure.
+  /// \copydoc SingleProblemPlanner::plan()
   trajectory::TrajectoryPtr plan(
-      const SolvableProblem& problem, Result* result = nullptr);
-  // Note: SolvableProblem is defined in SingleProblemPlanner.
+      const SolvableProblem& problem, Result* result = nullptr) override;
 
 protected:
   const robot::util::CRRTPlannerParameters mCRRTParameters;

--- a/include/aikido/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.hpp
+++ b/include/aikido/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.hpp
@@ -36,8 +36,8 @@ public:
       robot::util::CRRTPlannerParameters crrtParameters);
 
   /// \copydoc SingleProblemPlanner::plan()
-  trajectory::TrajectoryPtr plan(
-      const SolvableProblem& problem, Result* result = nullptr);
+  virtual trajectory::TrajectoryPtr plan(
+      const SolvableProblem& problem, Result* result = nullptr) final;
 
 protected:
   const robot::util::CRRTPlannerParameters mCRRTParameters;

--- a/include/aikido/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.hpp
+++ b/include/aikido/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.hpp
@@ -20,7 +20,7 @@ public:
   // Expose the implementation of Planner::plan(const Problem&, Result*) in
   // SingleProblemPlanner. Note that plan() of the base class takes Problem
   // while the virtual function defined in this class takes SolvableProblem,
-  // which is simply ConfigurationToTSR.
+  // which is simply ConfigurationToTSRwithTrajectoryConstraint.
   using SingleProblemPlanner::plan;
 
   /// Constructor
@@ -37,7 +37,7 @@ public:
 
   /// \copydoc SingleProblemPlanner::plan()
   trajectory::TrajectoryPtr plan(
-      const SolvableProblem& problem, Result* result = nullptr) override;
+      const SolvableProblem& problem, Result* result = nullptr);
 
 protected:
   const robot::util::CRRTPlannerParameters mCRRTParameters;

--- a/include/aikido/planner/dart/ConfigurationToTSRwithTrajectoryConstraint.hpp
+++ b/include/aikido/planner/dart/ConfigurationToTSRwithTrajectoryConstraint.hpp
@@ -1,0 +1,68 @@
+#ifndef AIKIDO_PLANNER_DART_CONFIGURATIONTOTSRWITHTRAJECTORYCONSTRAINT_HPP_
+#define AIKIDO_PLANNER_DART_CONFIGURATIONTOTSRWITHTRAJECTORYCONSTRAINT_HPP_
+
+#include "aikido/planner/dart/ConfigurationToTSR.hpp"
+
+namespace aikido {
+namespace planner {
+namespace dart {
+
+/// Planning problem to plan to a given single Task Space Region (TSR).
+class ConfigurationToTSRwithTrajectoryConstraint : public ConfigurationToTSR
+{
+public:
+  /// Constructor. Note that this constructor takes the start state from the
+  /// current state of the passed MetaSkeleton.
+  ///
+  /// \param[in] stateSpace State space.
+  /// \param[in] metaSkeleton MetaSkeleton that getStartState will return the
+  /// current state of when called.
+  /// \param[in] endEffectorBodyNode BodyNode to be planned to move to a desired
+  /// TSR.
+  /// \param[in] goalTSR Goal TSR.
+  /// \param[in] constraintTsr The constraint TSR for the trajectory.
+  /// \param[in] constraint Trajectory-wide constraint that must be satisfied.
+  /// \throw If \c stateSpace is not compatible with \c constraint's state
+  /// space.
+  ConfigurationToTSRwithTrajectoryConstraint(
+      statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+      ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton,
+      ::dart::dynamics::ConstBodyNodePtr endEffectorBodyNode,
+      constraint::dart::ConstTSRPtr goalTSR,
+      constraint::dart::ConstTSRPtr constraintTSR,
+      constraint::ConstTestablePtr constraint = nullptr);
+
+  /// Constructor. Note that this constructor sets the start state on
+  /// construction.
+  ///
+  /// \param[in] stateSpace State space.
+  /// \param[in] startState Start state to plan from.
+  /// \param[in] endEffectorBodyNode BodyNode to be planned to move to a desired
+  /// TSR.
+  /// \param[in] maxSamples Maximum number of TSR samples to plan to.
+  /// \param[in] goalTSR Goal TSR.
+  /// \param[in] constraintTsr The constraint TSR for the trajectory
+  /// \param[in] constraint Trajectory-wide constraint that must be satisfied.
+  /// \throw If \c stateSpace is not compatible with \c constraint's state
+  /// space.
+  ConfigurationToTSRwithTrajectoryConstraint(
+      statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+      const statespace::dart::MetaSkeletonStateSpace::State* startState,
+      ::dart::dynamics::ConstBodyNodePtr endEffectorBodyNode,
+      constraint::dart::ConstTSRPtr goalTSR,
+      constraint::dart::ConstTSRPtr constraintTSR,
+      constraint::ConstTestablePtr constraint = nullptr);
+
+  /// Return the trajectory constraint TSR
+  constraint::dart::ConstTSRPtr getConstraintTSR() const;
+
+protected:
+  /// Constraint TSR
+  const constraint::dart::ConstTSRPtr mConstraintTSR;
+};
+
+} // namespace dart
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_DART_CONFIGURATIONTOTSRWITHTRAJECTORYCONSTRAINT_HPP_

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -13,19 +13,6 @@ set(sources
   SequenceMetaPlanner.cpp
   World.cpp
   WorldStateSaver.cpp
-  dart/ConfigurationToConfiguration.cpp
-  dart/ConfigurationToConfigurationPlanner.cpp
-  dart/ConfigurationToEndEffectorOffset.cpp
-  dart/ConfigurationToEndEffectorPose.cpp
-  dart/ConfigurationToTSR.cpp
-  dart/ConfigurationToEndEffectorOffsetPlanner.cpp
-  # dart/ConfigurationToEndEffectorPosePlanner.cpp
-  dart/ConfigurationToTSRPlanner.cpp
-  dart/ConfigurationToTSRwithTrajectoryConstraint.cpp
-  dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.cpp
-  dart/ConfigurationToConfiguration_to_ConfigurationToConfiguration.cpp
-  dart/ConfigurationToConfiguration_to_ConfigurationToTSR.cpp
-  dart/util.cpp
 )
 
 add_library("${PROJECT_NAME}_planner" SHARED ${sources})
@@ -61,6 +48,7 @@ add_component_dependencies(${PROJECT_NAME} planner
 clang_format_add_sources(${sources})
 
 add_subdirectory("ompl")        # [constraint], [distance], [statespace], [trajectory], dart, ompl
+add_subdirectory("dart")        # [constraint], [distance], [trajectory], [statespace], [planner_ompl], dart, ompl
 add_subdirectory("parabolic")   # [external], [common], [trajectory], [statespace], dart
 add_subdirectory("vectorfield") # [common], [trajectory], [statespace], dart
 add_subdirectory("kunzretimer") # [external], [common], [trajectory], [statespace], dart

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -21,6 +21,8 @@ set(sources
   dart/ConfigurationToEndEffectorOffsetPlanner.cpp
   # dart/ConfigurationToEndEffectorPosePlanner.cpp
   dart/ConfigurationToTSRPlanner.cpp
+  dart/ConfigurationToTSRwithTrajectoryConstraint.cpp
+  dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.cpp
   dart/ConfigurationToConfiguration_to_ConfigurationToConfiguration.cpp
   dart/ConfigurationToConfiguration_to_ConfigurationToTSR.cpp
   dart/util.cpp

--- a/src/planner/dart/CMakeLists.txt
+++ b/src/planner/dart/CMakeLists.txt
@@ -1,0 +1,64 @@
+if(CMAKE_COMPILER_IS_GNUCXX)
+  if(OMPL_VERSION VERSION_GREATER 1.2.0 OR OMPL_VERSION VERSION_EQUAL 1.2.0)
+    if(Boost_VERSION VERSION_LESS 106501)
+      message(STATUS "OMPL planners are disabled for OMPL (>=1.2.0) + GCC + "
+          "Boost (< 1.65.1). For details, please see: "
+          " https://github.com/personalrobotics/aikido/issues/363"
+      )
+      return()
+    endif()
+  endif()
+endif()
+
+#==============================================================================
+# Libraries
+#
+set(sources
+  ConfigurationToConfiguration.cpp
+  ConfigurationToConfigurationPlanner.cpp
+  ConfigurationToEndEffectorOffset.cpp
+  ConfigurationToEndEffectorPose.cpp
+  ConfigurationToTSR.cpp
+  ConfigurationToEndEffectorOffsetPlanner.cpp
+  ConfigurationToTSRPlanner.cpp
+  ConfigurationToTSRwithTrajectoryConstraint.cpp
+  CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.cpp
+  ConfigurationToConfiguration_to_ConfigurationToConfiguration.cpp
+  ConfigurationToConfiguration_to_ConfigurationToTSR.cpp
+  util.cpp
+)
+
+add_library("${PROJECT_NAME}_planner_dart" SHARED ${sources})
+target_include_directories("${PROJECT_NAME}_planner_dart" SYSTEM
+  PUBLIC
+    ${DART_INCLUDE_DIRS}
+    ${OMPL_INCLUDE_DIRS}
+)
+target_link_libraries("${PROJECT_NAME}_planner_dart"
+  PUBLIC
+    "${PROJECT_NAME}_common"
+    "${PROJECT_NAME}_constraint"
+    "${PROJECT_NAME}_distance"
+    "${PROJECT_NAME}_trajectory"
+    "${PROJECT_NAME}_statespace"
+    "${PROJECT_NAME}_planner"
+    "${PROJECT_NAME}_planner_ompl"
+    ${DART_LIBRARIES}
+    ${OMPL_LIBRARIES}
+)
+target_compile_options("${PROJECT_NAME}_planner_dart"
+  PUBLIC ${AIKIDO_CXX_STANDARD_FLAGS}
+)
+
+add_component(${PROJECT_NAME} planner_dart)
+add_component_targets(${PROJECT_NAME} planner_dart "${PROJECT_NAME}_planner_dart")
+add_component_dependencies(${PROJECT_NAME} planner_dart
+  constraint
+  distance
+  planner
+  planner_ompl
+  statespace
+  trajectory
+)
+
+clang_format_add_sources(${sources})

--- a/src/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.cpp
+++ b/src/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.cpp
@@ -10,7 +10,7 @@
 #include "aikido/constraint/TestableIntersection.hpp"
 #include "aikido/constraint/dart/InverseKinematicsSampleable.hpp"
 #include "aikido/distance/defaults.hpp"
-#include "aikido/planner/ompl/OMPLConfigurationToConfigurationPlanner.hpp"
+#include "aikido/planner/ompl/Planner.hpp"
 #include "aikido/statespace/GeodesicInterpolator.hpp"
 #include "aikido/statespace/StateSpace.hpp"
 #include "aikido/statespace/dart/MetaSkeletonStateSaver.hpp"
@@ -87,9 +87,9 @@ CRRTConfigurationToTSRwithTrajectoryConstraintPlanner::plan(
       throw std::invalid_argument("MetaSkeleton has more than 1 skeleton.");
   }
 
-  const auto bodyNode = problem.getEndEffectorBodyNode();
-  const auto goalTsr = problem.getGoalTSR();
-  const auto constraintTsr = problem.getConstraintTSR();
+  auto bodyNode = problem.getEndEffectorBodyNode();
+  auto goalTsr = problem.getGoalTSR();
+  auto constraintTsr = problem.getConstraintTSR();
 
   // Create an IK solver with metaSkeleton dofs
   auto ik = InverseKinematics::create(const_cast<BodyNode*>(bodyNode.get()));

--- a/src/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.cpp
+++ b/src/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.cpp
@@ -3,52 +3,53 @@
 #include <ompl/geometric/planners/rrt/RRTConnect.h>
 
 #include "aikido/constraint.hpp"
-#include "aikido/constraint/Testable.hpp"
 #include "aikido/constraint/CyclicSampleable.hpp"
 #include "aikido/constraint/FiniteSampleable.hpp"
 #include "aikido/constraint/NewtonsMethodProjectable.hpp"
+#include "aikido/constraint/Testable.hpp"
 #include "aikido/constraint/TestableIntersection.hpp"
 #include "aikido/constraint/dart/InverseKinematicsSampleable.hpp"
 #include "aikido/distance/defaults.hpp"
 #include "aikido/planner/ompl/OMPLConfigurationToConfigurationPlanner.hpp"
-#include "aikido/statespace/dart/MetaSkeletonStateSaver.hpp"
-#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
 #include "aikido/statespace/GeodesicInterpolator.hpp"
 #include "aikido/statespace/StateSpace.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSaver.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
 
 namespace aikido {
 namespace planner {
 namespace dart {
 
 using constraint::CyclicSampleable;
+using constraint::NewtonsMethodProjectable;
 using constraint::Sampleable;
-using constraint::dart::createSampleableBounds;
-using constraint::dart::FrameDifferentiable;
-using constraint::dart::InverseKinematicsSampleable;
-using constraint::dart::createTestableBounds;
+using constraint::Testable;
 using constraint::dart::createProjectableBounds;
+using constraint::dart::createSampleableBounds;
+using constraint::dart::createTestableBounds;
 using constraint::dart::FrameDifferentiable;
 using constraint::dart::FrameTestable;
+using constraint::dart::InverseKinematicsSampleable;
 using constraint::dart::TSR;
-using constraint::Testable;
-using constraint::NewtonsMethodProjectable;
 using distance::createDistanceMetric;
-using statespace::dart::MetaSkeletonStateSpace;
-using statespace::dart::MetaSkeletonStateSaver;
-using statespace::GeodesicInterpolator;
 using planner::ompl::planCRRTConnect;
+using statespace::GeodesicInterpolator;
+using statespace::dart::MetaSkeletonStateSaver;
+using statespace::dart::MetaSkeletonStateSpace;
 
-using ::dart::dynamics::InverseKinematics;
 using ::dart::dynamics::BodyNode;
+using ::dart::dynamics::InverseKinematics;
 
 //==============================================================================
 CRRTConfigurationToTSRwithTrajectoryConstraintPlanner::
     CRRTConfigurationToTSRwithTrajectoryConstraintPlanner(
-      statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
-      ::dart::dynamics::MetaSkeletonPtr metaSkeleton,
-      double timelimit,
-      robot::util::CRRTPlannerParameters crrtParameters)
-  : dart::SingleProblemPlanner<CRRTConfigurationToTSRwithTrajectoryConstraintPlanner, ConfigurationToTSRwithTrajectoryConstraint>(
+        statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+        ::dart::dynamics::MetaSkeletonPtr metaSkeleton,
+        double timelimit,
+        robot::util::CRRTPlannerParameters crrtParameters)
+  : dart::SingleProblemPlanner<
+        CRRTConfigurationToTSRwithTrajectoryConstraintPlanner,
+        ConfigurationToTSRwithTrajectoryConstraint>(
         std::move(stateSpace), std::move(metaSkeleton))
   , mCRRTParameters(std::move(crrtParameters))
   , mTimelimit(timelimit)
@@ -57,7 +58,8 @@ CRRTConfigurationToTSRwithTrajectoryConstraintPlanner::
 }
 
 //==============================================================================
-trajectory::TrajectoryPtr CRRTConfigurationToTSRwithTrajectoryConstraintPlanner::plan(
+trajectory::TrajectoryPtr
+CRRTConfigurationToTSRwithTrajectoryConstraintPlanner::plan(
     const SolvableProblem& problem, Result* /*result*/)
 {
   std::size_t projectionMaxIteration = mCRRTParameters.projectionMaxIteration;
@@ -71,8 +73,8 @@ trajectory::TrajectoryPtr CRRTConfigurationToTSRwithTrajectoryConstraintPlanner:
   DART_UNUSED(saver);
 
   // Create seed constraint
-  std::shared_ptr<Sampleable> seedConstraint
-      = createSampleableBounds(mMetaSkeletonStateSpace, mCRRTParameters.rng->clone());
+  std::shared_ptr<Sampleable> seedConstraint = createSampleableBounds(
+      mMetaSkeletonStateSpace, mCRRTParameters.rng->clone());
 
   // TODO: DART may be updated to check for single skeleton
   if (mMetaSkeleton->getNumDofs() == 0)
@@ -106,7 +108,8 @@ trajectory::TrajectoryPtr CRRTConfigurationToTSRwithTrajectoryConstraintPlanner:
   // create goal testable
   auto goalTestable = std::make_shared<FrameTestable>(
       std::const_pointer_cast<MetaSkeletonStateSpace>(mMetaSkeletonStateSpace),
-      mMetaSkeleton, bodyNode.get(),
+      mMetaSkeleton,
+      bodyNode.get(),
       std::const_pointer_cast<TSR>(goalTsr));
 
   // create constraint sampleable
@@ -131,7 +134,8 @@ trajectory::TrajectoryPtr CRRTConfigurationToTSRwithTrajectoryConstraintPlanner:
       frameDiff, projectionToleranceVec, projectionMaxIteration);
 
   // Current state
-  auto startState = mMetaSkeletonStateSpace->getScopedStateFromMetaSkeleton(mMetaSkeleton.get());
+  auto startState = mMetaSkeletonStateSpace->getScopedStateFromMetaSkeleton(
+      mMetaSkeleton.get());
 
   // Call planner
   auto traj = planCRRTConnect(

--- a/src/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.cpp
+++ b/src/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.cpp
@@ -1,0 +1,160 @@
+#include "aikido/planner/dart/CRRTConfigurationToTSRwithTrajectoryConstraintPlanner.hpp"
+
+#include <ompl/geometric/planners/rrt/RRTConnect.h>
+
+#include "aikido/constraint.hpp"
+#include "aikido/constraint/Testable.hpp"
+#include "aikido/constraint/CyclicSampleable.hpp"
+#include "aikido/constraint/FiniteSampleable.hpp"
+#include "aikido/constraint/NewtonsMethodProjectable.hpp"
+#include "aikido/constraint/TestableIntersection.hpp"
+#include "aikido/constraint/dart/InverseKinematicsSampleable.hpp"
+#include "aikido/distance/defaults.hpp"
+#include "aikido/planner/ompl/OMPLConfigurationToConfigurationPlanner.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSaver.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
+#include "aikido/statespace/GeodesicInterpolator.hpp"
+#include "aikido/statespace/StateSpace.hpp"
+
+namespace aikido {
+namespace planner {
+namespace dart {
+
+using constraint::CyclicSampleable;
+using constraint::Sampleable;
+using constraint::dart::createSampleableBounds;
+using constraint::dart::FrameDifferentiable;
+using constraint::dart::InverseKinematicsSampleable;
+using constraint::dart::createTestableBounds;
+using constraint::dart::createProjectableBounds;
+using constraint::dart::FrameDifferentiable;
+using constraint::dart::FrameTestable;
+using constraint::dart::TSR;
+using constraint::Testable;
+using constraint::NewtonsMethodProjectable;
+using distance::createDistanceMetric;
+using statespace::dart::MetaSkeletonStateSpace;
+using statespace::dart::MetaSkeletonStateSaver;
+using statespace::GeodesicInterpolator;
+using planner::ompl::planCRRTConnect;
+
+using ::dart::dynamics::InverseKinematics;
+using ::dart::dynamics::BodyNode;
+
+//==============================================================================
+CRRTConfigurationToTSRwithTrajectoryConstraintPlanner::
+    CRRTConfigurationToTSRwithTrajectoryConstraintPlanner(
+      statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+      ::dart::dynamics::MetaSkeletonPtr metaSkeleton,
+      double timelimit,
+      robot::util::CRRTPlannerParameters crrtParameters)
+  : dart::SingleProblemPlanner<CRRTConfigurationToTSRwithTrajectoryConstraintPlanner, ConfigurationToTSRwithTrajectoryConstraint>(
+        std::move(stateSpace), std::move(metaSkeleton))
+  , mCRRTParameters(std::move(crrtParameters))
+  , mTimelimit(timelimit)
+{
+  // Do nothing
+}
+
+//==============================================================================
+trajectory::TrajectoryPtr CRRTConfigurationToTSRwithTrajectoryConstraintPlanner::plan(
+    const SolvableProblem& problem, Result* /*result*/)
+{
+  std::size_t projectionMaxIteration = mCRRTParameters.projectionMaxIteration;
+  double projectionTolerance = mCRRTParameters.projectionTolerance;
+
+  auto robot = mMetaSkeleton->getBodyNode(0)->getSkeleton();
+  std::lock_guard<std::mutex> lock(robot->getMutex());
+
+  // Save the current state of the stateSpace
+  auto saver = MetaSkeletonStateSaver(mMetaSkeleton);
+  DART_UNUSED(saver);
+
+  // Create seed constraint
+  std::shared_ptr<Sampleable> seedConstraint
+      = createSampleableBounds(mMetaSkeletonStateSpace, mCRRTParameters.rng->clone());
+
+  // TODO: DART may be updated to check for single skeleton
+  if (mMetaSkeleton->getNumDofs() == 0)
+    throw std::invalid_argument("MetaSkeleton has 0 degrees of freedom.");
+
+  auto skeleton = mMetaSkeleton->getDof(0)->getSkeleton();
+  for (size_t i = 1; i < mMetaSkeleton->getNumDofs(); ++i)
+  {
+    if (mMetaSkeleton->getDof(i)->getSkeleton() != skeleton)
+      throw std::invalid_argument("MetaSkeleton has more than 1 skeleton.");
+  }
+
+  const auto bodyNode = problem.getEndEffectorBodyNode();
+  const auto goalTsr = problem.getGoalTSR();
+  const auto constraintTsr = problem.getConstraintTSR();
+
+  // Create an IK solver with metaSkeleton dofs
+  auto ik = InverseKinematics::create(const_cast<BodyNode*>(bodyNode.get()));
+
+  ik->setDofs(mMetaSkeleton->getDofs());
+
+  // create goal sampleable
+  auto goalSampleable = std::make_shared<InverseKinematicsSampleable>(
+      mMetaSkeletonStateSpace,
+      mMetaSkeleton,
+      std::make_shared<CyclicSampleable>(std::const_pointer_cast<TSR>(goalTsr)),
+      seedConstraint,
+      ik,
+      mCRRTParameters.maxNumTrials);
+
+  // create goal testable
+  auto goalTestable = std::make_shared<FrameTestable>(
+      std::const_pointer_cast<MetaSkeletonStateSpace>(mMetaSkeletonStateSpace),
+      mMetaSkeleton, bodyNode.get(),
+      std::const_pointer_cast<TSR>(goalTsr));
+
+  // create constraint sampleable
+  auto constraintSampleable = std::make_shared<InverseKinematicsSampleable>(
+      mMetaSkeletonStateSpace,
+      mMetaSkeleton,
+      std::const_pointer_cast<TSR>(constraintTsr),
+      seedConstraint,
+      ik,
+      mCRRTParameters.maxNumTrials);
+
+  // create constraint projectable
+  auto frameDiff = std::make_shared<FrameDifferentiable>(
+      std::const_pointer_cast<MetaSkeletonStateSpace>(mMetaSkeletonStateSpace),
+      mMetaSkeleton,
+      bodyNode.get(),
+      std::const_pointer_cast<TSR>(constraintTsr));
+
+  std::vector<double> projectionToleranceVec(
+      frameDiff->getConstraintDimension(), projectionTolerance);
+  auto constraintProjectable = std::make_shared<NewtonsMethodProjectable>(
+      frameDiff, projectionToleranceVec, projectionMaxIteration);
+
+  // Current state
+  auto startState = mMetaSkeletonStateSpace->getScopedStateFromMetaSkeleton(mMetaSkeleton.get());
+
+  // Call planner
+  auto traj = planCRRTConnect(
+      startState,
+      goalTestable,
+      goalSampleable,
+      constraintProjectable,
+      mMetaSkeletonStateSpace,
+      std::make_shared<GeodesicInterpolator>(mMetaSkeletonStateSpace),
+      createDistanceMetric(mMetaSkeletonStateSpace),
+      constraintSampleable,
+      std::const_pointer_cast<constraint::Testable>(problem.getConstraint()),
+      createTestableBounds(mMetaSkeletonStateSpace),
+      createProjectableBounds(mMetaSkeletonStateSpace),
+      mTimelimit,
+      mCRRTParameters.maxExtensionDistance,
+      mCRRTParameters.maxDistanceBtwProjections,
+      mCRRTParameters.minStepSize,
+      mCRRTParameters.minTreeConnectionDistance);
+
+  return traj;
+}
+
+} // namespace dart
+} // namespace planner
+} // namespace aikido

--- a/src/planner/dart/ConfigurationToTSRwithTrajectoryConstraint.cpp
+++ b/src/planner/dart/ConfigurationToTSRwithTrajectoryConstraint.cpp
@@ -7,45 +7,50 @@ namespace planner {
 namespace dart {
 
 //==============================================================================
-ConfigurationToTSRwithTrajectoryConstraint::ConfigurationToTSRwithTrajectoryConstraint(
-    statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
-    ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton,
-    ::dart::dynamics::ConstBodyNodePtr endEffectorBodyNode,
-    constraint::dart::ConstTSRPtr goalTSR,
-    constraint::dart::ConstTSRPtr constraintTSR,
-    constraint::ConstTestablePtr constraint)
+ConfigurationToTSRwithTrajectoryConstraint::
+    ConfigurationToTSRwithTrajectoryConstraint(
+        statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+        ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton,
+        ::dart::dynamics::ConstBodyNodePtr endEffectorBodyNode,
+        constraint::dart::ConstTSRPtr goalTSR,
+        constraint::dart::ConstTSRPtr constraintTSR,
+        constraint::ConstTestablePtr constraint)
   : ConfigurationToTSR(
-    std::move(stateSpace),
-    std::move(metaSkeleton),
-    std::move(endEffectorBodyNode),
-    0, // This parameter is not used in this class.
-    std::move(goalTSR),
-    std::move(constraint))
+        std::move(stateSpace),
+        std::move(metaSkeleton),
+        std::move(endEffectorBodyNode),
+        0, // This parameter is not used in this class.
+        std::move(goalTSR),
+        std::move(constraint))
   , mConstraintTSR(constraintTSR)
 {
   // Do nothing.
 }
 
 //==============================================================================
-ConfigurationToTSRwithTrajectoryConstraint::ConfigurationToTSRwithTrajectoryConstraint(
-    statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
-    const statespace::dart::MetaSkeletonStateSpace::State* startState,
-    ::dart::dynamics::ConstBodyNodePtr endEffectorBodyNode,
-    constraint::dart::ConstTSRPtr goalTSR,
-    constraint::dart::ConstTSRPtr constraintTSR,
-    constraint::ConstTestablePtr constraint)
+ConfigurationToTSRwithTrajectoryConstraint::
+    ConfigurationToTSRwithTrajectoryConstraint(
+        statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+        const statespace::dart::MetaSkeletonStateSpace::State* startState,
+        ::dart::dynamics::ConstBodyNodePtr endEffectorBodyNode,
+        constraint::dart::ConstTSRPtr goalTSR,
+        constraint::dart::ConstTSRPtr constraintTSR,
+        constraint::ConstTestablePtr constraint)
   : ConfigurationToTSR(
-    std::move(stateSpace), startState,
-    std::move(endEffectorBodyNode),
-    0, // This parameter is not used in this class.
-    std::move(goalTSR), std::move(constraint))
+        std::move(stateSpace),
+        startState,
+        std::move(endEffectorBodyNode),
+        0, // This parameter is not used in this class.
+        std::move(goalTSR),
+        std::move(constraint))
   , mConstraintTSR(constraintTSR)
 {
   // Do nothing.
 }
 
 //==============================================================================
-constraint::dart::ConstTSRPtr ConfigurationToTSRwithTrajectoryConstraint::getConstraintTSR() const
+constraint::dart::ConstTSRPtr
+ConfigurationToTSRwithTrajectoryConstraint::getConstraintTSR() const
 {
   return mConstraintTSR;
 }

--- a/src/planner/dart/ConfigurationToTSRwithTrajectoryConstraint.cpp
+++ b/src/planner/dart/ConfigurationToTSRwithTrajectoryConstraint.cpp
@@ -1,0 +1,55 @@
+#include "aikido/planner/dart/ConfigurationToTSRwithTrajectoryConstraint.hpp"
+
+#include "aikido/constraint/Testable.hpp"
+
+namespace aikido {
+namespace planner {
+namespace dart {
+
+//==============================================================================
+ConfigurationToTSRwithTrajectoryConstraint::ConfigurationToTSRwithTrajectoryConstraint(
+    statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+    ::dart::dynamics::ConstMetaSkeletonPtr metaSkeleton,
+    ::dart::dynamics::ConstBodyNodePtr endEffectorBodyNode,
+    constraint::dart::ConstTSRPtr goalTSR,
+    constraint::dart::ConstTSRPtr constraintTSR,
+    constraint::ConstTestablePtr constraint)
+  : ConfigurationToTSR(
+    std::move(stateSpace),
+    std::move(metaSkeleton),
+    std::move(endEffectorBodyNode),
+    0, // This parameter is not used in this class.
+    std::move(goalTSR),
+    std::move(constraint))
+  , mConstraintTSR(constraintTSR)
+{
+  // Do nothing.
+}
+
+//==============================================================================
+ConfigurationToTSRwithTrajectoryConstraint::ConfigurationToTSRwithTrajectoryConstraint(
+    statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+    const statespace::dart::MetaSkeletonStateSpace::State* startState,
+    ::dart::dynamics::ConstBodyNodePtr endEffectorBodyNode,
+    constraint::dart::ConstTSRPtr goalTSR,
+    constraint::dart::ConstTSRPtr constraintTSR,
+    constraint::ConstTestablePtr constraint)
+  : ConfigurationToTSR(
+    std::move(stateSpace), startState,
+    std::move(endEffectorBodyNode),
+    0, // This parameter is not used in this class.
+    std::move(goalTSR), std::move(constraint))
+  , mConstraintTSR(constraintTSR)
+{
+  // Do nothing.
+}
+
+//==============================================================================
+constraint::dart::ConstTSRPtr ConfigurationToTSRwithTrajectoryConstraint::getConstraintTSR() const
+{
+  return mConstraintTSR;
+}
+
+} // namespace dart
+} // namespace planner
+} // namespace aikido

--- a/src/planner/vectorfield/CMakeLists.txt
+++ b/src/planner/vectorfield/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries("${PROJECT_NAME}_planner_vectorfield"
     "${PROJECT_NAME}_trajectory"
     "${PROJECT_NAME}_statespace"
     "${PROJECT_NAME}_planner"
+    "${PROJECT_NAME}_planner_dart"
     ${DART_LIBRARIES}
     ${Boost_LIBRARIES}
 )

--- a/tests/planner/CMakeLists.txt
+++ b/tests/planner/CMakeLists.txt
@@ -15,7 +15,8 @@ target_link_libraries(test_DartPlanners
   "${PROJECT_NAME}_constraint"
   "${PROJECT_NAME}_distance"
   "${PROJECT_NAME}_trajectory"
-  "${PROJECT_NAME}_planner")
+  "${PROJECT_NAME}_planner"
+  "${PROJECT_NAME}_planner_dart")
 
 aikido_add_test(test_World test_World.cpp)
 target_link_libraries(test_World


### PR DESCRIPTION
In preparation for #467, this PR contains the following update:

- Add `planner::dart::ConfigurationToTSRwithTrajectoryConstraint`
- Add `planner::dart::CRRTConfigurationToTSRwithTrajectoryConstraintPlanner`
- Add `planner_dart` component and make relevant changes in CMakeLists files.

The last change is necessary because `CRRTConfigurationToTSRwithTrajectoryConstraintPlanner` needs to call `planner_ompl`, which needs to be built before this planner is compiled.

**Testing**
This PR passes existing unit tests. I'll add unit tests for this planner after the initial review.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
