### PR TITLE
Delete old post-processor code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Planner
 
   * Defined post-processor parameter structs in AIKIDO: [#579](https://github.com/personalrobotics/aikido/pull/579)
-  * Deleted old post-processor code: [#581](https://github.com/personalrobotics/aikido/pull/581)
+  * Deleted old post-processor interface: [#581](https://github.com/personalrobotics/aikido/pull/581)
 
 ### 0.3.0 (2020-05-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Planner
 
   * Defined post-processor parameter structs in AIKIDO: [#579](https://github.com/personalrobotics/aikido/pull/579)
+  * Deleted old post-processor code: [#581](https://github.com/personalrobotics/aikido/pull/581)
 
 ### 0.3.0 (2020-05-22)
 

--- a/include/aikido/robot/ConcreteManipulator.hpp
+++ b/include/aikido/robot/ConcreteManipulator.hpp
@@ -32,24 +32,6 @@ public:
   virtual ConstHandPtr getHand() const override;
 
   // Documentation inherited.
-  virtual std::unique_ptr<aikido::trajectory::Spline> smoothPath(
-      const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-      const aikido::trajectory::Trajectory* path,
-      const constraint::TestablePtr& constraint) override;
-
-  // Documentation inherited.
-  virtual std::unique_ptr<aikido::trajectory::Spline> retimePath(
-      const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-      const aikido::trajectory::Trajectory* path) override;
-
-  // Documentation inherited.
-  virtual std::unique_ptr<aikido::trajectory::Spline> retimePathWithKunz(
-      const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-      const aikido::trajectory::Trajectory* path,
-      double maxDeviation,
-      double timestep) override;
-
-  // Documentation inherited.
   virtual std::future<void> executeTrajectory(
       const trajectory::TrajectoryPtr& trajectory) const override;
 

--- a/include/aikido/robot/ConcreteRobot.hpp
+++ b/include/aikido/robot/ConcreteRobot.hpp
@@ -54,24 +54,6 @@ public:
   virtual ~ConcreteRobot() = default;
 
   // Documentation inherited.
-  virtual aikido::trajectory::UniqueSplinePtr smoothPath(
-      const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-      const aikido::trajectory::Trajectory* path,
-      const constraint::TestablePtr& constraint) override;
-
-  // Documentation inherited.
-  virtual aikido::trajectory::UniqueSplinePtr retimePath(
-      const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-      const aikido::trajectory::Trajectory* path) override;
-
-  // Documentation inherited.
-  virtual std::unique_ptr<aikido::trajectory::Spline> retimePathWithKunz(
-      const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-      const aikido::trajectory::Trajectory* path,
-      double maxDeviation,
-      double timestep) override;
-
-  // Documentation inherited.
   virtual std::future<void> executeTrajectory(
       const trajectory::TrajectoryPtr& trajectory) const override;
 
@@ -111,20 +93,6 @@ public:
       const statespace::dart::ConstMetaSkeletonStateSpacePtr& space,
       const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
       const constraint::dart::CollisionFreePtr& collisionFree) const override;
-
-  // Get a smoothing post postprocessor that respects velocity and acceleration
-  // limits, as well as the passed constraint.
-  /// \param[in] metaSkeleton The MetaSkeleton whose limits must be respected.
-  std::shared_ptr<aikido::planner::TrajectoryPostProcessor>
-  getTrajectoryPostProcessor(
-      const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-      bool enableShortcut,
-      bool enableBlend,
-      double shortcutTimelimit,
-      double blendRadius,
-      int blendIterations,
-      double feasibilityCheckResolution,
-      double feasibilityApproxTolerance) const;
 
   /// Get a postprocessor that respects velocity and acceleration limits. The
   /// specific postprocessor returned is controlled by `postProcessorParams`.

--- a/include/aikido/robot/Robot.hpp
+++ b/include/aikido/robot/Robot.hpp
@@ -28,37 +28,6 @@ class Robot
 public:
   virtual ~Robot() = default;
 
-  /// Returns a timed trajectory that can be executed by the robot.
-  /// \param[in] metaSkeleton Metaskeleton of the path.
-  /// \param[in] path Geometric path to execute.
-  /// \param[in] constraint Must be satisfied after postprocessing. Typically
-  /// collision constraint is passed.
-  virtual std::unique_ptr<aikido::trajectory::Spline> smoothPath(
-      const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-      const aikido::trajectory::Trajectory* path,
-      const constraint::TestablePtr& constraint)
-      = 0;
-
-  /// Returns a timed trajectory that can be executed by the robot.
-  /// \param[in] metaSkeleton Metaskeleton of the path.
-  /// \param[in] path Geometric path to execute.
-  virtual std::unique_ptr<aikido::trajectory::Spline> retimePath(
-      const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-      const aikido::trajectory::Trajectory* path)
-      = 0;
-
-  /// Returns a timed trajectory computed with KunzRetimer
-  /// \param[in] metaSkeleton Metaskeleton of the path.
-  /// \param[in] path Geometric path to execute.
-  /// \param[in] maxDeviation Maximum deviation allowed from original path.
-  /// \param[in] timestep Time step between trajectory points.
-  virtual std::unique_ptr<aikido::trajectory::Spline> retimePathWithKunz(
-      const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-      const aikido::trajectory::Trajectory* path,
-      double maxDeviation,
-      double timestep)
-      = 0;
-
   /// Executes a trajectory
   /// \param[in] trajectory Timed trajectory to execute
   virtual std::future<void> executeTrajectory(

--- a/src/robot/ConcreteManipulator.cpp
+++ b/src/robot/ConcreteManipulator.cpp
@@ -20,34 +20,6 @@ ConstHandPtr ConcreteManipulator::getHand() const
 }
 
 //==============================================================================
-std::unique_ptr<aikido::trajectory::Spline> ConcreteManipulator::smoothPath(
-    const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-    const aikido::trajectory::Trajectory* path,
-    const constraint::TestablePtr& constraint)
-{
-  return mRobot->smoothPath(metaSkeleton, path, constraint);
-}
-
-//==============================================================================
-std::unique_ptr<aikido::trajectory::Spline> ConcreteManipulator::retimePath(
-    const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-    const aikido::trajectory::Trajectory* path)
-{
-  return mRobot->retimePath(metaSkeleton, path);
-}
-
-//==============================================================================
-std::unique_ptr<aikido::trajectory::Spline>
-ConcreteManipulator::retimePathWithKunz(
-    const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-    const aikido::trajectory::Trajectory* path,
-    double maxDeviation,
-    double timestep)
-{
-  return mRobot->retimePathWithKunz(metaSkeleton, path, maxDeviation, timestep);
-}
-
-//==============================================================================
 std::future<void> ConcreteManipulator::executeTrajectory(
     const trajectory::TrajectoryPtr& trajectory) const
 {

--- a/src/robot/ConcreteRobot.cpp
+++ b/src/robot/ConcreteRobot.cpp
@@ -121,73 +121,6 @@ ConcreteRobot::ConcreteRobot(
 }
 
 //==============================================================================
-UniqueSplinePtr ConcreteRobot::smoothPath(
-    const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-    const aikido::trajectory::Trajectory* path,
-    const constraint::TestablePtr& constraint)
-{
-  Eigen::VectorXd velocityLimits = getVelocityLimits(*metaSkeleton);
-  Eigen::VectorXd accelerationLimits = getAccelerationLimits(*metaSkeleton);
-  auto smoother
-      = std::make_shared<ParabolicSmoother>(velocityLimits, accelerationLimits);
-
-  auto interpolated = dynamic_cast<const Interpolated*>(path);
-  if (interpolated)
-    return smoother->postprocess(
-        *interpolated, *(cloneRNG().get()), constraint);
-
-  auto spline = dynamic_cast<const Spline*>(path);
-  if (spline)
-    return smoother->postprocess(*spline, *(cloneRNG().get()), constraint);
-
-  throw std::invalid_argument("Path should be either Spline or Interpolated.");
-}
-
-//==============================================================================
-UniqueSplinePtr ConcreteRobot::retimePath(
-    const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-    const aikido::trajectory::Trajectory* path)
-{
-  Eigen::VectorXd velocityLimits = getVelocityLimits(*metaSkeleton);
-  Eigen::VectorXd accelerationLimits = getAccelerationLimits(*metaSkeleton);
-  auto retimer
-      = std::make_shared<ParabolicTimer>(velocityLimits, accelerationLimits);
-
-  auto interpolated = dynamic_cast<const Interpolated*>(path);
-  if (interpolated)
-    return retimer->postprocess(*interpolated, *(cloneRNG().get()));
-
-  auto spline = dynamic_cast<const Spline*>(path);
-  if (spline)
-    return retimer->postprocess(*spline, *(cloneRNG().get()));
-
-  throw std::invalid_argument("Path should be either Spline or Interpolated.");
-}
-
-//==============================================================================
-UniqueSplinePtr ConcreteRobot::retimePathWithKunz(
-    const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-    const aikido::trajectory::Trajectory* path,
-    double maxDeviation,
-    double timestep)
-{
-  Eigen::VectorXd velocityLimits = getVelocityLimits(*metaSkeleton);
-  Eigen::VectorXd accelerationLimits = getAccelerationLimits(*metaSkeleton);
-  auto retimer = std::make_shared<KunzRetimer>(
-      velocityLimits, accelerationLimits, maxDeviation, timestep);
-
-  auto interpolated = dynamic_cast<const Interpolated*>(path);
-  if (interpolated)
-    return retimer->postprocess(*interpolated, *(cloneRNG().get()));
-
-  auto spline = dynamic_cast<const Spline*>(path);
-  if (spline)
-    return retimer->postprocess(*spline, *(cloneRNG().get()));
-
-  throw std::invalid_argument("Path should be either Spline or Interpolated.");
-}
-
-//==============================================================================
 std::future<void> ConcreteRobot::executeTrajectory(
     const TrajectoryPtr& trajectory) const
 {
@@ -302,33 +235,6 @@ TestablePtr ConcreteRobot::getFullCollisionConstraint(
   }
 
   return std::make_shared<TestableIntersection>(space, constraints);
-}
-
-//==============================================================================
-std::shared_ptr<TrajectoryPostProcessor>
-ConcreteRobot::getTrajectoryPostProcessor(
-    const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-    bool enableShortcut,
-    bool enableBlend,
-    double shortcutTimelimit,
-    double blendRadius,
-    int blendIterations,
-    double feasibilityCheckResolution,
-    double feasibilityApproxTolerance) const
-{
-  Eigen::VectorXd velocityLimits = getVelocityLimits(*metaSkeleton);
-  Eigen::VectorXd accelerationLimits = getAccelerationLimits(*metaSkeleton);
-
-  return std::make_shared<ParabolicSmoother>(
-      velocityLimits,
-      accelerationLimits,
-      enableShortcut,
-      enableBlend,
-      shortcutTimelimit,
-      blendRadius,
-      blendIterations,
-      feasibilityCheckResolution,
-      feasibilityApproxTolerance);
 }
 
 //==============================================================================


### PR DESCRIPTION
Now that we've merged https://github.com/personalrobotics/aikido/pull/579 and all upstream PRs, it's time to delete the old PP functionality before we had these nice new methods. Specifically, we're throwing out `smoothPath`, `retimePath`, `retimePathWithKunz`, and the old version of `getTrajectoryPostProcessor` that was hardcoded to return a ParabolicSmoother.

This will break lots of things upstream, but we'll handle those separately.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
