### PR TITLE
Add planner_dart component for DART planners

### DIFF
--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -13,17 +13,6 @@ set(sources
   SequenceMetaPlanner.cpp
   World.cpp
   WorldStateSaver.cpp
-  dart/ConfigurationToConfiguration.cpp
-  dart/ConfigurationToConfigurationPlanner.cpp
-  dart/ConfigurationToEndEffectorOffset.cpp
-  dart/ConfigurationToEndEffectorPose.cpp
-  dart/ConfigurationToTSR.cpp
-  dart/ConfigurationToEndEffectorOffsetPlanner.cpp
-  # dart/ConfigurationToEndEffectorPosePlanner.cpp
-  dart/ConfigurationToTSRPlanner.cpp
-  dart/ConfigurationToConfiguration_to_ConfigurationToConfiguration.cpp
-  dart/ConfigurationToConfiguration_to_ConfigurationToTSR.cpp
-  dart/util.cpp
 )
 
 add_library("${PROJECT_NAME}_planner" SHARED ${sources})
@@ -59,6 +48,7 @@ add_component_dependencies(${PROJECT_NAME} planner
 clang_format_add_sources(${sources})
 
 add_subdirectory("ompl")        # [constraint], [distance], [statespace], [trajectory], dart, ompl
+add_subdirectory("dart")        # [constraint], [distance], [trajectory], [statespace], [planner_ompl], dart, ompl
 add_subdirectory("parabolic")   # [external], [common], [trajectory], [statespace], dart
 add_subdirectory("vectorfield") # [common], [trajectory], [statespace], dart
 add_subdirectory("kunzretimer") # [external], [common], [trajectory], [statespace], dart

--- a/src/planner/dart/CMakeLists.txt
+++ b/src/planner/dart/CMakeLists.txt
@@ -1,0 +1,62 @@
+if(CMAKE_COMPILER_IS_GNUCXX)
+  if(OMPL_VERSION VERSION_GREATER 1.2.0 OR OMPL_VERSION VERSION_EQUAL 1.2.0)
+    if(Boost_VERSION VERSION_LESS 106501)
+      message(STATUS "OMPL planners are disabled for OMPL (>=1.2.0) + GCC + "
+          "Boost (< 1.65.1). For details, please see: "
+          " https://github.com/personalrobotics/aikido/issues/363"
+      )
+      return()
+    endif()
+  endif()
+endif()
+
+#==============================================================================
+# Libraries
+#
+set(sources
+  ConfigurationToConfiguration.cpp
+  ConfigurationToConfigurationPlanner.cpp
+  ConfigurationToConfiguration_to_ConfigurationToConfiguration.cpp
+  ConfigurationToConfiguration_to_ConfigurationToTSR.cpp
+  ConfigurationToEndEffectorOffset.cpp
+  ConfigurationToEndEffectorPose.cpp
+  ConfigurationToEndEffectorOffsetPlanner.cpp
+  ConfigurationToTSR.cpp
+  ConfigurationToTSRPlanner.cpp
+  util.cpp
+)
+
+add_library("${PROJECT_NAME}_planner_dart" SHARED ${sources})
+target_include_directories("${PROJECT_NAME}_planner_dart" SYSTEM
+  PUBLIC
+    ${DART_INCLUDE_DIRS}
+    ${OMPL_INCLUDE_DIRS}
+)
+target_link_libraries("${PROJECT_NAME}_planner_dart"
+  PUBLIC
+    "${PROJECT_NAME}_common"
+    "${PROJECT_NAME}_constraint"
+    "${PROJECT_NAME}_distance"
+    "${PROJECT_NAME}_trajectory"
+    "${PROJECT_NAME}_statespace"
+    "${PROJECT_NAME}_planner"
+    "${PROJECT_NAME}_planner_ompl"
+    ${DART_LIBRARIES}
+    ${OMPL_LIBRARIES}
+)
+target_compile_options("${PROJECT_NAME}_planner_dart"
+  PUBLIC ${AIKIDO_CXX_STANDARD_FLAGS}
+)
+
+add_component(${PROJECT_NAME} planner_dart)
+add_component_targets(${PROJECT_NAME} planner_dart "${PROJECT_NAME}_planner_dart")
+add_component_dependencies(${PROJECT_NAME} planner_dart
+  constraint
+  distance
+  planner
+  planner_ompl
+  statespace
+  trajectory
+)
+
+clang_format_add_sources(${sources})

--- a/src/planner/vectorfield/CMakeLists.txt
+++ b/src/planner/vectorfield/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries("${PROJECT_NAME}_planner_vectorfield"
     "${PROJECT_NAME}_trajectory"
     "${PROJECT_NAME}_statespace"
     "${PROJECT_NAME}_planner"
+    "${PROJECT_NAME}_planner_dart"
     ${DART_LIBRARIES}
     ${Boost_LIBRARIES}
 )

--- a/tests/planner/CMakeLists.txt
+++ b/tests/planner/CMakeLists.txt
@@ -15,7 +15,8 @@ target_link_libraries(test_DartPlanners
   "${PROJECT_NAME}_constraint"
   "${PROJECT_NAME}_distance"
   "${PROJECT_NAME}_trajectory"
-  "${PROJECT_NAME}_planner")
+  "${PROJECT_NAME}_planner"
+  "${PROJECT_NAME}_planner_dart")
 
 aikido_add_test(test_World test_World.cpp)
 target_link_libraries(test_World


### PR DESCRIPTION
This PR creates `planner_dart` component and builds all DART planners as `planner_dart` component.
***

**Before creating a pull request**

- [ ] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
