### PR TITLE
Deprecate robot/util -> planToConfiguration() [WIP]

### DIFF
--- a/include/aikido/robot/util.hpp
+++ b/include/aikido/robot/util.hpp
@@ -93,22 +93,6 @@ struct CRRTPlannerParameters
   double projectionTolerance;
 };
 
-/// Plan the robot to a specific configuration.
-/// Restores the robot to its initial configuration after planning.
-/// \param[in] space The StateSpace for the metaskeleton
-/// \param[in] metaSkeleton MetaSkeleton to plan with.
-/// \param[in] goalState Goal state
-/// \param[in] collisionTestable Testable constraint to check for collision.
-/// \param[in] rng Random number generator
-/// \param[in] timelimit Max time to spend per planning to each IK
-trajectory::TrajectoryPtr planToConfiguration(
-    const statespace::dart::MetaSkeletonStateSpacePtr& space,
-    const dart::dynamics::MetaSkeletonPtr& metaSkeleton,
-    const statespace::StateSpace::State* goalState,
-    const constraint::TestablePtr& collisionTestable,
-    common::RNG* rng,
-    double timelimit);
-
 /// Plan the robot to a set of configurations.
 /// Restores the robot to its initial configuration after planning.
 /// \param[in] space The StateSpace for the metaskeleton


### PR DESCRIPTION
This PR removes `planToConfiguration()` from `robot/util`, and updates the corresponding function in `ConcreteRobot` to use a snap planner.

We actually don't remove the method completely from `robot/util`, just the header: it's needed elsewhere in the `.cpp` file.

**TODO/WIP**:

1. Should we use the normal `ConfigurationToConfiguration` planner, or the DART version? Both work fine here and the normal version requires less cruft, so I've gone with that. LMK your thoughts!
2. Should we construct the planner in `ConcreteRobot -> planToConfiguration`, or have a planner member var in `ConcreteRobot`? The reason I didn't do this is because the `MetaSkeleton` passed to the planner constructor(s) may not match the `metaSkeleton` argument of `planToConfiguration()`.

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [ ] Format code with `make format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
