### PR TITLE
Bump OSX Travis version to 12u.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
       services: docker
 
     - os: osx
-      osx_image: xcode11.6
+      osx_image: xcode12u
       compiler: clang
       env:
         - BUILD_NAME=XCODE11_CMAKE_RELEASE
@@ -99,7 +99,7 @@ jobs:
       services: docker
 
     - os: osx
-      osx_image: xcode11.6
+      osx_image: xcode12u
       compiler: clang
       env:
         - BUILD_NAME=XCODE11_CMAKE_RELEASE


### PR DESCRIPTION
For some reason OSX Travis is busted again, but bumping the image version (again) seems to fix things.

Hopefully unblocks https://github.com/personalrobotics/aikido/pull/574.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
