### PR TITLE
Hotfix for PlanToOffset

### DIFF
--- a/src/robot/Robot.cpp
+++ b/src/robot/Robot.cpp
@@ -455,7 +455,7 @@ trajectory::TrajectoryPtr Robot::planToOffset(
         trajPostProcessor) const
 {
   // Get Body Node
-  auto bn = mMetaSkeleton->getBodyNode(bodyNodeName);
+  auto bn = getRootSkeleton()->getBodyNode(bodyNodeName);
   if (!bn)
   {
     dtwarn << "Request body node not present in robot '" << mName << "'"
@@ -555,7 +555,7 @@ trajectory::TrajectoryPtr Robot::planToTSR(
     const distance::ConstConfigurationRankerPtr& ranker) const
 {
   // Get Body Node
-  auto bn = mMetaSkeleton->getBodyNode(bodyNodeName);
+  auto bn = getRootSkeleton()->getBodyNode(bodyNodeName);
   if (!bn)
   {
     dtwarn << "Request body node not present in robot '" << mName << "'"


### PR DESCRIPTION
The New PlanToOffset function (based on the original planToEndEffectorOffset) requires the body node to be part of the controlled Metaskeleton. This isn't actually a required check, and it makes it difficult to, say, select the end effector body node when the controlled metaskeleton only covers the controlled arm.

Additionally, the ConfigurationToEndEffectorOffset planner needs the true metaskeleton (not a clone) to actually function properly. This was tested on the Kinova Gen3 (ADA) robot feeding demo.

***

**Before creating a pull request**

- [ N/A ] Document new methods and classes
- [ N/A ] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ N/A ] Summarize this change in `CHANGELOG.md`
- [ N/A ] Add unit test(s) for this change
