### PR TITLE
Check that all planning problems only hold ScopedStates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 
 * Planner
 
+  * Check that all planning problems only hold ScopedStates: [#569](https://github.com/personalrobotics/aikido/pull/569)
   * Make all DART planners take MetaSkeleton, and add adapter for turning planners into DART planners: [#437](https://github.com/personalrobotics/aikido/pull/437)
   * Added parabolic timing for linear spline [#302](https://github.com/personalrobotics/aikido/pull/302), [#324](https://github.com/personalrobotics/aikido/pull/324)
   * Fixed step sequence iteration in VFP: [#303](https://github.com/personalrobotics/aikido/pull/303)

--- a/include/aikido/planner/ConfigurationToConfigurations.hpp
+++ b/include/aikido/planner/ConfigurationToConfigurations.hpp
@@ -51,7 +51,7 @@ public:
 
 protected:
   /// Start state.
-  const statespace::StateSpace::State* mStartState;
+  statespace::StateSpace::ScopedState mStartState;
 
   /// Goal States.
   const GoalStates mGoalStates;

--- a/include/aikido/planner/ConfigurationToConfigurations.hpp
+++ b/include/aikido/planner/ConfigurationToConfigurations.hpp
@@ -47,7 +47,7 @@ public:
   std::size_t getNumGoalStates() const;
 
   /// Returns goal states.
-  const GoalStates& getGoalStates() const;
+  const GoalStates getGoalStates() const;
 
 protected:
   /// Start state.

--- a/include/aikido/planner/ConfigurationToConfigurations.hpp
+++ b/include/aikido/planner/ConfigurationToConfigurations.hpp
@@ -18,7 +18,7 @@ namespace planner {
 class ConfigurationToConfigurations : public Problem
 {
 public:
-  using GoalStates = std::unordered_set<const statespace::StateSpace::State*>;
+  using GoalStates = std::vector<const statespace::StateSpace::State*>;
 
   /// Constructor.
   ///
@@ -54,7 +54,7 @@ protected:
   statespace::StateSpace::ScopedState mStartState;
 
   /// Goal States.
-  const GoalStates mGoalStates;
+  std::vector<statespace::StateSpace::ScopedState> mGoalStates;
 };
 
 } // namespace planner

--- a/include/aikido/planner/ConfigurationToConfigurations.hpp
+++ b/include/aikido/planner/ConfigurationToConfigurations.hpp
@@ -47,7 +47,7 @@ public:
   std::size_t getNumGoalStates() const;
 
   /// Returns goal states.
-  const GoalStates getGoalStates() const;
+  GoalStates getGoalStates() const;
 
 protected:
   /// Start state.

--- a/src/planner/ConfigurationToConfigurations.cpp
+++ b/src/planner/ConfigurationToConfigurations.cpp
@@ -12,7 +12,7 @@ ConfigurationToConfigurations::ConfigurationToConfigurations(
     const GoalStates& goalStates,
     constraint::ConstTestablePtr constraint)
   : Problem(std::move(stateSpace), std::move(constraint))
-  , mStartState(startState)
+  , mStartState(stateSpace->cloneState(startState))
   , mGoalStates(goalStates)
 {
   // Do nothing

--- a/src/planner/ConfigurationToConfigurations.cpp
+++ b/src/planner/ConfigurationToConfigurations.cpp
@@ -47,7 +47,7 @@ std::size_t ConfigurationToConfigurations::getNumGoalStates() const
 }
 
 //==============================================================================
-const ConfigurationToConfigurations::GoalStates&
+const ConfigurationToConfigurations::GoalStates
 ConfigurationToConfigurations::getGoalStates() const
 {
   std::vector<const statespace::StateSpace::State*> pointerStates;

--- a/src/planner/ConfigurationToConfigurations.cpp
+++ b/src/planner/ConfigurationToConfigurations.cpp
@@ -16,7 +16,7 @@ ConfigurationToConfigurations::ConfigurationToConfigurations(
 {
   for (const statespace::StateSpace::State* goal : goalStates)
   {
-      mGoalStates.push_back(stateSpace->cloneState(goal));
+    mGoalStates.push_back(stateSpace->cloneState(goal));
   }
 }
 
@@ -51,7 +51,8 @@ ConfigurationToConfigurations::GoalStates
 ConfigurationToConfigurations::getGoalStates() const
 {
   std::vector<const statespace::StateSpace::State*> pointerStates;
-  for (const auto& goal : mGoalStates) {
+  for (const auto& goal : mGoalStates)
+  {
     pointerStates.push_back(goal.getState());
   }
   return pointerStates;

--- a/src/planner/ConfigurationToConfigurations.cpp
+++ b/src/planner/ConfigurationToConfigurations.cpp
@@ -13,9 +13,11 @@ ConfigurationToConfigurations::ConfigurationToConfigurations(
     constraint::ConstTestablePtr constraint)
   : Problem(std::move(stateSpace), std::move(constraint))
   , mStartState(stateSpace->cloneState(startState))
-  , mGoalStates(goalStates)
 {
-  // Do nothing
+  for (const statespace::StateSpace::State* goal : goalStates)
+  {
+      mGoalStates.push_back(stateSpace->cloneState(goal));
+  }
 }
 
 //==============================================================================
@@ -48,7 +50,13 @@ std::size_t ConfigurationToConfigurations::getNumGoalStates() const
 const ConfigurationToConfigurations::GoalStates&
 ConfigurationToConfigurations::getGoalStates() const
 {
-  return mGoalStates;
+  std::vector<const statespace::StateSpace::State*> pointerStates;
+  for (size_t idx = 0; idx < mGoalStates.size(); idx++)
+  {
+    pointerStates.push_back(mGoalStates.at(idx).getState());
+  }
+
+  return pointerStates;
 }
 
 } // namespace planner

--- a/src/planner/ConfigurationToConfigurations.cpp
+++ b/src/planner/ConfigurationToConfigurations.cpp
@@ -47,15 +47,13 @@ std::size_t ConfigurationToConfigurations::getNumGoalStates() const
 }
 
 //==============================================================================
-const ConfigurationToConfigurations::GoalStates
+ConfigurationToConfigurations::GoalStates
 ConfigurationToConfigurations::getGoalStates() const
 {
   std::vector<const statespace::StateSpace::State*> pointerStates;
-  for (size_t idx = 0; idx < mGoalStates.size(); idx++)
-  {
-    pointerStates.push_back(mGoalStates.at(idx).getState());
+  for (const auto& goal : mGoalStates) {
+    pointerStates.push_back(goal.getState());
   }
-
   return pointerStates;
 }
 


### PR DESCRIPTION
See: https://github.com/personalrobotics/aikido/issues/445

I've gone through and checked that all planner problem classes hold only `ScopedState` instead of raw pointers (to prevent the dangling pointer issue mentioned above). 

It turns out the only class that needed fixing was `ConfigurationToConfigurations`. At some point, it looks like the other problems were moved over to holding `ScopedState`. This PR addresses this.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
