### PR TITLE
Fix crashing OSX Travis Image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
       services: docker
 
     - os: osx
-      osx_image: xcode12u
+      osx_image: xcode12
       compiler: clang
       env:
         - BUILD_NAME=XCODE11_CMAKE_RELEASE
@@ -99,7 +99,7 @@ jobs:
       services: docker
 
     - os: osx
-      osx_image: xcode12u
+      osx_image: xcode12
       compiler: clang
       env:
         - BUILD_NAME=XCODE11_CMAKE_RELEASE


### PR DESCRIPTION
OSX Travis is crashing again because of the same inability to find DART. Switching the image version again from 12u -> 12 seems to fix this.

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [ ] Format code with `make format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
