### PR TITLE
Make sure self-collision chcks entire skeleton, not just subrobot

### DIFF
--- a/src/robot/Robot.cpp
+++ b/src/robot/Robot.cpp
@@ -292,7 +292,8 @@ constraint::dart::CollisionFreePtr Robot::getSelfCollisionConstraint() const
       = std::make_shared<constraint::dart::CollisionFree>(
           mStateSpace, mMetaSkeleton, mCollisionDetector, collisionOption);
   collisionFreeConstraint->addSelfCheck(
-      mCollisionDetector->createCollisionGroupAsSharedPtr(mMetaSkeleton.get()));
+      mCollisionDetector->createCollisionGroupAsSharedPtr(
+          getRootSkeleton().get()));
   return collisionFreeConstraint;
 }
 


### PR DESCRIPTION
Quick 1-line fix to Robot class.

***

**Before creating a pull request**

- [ N/A ] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [ N/A ] Set version target by selecting a milestone on the right side
- [ N/A ] Summarize this change in `CHANGELOG.md`
- [ N/A ] Add unit test(s) for this change
