### PR TITLE
Change Boost version string to canonical representation

### DIFF
--- a/src/planner/ompl/CMakeLists.txt
+++ b/src/planner/ompl/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(CMAKE_COMPILER_IS_GNUCXX)
   if(OMPL_VERSION VERSION_GREATER 1.2.0 OR OMPL_VERSION VERSION_EQUAL 1.2.0)
-    if(Boost_VERSION VERSION_LESS 106501)
+    if(Boost_VERSION VERSION_LESS 1.65.1)
       message(STATUS "OMPL planners are disabled for OMPL (>=1.2.0) + GCC + "
           "Boost (< 1.65.1). For details, please see: "
           " https://github.com/personalrobotics/aikido/issues/363"


### PR DESCRIPTION
Replace `0` with `.`, as is done in the OMPL version check in the previous line.

This is required on newer version of CMake.

***

**Before creating a pull request**

- [ N/A ] Document new methods and classes
- [ N/A ] Format code with `make format`

**Before merging a pull request**

- [ N/A ] Set version target by selecting a milestone on the right side
- [ N/A ] Summarize this change in `CHANGELOG.md`
- [ N/A ] Add unit test(s) for this change
