### PR TITLE
Check ability of Robot class to handle R0 joints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,21 @@
   * Added generic and position/velocity/effort Executor types [#602](https://github.com/personalrobotics/aikido/pull/602)
 
 * IO
+
   * Updated DartLoader usage, previously deprecated by DART 6.12 [#619](https://github.com/personalrobotics/aikido/pull/619)
 
 * Robot
+
   * Simplify Robot API [#593](https://github.com/personalrobotics/aikido/pull/593)
 
 * RViz
 
   * Fix addTSRMarker Bug: [#618](https://github.com/personalrobotics/aikido/pull/618)
   * Propogate removal of WorldInteractiveMarkerViewer to Aikidopy: [#599](https://github.com/personalrobotics/aikido/pull/599)
+
+* State Space
+
+  * Handle R0 (i.e. Weld) Joints in MetaSkeletonStatespace: [#622](https://github.com/personalrobotics/aikido/pull/622)
 
 * Planner
 

--- a/include/aikido/robot/util.hpp
+++ b/include/aikido/robot/util.hpp
@@ -29,7 +29,7 @@ namespace util {
 const std::vector<double> defaultVFParams{
     0.03,  // distanceTolerance
     0.004, // positionTolerance
-    0.004, // angularTolerance
+    0.01,  // angularTolerance
     0.01,  // initialStepSize
     1e-3,  // jointlimitTolerance
     1e-3,  // constraintCheckResolution

--- a/include/aikido/statespace/dart/MetaSkeletonStateSpace.hpp
+++ b/include/aikido/statespace/dart/MetaSkeletonStateSpace.hpp
@@ -39,9 +39,6 @@ public:
     /// Return the name of the MetaSkeleton.
     const std::string& getName() const;
 
-    /// Return the number of joints in the MetaSkeleton.
-    std::size_t getNumJoints() const;
-
     /// Return the number of DOFs in the MetaSkeleton.
     std::size_t getNumDofs() const;
 
@@ -78,8 +75,8 @@ public:
     /// Name of the MetaSkeleton
     std::string mName;
 
-    /// Number of joints in the MetaSkeleton
-    std::size_t mNumJoints;
+    /// Number of dofs in the MetaSkeleton
+    std::size_t mNumDofs;
 
     /// Names of DOFs in the MetaSkeleton
     std::vector<std::string> mDofNames;

--- a/src/control/KinematicSimulationTrajectoryExecutor.cpp
+++ b/src/control/KinematicSimulationTrajectoryExecutor.cpp
@@ -161,11 +161,6 @@ void KinematicSimulationTrajectoryExecutor::cancel()
     mPromise->set_exception(
         std::make_exception_ptr(std::runtime_error("Trajectory canceled.")));
   }
-  else
-  {
-    dtwarn << "[KinematicSimulationTrajectoryExecutor::cancel] Attempting to "
-           << "cancel trajectory, but no trajectory in progress.\n";
-  }
 }
 
 } // namespace control

--- a/src/planner/vectorfield/MoveEndEffectorOffsetVectorField.cpp
+++ b/src/planner/vectorfield/MoveEndEffectorOffsetVectorField.cpp
@@ -79,7 +79,8 @@ MoveEndEffectorOffsetVectorField::evaluateCartesianStatus(
 
   if (fabs(orientationError) > mAngularTolerance)
   {
-    dtwarn << "Deviated from orientation constraint.";
+    dtwarn << "Deviated from orientation constraint: ("
+           << fabs(orientationError) << " > " << mAngularTolerance << ")";
     return VectorFieldPlannerStatus::TERMINATE;
   }
 

--- a/src/robot/IkFast.cpp
+++ b/src/robot/IkFast.cpp
@@ -25,7 +25,7 @@ IkFast::IkFast(
   std::vector<std::size_t> ikFastFreeDofs = {};
 
   // TODO (sniyaz): Add free DOF support!
-  for (size_t i = 0; i < armSpace->getProperties().getNumJoints(); i++)
+  for (size_t i = 0; i < armSpace->getProperties().getNumDofs(); i++)
   {
     ikFastSolveDofs.push_back(i);
   }

--- a/src/robot/Robot.cpp
+++ b/src/robot/Robot.cpp
@@ -45,10 +45,8 @@ Robot::Robot(
   , mSelfCollisionFilter(
         std::make_shared<dart::collision::BodyNodeCollisionFilter>())
 {
-  auto controlledMetaSkeleton
-      = dart::dynamics::Group::create(name, mMetaSkeleton->getDofs());
   mStateSpace = std::make_shared<statespace::dart::MetaSkeletonStateSpace>(
-      controlledMetaSkeleton.get());
+      mMetaSkeleton.get());
 
   auto skeletonObj = getRootSkeleton();
   skeletonObj->enableSelfCollisionCheck();
@@ -81,10 +79,8 @@ Robot::Robot(
   , mSelfCollisionFilter(collisionFilter)
   , mWorld(nullptr)
 {
-  auto controlledMetaSkeleton
-      = dart::dynamics::Group::create(name, mMetaSkeleton->getDofs());
   mStateSpace = std::make_shared<statespace::dart::MetaSkeletonStateSpace>(
-      controlledMetaSkeleton.get());
+      mMetaSkeleton.get());
 }
 
 //==============================================================================

--- a/src/statespace/dart/MetaSkeletonStateSpace.cpp
+++ b/src/statespace/dart/MetaSkeletonStateSpace.cpp
@@ -71,6 +71,7 @@ std::vector<std::shared_ptr<const JointStateSpace>> createStateSpace(
       }
     }
 
+    // Do not add R0 spaces
     spaces.emplace_back(createJointStateSpace(joint).release());
   }
 
@@ -83,7 +84,7 @@ std::vector<std::shared_ptr<const JointStateSpace>> createStateSpace(
 MetaSkeletonStateSpace::Properties::Properties(
     const ::dart::dynamics::MetaSkeleton* metaskeleton)
   : mName(metaskeleton->getName())
-  , mNumJoints(metaskeleton->getNumJoints())
+  , mNumDofs(metaskeleton->getNumDofs())
   , mDofNames(metaskeleton->getNumDofs())
   , mPositionLowerLimits(metaskeleton->getPositionLowerLimits())
   , mPositionUpperLimits(metaskeleton->getPositionUpperLimits())
@@ -124,15 +125,9 @@ const std::string& MetaSkeletonStateSpace::Properties::getName() const
 }
 
 //==============================================================================
-std::size_t MetaSkeletonStateSpace::Properties::getNumJoints() const
-{
-  return mNumJoints;
-}
-
-//==============================================================================
 std::size_t MetaSkeletonStateSpace::Properties::getNumDofs() const
 {
-  return mDofNames.size();
+  return mNumDofs;
 }
 
 //==============================================================================
@@ -216,7 +211,7 @@ bool MetaSkeletonStateSpace::Properties::operator==(
   if (mName != otherProperties.mName)
     return false;
 
-  if (mNumJoints != otherProperties.mNumJoints)
+  if (mNumDofs != otherProperties.mNumDofs)
     return false;
 
   if (mDofNames != otherProperties.mDofNames)
@@ -225,7 +220,7 @@ bool MetaSkeletonStateSpace::Properties::operator==(
   if (mIndexMap != otherProperties.mIndexMap)
     return false;
 
-  for (std::size_t i = 0; i < mNumJoints; ++i)
+  for (std::size_t i = 0; i < mNumDofs; ++i)
   {
     if (mPositionLowerLimits[i] != otherProperties.mPositionLowerLimits[i])
       return false;

--- a/src/trajectory/util.cpp
+++ b/src/trajectory/util.cpp
@@ -21,6 +21,7 @@ using aikido::statespace::CartesianProduct;
 using aikido::statespace::ConstStateSpacePtr;
 using aikido::statespace::GeodesicInterpolator;
 using aikido::statespace::R;
+using aikido::statespace::R0;
 using aikido::statespace::R1;
 using aikido::statespace::SO2;
 using aikido::statespace::StateSpace;
@@ -47,6 +48,10 @@ bool checkStateSpace(const statespace::StateSpace* _stateSpace)
     return true;
   }
   else if (dynamic_cast<const SO2*>(_stateSpace) != nullptr)
+  {
+    return true;
+  }
+  else if (dynamic_cast<const R0*>(_stateSpace) != nullptr)
   {
     return true;
   }
@@ -266,7 +271,7 @@ UniqueInterpolatedPtr toR1JointTrajectory(const Interpolated& trajectory)
 {
   if (!checkStateSpace(trajectory.getStateSpace().get()))
     throw std::invalid_argument(
-        "toR1JointTrajectory only supports R1 and SO2 joint spaces");
+        "toR1JointTrajectory only supports R1, SO2, and R0 joint spaces");
 
   auto interpolator = std::dynamic_pointer_cast<const GeodesicInterpolator>(
       trajectory.getInterpolator());

--- a/src/trajectory/util.cpp
+++ b/src/trajectory/util.cpp
@@ -42,7 +42,7 @@ namespace {
 
 bool checkStateSpace(const statespace::StateSpace* _stateSpace)
 {
-  // Only supports single-DOF joint spaces, namely R1 and SO2.
+  // Only supports single-DOF joint spaces, namely R1 and SO2 (and R0).
   if (dynamic_cast<const R1*>(_stateSpace) != nullptr)
   {
     return true;


### PR DESCRIPTION
Previously, the Robot class only worked with "controlled MetaSkeletons" by default (i.e. the MetaSkeleton stripped of all fixed and R0 joints). However, our planners do not make that distinction by default. Therefore, there were number-of-joint mismatches between many generated trajectories and their corresponding MetaSkeletons when checking state space compatibility.

The solution was to either:
(1) Update the codebase to strip all R0 joints from any MetaSkeletons we plan on.
OR
(2) Just remove the concept of joints entirely from the MetaSkeletonStateSpace and only deal with DoFs.

Because DART already deals only with DoFs in functions like "getPositions", this push goes for the latter.

As a consequence, some conversion code that claims to only work with R1 and SO2 joints was updated to allow R0 joints (which make no change to code execution anyway).

***

**Before creating a pull request**

- [ N/A ] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
