### PR TITLE
Add planToPoseOffset via VectorFieldPosePlanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
   * Simplify Robot API [#593](https://github.com/personalrobotics/aikido/pull/593)
   * Implemented generic Executors into Robot class [#614](https://github.com/personalrobotics/aikido/pull/614)
-  * Added planToTwist into Robot class [#628](https://github.com/personalrobotics/aikido/pull/628)
+  * Added planToPoseOffset into Robot class [#628](https://github.com/personalrobotics/aikido/pull/628)
 
 * RViz
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
   * Fixed bug in RosTrajectoryExecutor [#596](https://github.com/personalrobotics/aikido/pull/596)
   * Added generic and position/velocity/effort Executor types [#602](https://github.com/personalrobotics/aikido/pull/602)
   * Added JacobianExecutor wrapping any Velocity/EffortExecutor [#605](https://github.com/personalrobotics/aikido/pull/605)
-  * Implemented generic Executors into Robot class [#614](https://github.com/personalrobotics/aikido/pull/614)
   * Added VisualServoingVelocityExecutor wrapping JacobianExecutor [#620](https://github.com/personalrobotics/aikido/pull/620)
   * Ignored R0 (i.e. Weld) Joints in Conversions [#623](https://github.com/personalrobotics/aikido/pull/623)
 
@@ -18,6 +17,8 @@
 * Robot
 
   * Simplify Robot API [#593](https://github.com/personalrobotics/aikido/pull/593)
+  * Implemented generic Executors into Robot class [#614](https://github.com/personalrobotics/aikido/pull/614)
+  * Added planToTwist into Robot class [#628](https://github.com/personalrobotics/aikido/pull/628)
 
 * RViz
 
@@ -35,6 +36,7 @@
   * Added ConfigurationToConfigurations planner adapter: [#587](https://github.com/personalrobotics/aikido/pull/587)
   * Cleaned up planning methods in robot/util: [#588](https://github.com/personalrobotics/aikido/pull/588)
   * Added batches to ConcreteRobot's planToTSR: [#607](https://github.com/personalrobotics/aikido/pull/607)
+  * Added ConfigurationToEndEffectorPose planner type [#628](https://github.com/personalrobotics/aikido/pull/628)
 
 * Build & Testing & ETC
 

--- a/include/aikido/common/util.hpp
+++ b/include/aikido/common/util.hpp
@@ -1,6 +1,7 @@
 #ifndef AIKIDO_COMMON_UTIL_HPP_
 #define AIKIDO_COMMON_UTIL_HPP_
 
+#include <cmath>
 #include <future>
 
 namespace aikido {
@@ -23,6 +24,16 @@ inline std::future<T> make_ready_future(T obj)
   auto promise = std::promise<T>();
   promise.set_value(obj);
   return promise.get_future();
+}
+
+/// Check for a value near-zero
+#ifndef AIKIDO_COMMON_NEARZERO
+#define AIKIDO_COMMON_NEARZERO 1E-8
+#endif
+
+inline bool FuzzyZero(double value, double tol = AIKIDO_COMMON_NEARZERO)
+{
+  return (abs(value) <= tol);
 }
 
 } // namespace common

--- a/include/aikido/planner/dart/ConfigurationToEndEffectorPosePlanner.hpp
+++ b/include/aikido/planner/dart/ConfigurationToEndEffectorPosePlanner.hpp
@@ -1,0 +1,51 @@
+#ifndef AIKIDO_PLANNER_DART_CONFIGURATIONTOENDEFFECTORPOSEPLANNER_HPP_
+#define AIKIDO_PLANNER_DART_CONFIGURATIONTOENDEFFECTORPOSEPLANNER_HPP_
+
+#include "aikido/planner/dart/ConfigurationToEndEffectorPose.hpp"
+#include "aikido/planner/dart/SingleProblemPlanner.hpp"
+#include "aikido/statespace/dart/MetaSkeletonStateSpace.hpp"
+#include "aikido/trajectory/Trajectory.hpp"
+
+namespace aikido {
+namespace planner {
+namespace dart {
+
+/// Base planner class for ConfigurationToEndEffectorPose planning problem.
+class ConfigurationToEndEffectorPosePlanner
+  : public dart::SingleProblemPlanner<
+        ConfigurationToEndEffectorPosePlanner,
+        ConfigurationToEndEffectorPose>
+{
+public:
+  // Expose the implementation of Planner::plan(const Problem&, Result*) in
+  // SingleProblemPlanner. Note that plan() of the base class takes Problem
+  // while the virtual function defined in this class takes SolvableProblem,
+  // which is simply ConfigurationToEndEffectorPose.
+  using SingleProblemPlanner::plan;
+
+  /// Constructor
+  ///
+  /// \param[in] stateSpace State space that this planner associated with.
+  /// \param[in] metaSkeleton MetaSkeleton to use for planning.
+  ConfigurationToEndEffectorPosePlanner(
+      statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+      ::dart::dynamics::MetaSkeletonPtr metaSkeleton);
+
+  /// Solves \c problem returning the result to \c result.
+  /// NOTE: Because this is a DART planner, this method must both 1) lock the
+  /// MetaSkeleton during planning and 2) reset the MetaSkeleton state after
+  /// planning.
+  ///
+  /// \param[in] problem Planning problem to be solved by the planner.
+  /// \param[out] result Result of planning procedure.
+  virtual trajectory::TrajectoryPtr plan(
+      const SolvableProblem& problem, Result* result = nullptr)
+      = 0;
+  // Note: SolvableProblem is defined in SingleProblemPlanner.
+};
+
+} // namespace dart
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_DART_CONFIGURATIONTOENDEFFECTORPOSEPLANNER_HPP_

--- a/include/aikido/planner/vectorfield/MoveEndEffectorPoseVectorField.hpp
+++ b/include/aikido/planner/vectorfield/MoveEndEffectorPoseVectorField.hpp
@@ -1,6 +1,8 @@
 #ifndef AIKIDO_PLANNER_VECTORFIELD_MOVEENDEFFECTORPOSEVECTORFIELD_HPP_
 #define AIKIDO_PLANNER_VECTORFIELD_MOVEENDEFFECTORPOSEVECTORFIELD_HPP_
 
+#include <limits>
+
 #include "aikido/planner/vectorfield/BodyNodePoseVectorField.hpp"
 
 namespace aikido {
@@ -76,7 +78,11 @@ protected:
 
   /// Cache for desired twist between start and goal.
   Eigen::Vector6d mDesiredTwist;
-  Eigen::Vector6d mNormalizedTwist;
+  Eigen::Vector3d mDirection;
+  Eigen::Vector3d mRotation;
+
+  /// Cache of last pose error
+  std::shared_ptr<double> mLastPoseError;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/include/aikido/planner/vectorfield/MoveEndEffectorPoseVectorField.hpp
+++ b/include/aikido/planner/vectorfield/MoveEndEffectorPoseVectorField.hpp
@@ -28,10 +28,10 @@ public:
   /// \param[in] metaskeleton MetaSkeleton to plan with
   /// \param[in] bn Body node of end-effector.
   /// \param[in] goalPose Desired end-effector pose.
-  /// \param[in] goalTolerance Stop when within this value of goal pose.
+  /// \param[in] goalTolerance Geodesic Distance from goal to stop planning.
   /// \param[in] r Conversion of radius to meters in computing goalTolerance.
-  /// \param[in] positionTolerance Constraint tolerance in meters.
-  /// \param[in] angularTolerance Constraint tolerance in radians.
+  /// \param[in] positionTolerance Straight-line constraint tolerance in meters.
+  /// \param[in] angularTolerance Rotation deviation tolerance in radians.
   /// \param[in] maxStepSize The maximum step size used to guarantee
   /// that the integrator does not step out of joint limits.
   /// \param[in] jointLimitPadding If less then this distance to joint
@@ -65,7 +65,7 @@ protected:
   double mGoalTolerance;
 
   /// Conversion ratio from radius to meter.
-  double mConversionRatioFromRadiusToMeter;
+  double mConversionRatioFromRadianToMeter;
 
   /// Tolerance of linear deviation error.
   double mPositionTolerance;

--- a/include/aikido/planner/vectorfield/MoveEndEffectorPoseVectorField.hpp
+++ b/include/aikido/planner/vectorfield/MoveEndEffectorPoseVectorField.hpp
@@ -26,20 +26,23 @@ public:
   /// \param[in] metaskeleton MetaSkeleton to plan with
   /// \param[in] bn Body node of end-effector.
   /// \param[in] goalPose Desired end-effector pose.
-  /// \param[in] poseErrorTolerance Constraint error tolerance in meters.
-  /// \param[in] r Conversion of radius to meters in computing Geodesic
-  /// distance.
+  /// \param[in] goalTolerance Stop when within this value of goal pose.
+  /// \param[in] r Conversion of radius to meters in computing goalTolerance.
+  /// \param[in] positionTolerance Constraint tolerance in meters.
+  /// \param[in] angularTolerance Constraint tolerance in radians.
   /// \param[in] maxStepSize The maximum step size used to guarantee
   /// that the integrator does not step out of joint limits.
   /// \param[in] jointLimitPadding If less then this distance to joint
   /// limit, velocity is bounded in that direction to 0.
   MoveEndEffectorPoseVectorField(
-      aikido::statespace::dart::MetaSkeletonStateSpacePtr stateSpace,
-      dart::dynamics::MetaSkeletonPtr metaskeleton,
-      dart::dynamics::BodyNodePtr bn,
+      aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+      ::dart::dynamics::MetaSkeletonPtr metaskeleton,
+      ::dart::dynamics::ConstBodyNodePtr bn,
       const Eigen::Isometry3d& goalPose,
-      double poseErrorTolerance,
+      double goalTolerance,
       double r,
+      double positionTolerance,
+      double angularTolerance,
       double maxStepSize,
       double jointLimitPadding);
 
@@ -57,10 +60,23 @@ protected:
   Eigen::Isometry3d mGoalPose;
 
   /// Tolerance of pose error.
-  double mPoseErrorTolerance;
+  double mGoalTolerance;
 
   /// Conversion ratio from radius to meter.
   double mConversionRatioFromRadiusToMeter;
+
+  /// Tolerance of linear deviation error.
+  double mPositionTolerance;
+
+  /// Tolerance of angular error.
+  double mAngularTolerance;
+
+  /// Start pose of the end-effector.
+  Eigen::Isometry3d mStartPose;
+
+  /// Cache for desired twist between start and goal.
+  Eigen::Vector6d mDesiredTwist;
+  Eigen::Vector6d mNormalizedTwist;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/include/aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorPosePlanner.hpp
+++ b/include/aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorPosePlanner.hpp
@@ -1,0 +1,94 @@
+#ifndef AIKIDO_PLANNER_VECTORFIELD_VECTORFIELDCONFIGURATIONTOENDEFFECTORPOSEPLANNER_HPP_
+#define AIKIDO_PLANNER_VECTORFIELD_VECTORFIELDCONFIGURATIONTOENDEFFECTORPOSEPLANNER_HPP_
+
+#include "aikido/planner/dart/ConfigurationToEndEffectorPose.hpp"
+#include "aikido/planner/dart/ConfigurationToEndEffectorPosePlanner.hpp"
+
+namespace aikido {
+namespace planner {
+namespace vectorfield {
+
+/// Planner that generates a trajectory that moves the end-effector to
+/// a given pose.
+class VectorFieldConfigurationToEndEffectorPosePlanner
+  : public planner::dart::ConfigurationToEndEffectorPosePlanner
+{
+public:
+  /// Constructor.
+  ///
+  /// \param[in] stateSpace State space that this planner is associated with.
+  /// \param[in] metaSkeleton MetaSkeleton to plan with.
+  /// \param[in] goalTolerance Distance from goal to stop planning.
+  /// \param[in] anglePoseRatio Conversion ratio from radian to
+  /// meter in computing the goal tolerance.
+  /// \param[in] positionTolerance How a planned trajectory is allowed to
+  /// deviated from a straight line segment defined by the direction and the
+  /// distance.
+  /// \param[in] angularTolerance How a planned trajectory is allowed to deviate
+  /// from a given direction.
+  /// \param[in] initialStepSize Initial step size.
+  /// \param[in] jointLimitTolerance If less then this distance to joint
+  /// limit, velocity is bounded in that direction to 0.
+  /// \param[in] constraintCheckResolution Resolution used in constraint
+  /// checking.
+  /// \param[in] timelimit timeout in seconds.
+  VectorFieldConfigurationToEndEffectorPosePlanner(
+      statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+      ::dart::dynamics::MetaSkeletonPtr metaSkeleton,
+      double goalTolerance,
+      double anglePoseRatio,
+      double positionTolerance,
+      double angularTolerance,
+      double initialStepSize,
+      double jointLimitTolerance,
+      double constraintCheckResolution,
+      std::chrono::duration<double> timelimit);
+
+  /// Plan to a trajectory that moves the end-effector to a
+  /// given pose.
+  ///
+  /// The planner returns success if the resulting trajectory satisfies
+  /// constraint at some resolution and failure (returning \c nullptr)
+  /// otherwise. The reason for the failure is stored in the \c result output
+  /// parameter.
+  ///
+  /// \param[in] problem Planning problem.
+  /// \param[out] result Information about success or failure.
+  /// \return Trajectory or \c nullptr if planning failed.
+  trajectory::TrajectoryPtr plan(
+      const SolvableProblem& problem, Result* result = nullptr) override;
+
+protected:
+  /// Tolerated geodesic distance from goal.
+  double mGoalTolerance;
+
+  /// Conversion ratio from radian to
+  /// meter in computing the combined geodesic error.
+  double mAnglePoseRatio;
+
+  /// How a planned trajectory is allowed to deviated from a straight line
+  /// segment defined by the direction and the distance.
+  double mPositionTolerance;
+
+  /// How a planned trajectory is allowed to deviate from a given direction.
+  double mAngularTolerance;
+
+  /// Initial step size.
+  double mInitialStepSize;
+
+  /// If less then this distance to joint limit, velocity is bounded in that
+  /// direction to 0.
+  double mJointLimitTolerance;
+
+  /// Resolution used in constraint checking.
+  double mConstraintCheckResolution;
+
+  /// Timeout in seconds.
+  std::chrono::duration<double> mTimelimit;
+};
+
+} // namespace vectorfield
+} // namespace planner
+} // namespace aikido
+
+#endif // AIKIDO_PLANNER_VECTORFIELD_VECTORFIELDCONFIGURATIONTOENDEFFECTORPOSEPLANNER_HPP_

--- a/include/aikido/planner/vectorfield/VectorFieldPlanner.hpp
+++ b/include/aikido/planner/vectorfield/VectorFieldPlanner.hpp
@@ -83,11 +83,14 @@ aikido::trajectory::UniqueInterpolatedPtr planToEndEffectorOffset(
 /// \param[in] bn Body node of the end-effector.
 /// \param[in] constraint Trajectory-wide constraint that must be satisfied.
 /// \param[in] goalPose Desired end-effector pose.
-/// \param[in] poseErrorTolerance How a planned trajectory is allowed to
+/// \param[in] goalTolerance Distance from goal to stop planning.
+/// \param[in] conversionRatioInGeodesicDistance Conversion ratio from radius to
+/// meter in comparison with goalTolerance.
+/// \param[in] positionTolerance How a planned trajectory is allowed to
 /// deviated from a straight line segment defined by the direction and the
 /// distance.
-/// \param[in] conversionRatioInGeodesicDistance Conversion ratio from radius to
-/// meter in computing geodesic distance.
+/// \param[in] angularTolerance How a planned trajectory is allowed to deviate
+/// from a given direction.
 /// \param[in] initialStepSize Initial step size.
 /// \param[in] jointLimitTolerance If less then this distance to joint
 /// limit, velocity is bounded in that direction to 0.
@@ -96,13 +99,16 @@ aikido::trajectory::UniqueInterpolatedPtr planToEndEffectorOffset(
 /// \param[out] result information about success or failure.
 /// \return Trajectory or \c nullptr if planning failed.
 aikido::trajectory::UniqueInterpolatedPtr planToEndEffectorPose(
-    const aikido::statespace::dart::MetaSkeletonStateSpacePtr& stateSpace,
+    const aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr& stateSpace,
+    const statespace::dart::MetaSkeletonStateSpace::State& startState,
     ::dart::dynamics::MetaSkeletonPtr metaskeleton,
-    const ::dart::dynamics::BodyNodePtr& bn,
-    const aikido::constraint::TestablePtr& constraint,
+    const ::dart::dynamics::ConstBodyNodePtr& bn,
+    const aikido::constraint::ConstTestablePtr& constraint,
     const Eigen::Isometry3d& goalPose,
-    double poseErrorTolerance,
+    double goalTolerance,
     double conversionRatioInGeodesicDistance,
+    double positionTolerance,
+    double angularTolerance,
     double initialStepSize,
     double jointLimitTolerance,
     double constraintCheckResolution,

--- a/include/aikido/planner/vectorfield/VectorFieldPlanner.hpp
+++ b/include/aikido/planner/vectorfield/VectorFieldPlanner.hpp
@@ -83,18 +83,20 @@ aikido::trajectory::UniqueInterpolatedPtr planToEndEffectorOffset(
 /// \param[in] bn Body node of the end-effector.
 /// \param[in] constraint Trajectory-wide constraint that must be satisfied.
 /// \param[in] goalPose Desired end-effector pose.
-/// \param[in] goalTolerance Distance from goal to stop planning.
-/// \param[in] conversionRatioInGeodesicDistance Conversion ratio from radians
-/// to meters for comparisons with goalTolerance. \param[in] positionTolerance
-/// How a planned trajectory is allowed to deviated from a straight line segment
-/// defined by the direction and the distance. \param[in] angularTolerance How a
-/// planned trajectory is allowed to deviate from a given direction. \param[in]
-/// initialStepSize Initial step size. \param[in] jointLimitTolerance If less
-/// then this distance to joint limit, velocity is bounded in that direction to
-/// 0. \param[in] constraintCheckResolution Resolution used in constraint
-/// checking. \param[in] timelimit Timeout in seconds. \param[out] result
-/// information about success or failure. \return Trajectory or \c nullptr if
-/// planning failed.
+/// \param[in] goalTolerance Geodesic distance from goal to stop planning
+/// \param[in] conversionRatioInGeodesicDistance Conversion ratio from radian to
+/// meter in computing geodesic distance
+/// \param[in] positionTolerance How a planned trajectory is allowed to deviate
+/// from a straight line segment.
+/// \param[in] angularTolerance How a planned trajectory is allowed to
+/// deviate from a straight rotation.
+/// \param[in] initialStepSize Initial step size.
+/// \param[in] jointLimitTolerance If less then this distance to joint limit,
+/// velocity is bounded in that direction to 0.
+/// \param[in] constraintCheckResolution Resolution used in constraint checking.
+/// \param[in] timelimit Timeout in seconds.
+/// \param[out] result Information about success or failure.
+/// \return Trajectory or \c nullptr if plannin failed.
 aikido::trajectory::UniqueInterpolatedPtr planToEndEffectorPose(
     const aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr& stateSpace,
     const statespace::dart::MetaSkeletonStateSpace::State& startState,

--- a/include/aikido/planner/vectorfield/VectorFieldPlanner.hpp
+++ b/include/aikido/planner/vectorfield/VectorFieldPlanner.hpp
@@ -84,20 +84,17 @@ aikido::trajectory::UniqueInterpolatedPtr planToEndEffectorOffset(
 /// \param[in] constraint Trajectory-wide constraint that must be satisfied.
 /// \param[in] goalPose Desired end-effector pose.
 /// \param[in] goalTolerance Distance from goal to stop planning.
-/// \param[in] conversionRatioInGeodesicDistance Conversion ratio from radius to
-/// meter in comparison with goalTolerance.
-/// \param[in] positionTolerance How a planned trajectory is allowed to
-/// deviated from a straight line segment defined by the direction and the
-/// distance.
-/// \param[in] angularTolerance How a planned trajectory is allowed to deviate
-/// from a given direction.
-/// \param[in] initialStepSize Initial step size.
-/// \param[in] jointLimitTolerance If less then this distance to joint
-/// limit, velocity is bounded in that direction to 0.
-/// \param[in] constraintCheckResolution Resolution used in constraint checking.
-/// \param[in] timelimit Timeout in seconds.
-/// \param[out] result information about success or failure.
-/// \return Trajectory or \c nullptr if planning failed.
+/// \param[in] conversionRatioInGeodesicDistance Conversion ratio from radians
+/// to meters for comparisons with goalTolerance. \param[in] positionTolerance
+/// How a planned trajectory is allowed to deviated from a straight line segment
+/// defined by the direction and the distance. \param[in] angularTolerance How a
+/// planned trajectory is allowed to deviate from a given direction. \param[in]
+/// initialStepSize Initial step size. \param[in] jointLimitTolerance If less
+/// then this distance to joint limit, velocity is bounded in that direction to
+/// 0. \param[in] constraintCheckResolution Resolution used in constraint
+/// checking. \param[in] timelimit Timeout in seconds. \param[out] result
+/// information about success or failure. \return Trajectory or \c nullptr if
+/// planning failed.
 aikido::trajectory::UniqueInterpolatedPtr planToEndEffectorPose(
     const aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr& stateSpace,
     const statespace::dart::MetaSkeletonStateSpace::State& startState,

--- a/include/aikido/robot/Robot.hpp
+++ b/include/aikido/robot/Robot.hpp
@@ -206,17 +206,17 @@ public:
 
   ///
   /// Plan a specific body node of the robot to
-  /// a twist (i.e. position offset + rotation).
+  /// a pose offset (i.e. position offset + rotation).
   ///
   /// \param[in] bodyNodeName Bodynode (usually the end effector) to offset
-  /// \param[in] offset Position offset in R^3
-  /// \param[in] rotation Rotation (R^3 vector, norm is rotation amount)
+  /// \param[in] offset Translation in R^3 (world Frame)
+  /// \param[in] rotation Axis in R^3, norm is angle (world Frame)
   /// \param[in] testableConstraint Planning (e.g. collision) constraints, set
   /// to nullptr for no constraints (not recommended)
   /// \param[in] planner Configuration planner, defaults to
   /// VectorFieldConfigurationToEndEffectorOffsetPlanner
   /// with robot::util::defaultVFParams
-  trajectory::TrajectoryPtr planToTwist(
+  trajectory::TrajectoryPtr planToPoseOffset(
       const std::string bodyNodeName,
       const Eigen::Vector3d& offset,
       const Eigen::Vector3d& rotation,
@@ -229,7 +229,7 @@ public:
       = nullptr) const;
 
   /// Default to selfCollisionConstraint
-  trajectory::TrajectoryPtr planToTwist(
+  trajectory::TrajectoryPtr planToPoseOffset(
       const std::string bodyNodeName,
       const Eigen::Vector3d& offset,
       const Eigen::Vector3d& rotation,

--- a/include/aikido/robot/Robot.hpp
+++ b/include/aikido/robot/Robot.hpp
@@ -22,6 +22,7 @@
 #include "aikido/planner/Planner.hpp"
 #include "aikido/planner/World.hpp"
 #include "aikido/planner/dart/ConfigurationToEndEffectorOffsetPlanner.hpp"
+#include "aikido/planner/dart/ConfigurationToEndEffectorPosePlanner.hpp"
 #include "aikido/planner/kunzretimer/KunzRetimer.hpp"
 #include "aikido/robot/util.hpp"
 #include "aikido/statespace/StateSpace.hpp"
@@ -178,7 +179,8 @@ public:
   /// \param[in] offset Position offset in R^3
   /// \param[in] testableConstraint Planning (e.g. collision) constraints, set
   /// to nullptr for no constraints (not recommended)
-  /// \param[in] planner Configuration planner, defaults to VectorFieldPlanner
+  /// \param[in] planner Configuration-to-Offset planner, defaults to
+  /// VectorFieldConfigurationToEndEffectorOffsetPlanner
   /// with robot::util::defaultVFParams
   trajectory::TrajectoryPtr planToOffset(
       const std::string bodyNodeName,
@@ -197,6 +199,42 @@ public:
       const Eigen::Vector3d& offset,
       const std::shared_ptr<
           planner::dart::ConfigurationToEndEffectorOffsetPlanner>& planner
+      = nullptr,
+      const std::shared_ptr<aikido::planner::TrajectoryPostProcessor>
+          trajPostProcessor
+      = nullptr) const;
+
+  ///
+  /// Plan a specific body node of the robot to
+  /// a twist (i.e. position offset + rotation).
+  ///
+  /// \param[in] bodyNodeName Bodynode (usually the end effector) to offset
+  /// \param[in] offset Position offset in R^3
+  /// \param[in] rotation Rotation (R^3 vector, norm is rotation amount)
+  /// \param[in] testableConstraint Planning (e.g. collision) constraints, set
+  /// to nullptr for no constraints (not recommended)
+  /// \param[in] planner Configuration planner, defaults to
+  /// VectorFieldConfigurationToEndEffectorOffsetPlanner
+  /// with robot::util::defaultVFParams
+  trajectory::TrajectoryPtr planToTwist(
+      const std::string bodyNodeName,
+      const Eigen::Vector3d& offset,
+      const Eigen::Vector3d& rotation,
+      const constraint::TestablePtr& testableConstraint,
+      const std::shared_ptr<
+          planner::dart::ConfigurationToEndEffectorPosePlanner>& planner
+      = nullptr,
+      const std::shared_ptr<aikido::planner::TrajectoryPostProcessor>
+          trajPostProcessor
+      = nullptr) const;
+
+  /// Default to selfCollisionConstraint
+  trajectory::TrajectoryPtr planToTwist(
+      const std::string bodyNodeName,
+      const Eigen::Vector3d& offset,
+      const Eigen::Vector3d& rotation,
+      const std::shared_ptr<
+          planner::dart::ConfigurationToEndEffectorPosePlanner>& planner
       = nullptr,
       const std::shared_ptr<aikido::planner::TrajectoryPostProcessor>
           trajPostProcessor

--- a/include/aikido/robot/util.hpp
+++ b/include/aikido/robot/util.hpp
@@ -25,15 +25,18 @@ namespace robot {
 namespace util {
 
 /// Default Vector Field Planner Parameters
-/// Suitable for ADA-robot end-effector offsets
+/// Suitable for ADA-robot end-effector movements
 const std::vector<double> defaultVFParams{
-    0.03,  // distanceTolerance
+    0.03,  // distanceTolerance (offset-only)
     0.004, // positionTolerance
     0.01,  // angularTolerance
     0.01,  // initialStepSize
     1e-3,  // jointlimitTolerance
     1e-3,  // constraintCheckResolution
-    1.0};  // timeout
+    1.0,   // timeout (s)
+    0.01,  // goalTolerance (twist-only)
+    1.0    // angle-to-distance ratio (twist-only)
+};
 
 /// Paramters for Vector Field Planner
 struct VectorFieldPlannerParameters
@@ -58,14 +61,18 @@ struct VectorFieldPlannerParameters
       double jointLimitTolerance = defaultVFParams[4],
       double constraintCheckResolution = defaultVFParams[5],
       std::chrono::duration<double> timeout
-      = std::chrono::duration<double>(defaultVFParams[6]))
+      = std::chrono::duration<double>(defaultVFParams[6]),
+      double goalTolerance = defaultVFParams[7],
+      double angleDistanceRatio = defaultVFParams[8])
     : distanceTolerance(distanceTolerance)
     , positionTolerance(positionTolerance)
     , angularTolerance(angularTolerance)
     , initialStepSize(initialStepSize)
     , jointLimitTolerance(jointLimitTolerance)
     , constraintCheckResolution(constraintCheckResolution)
-    , timeout(timeout){
+    , timeout(timeout)
+    , goalTolerance(goalTolerance)
+    , angleDistanceRatio(angleDistanceRatio){
           // Do nothing
       };
 
@@ -76,6 +83,8 @@ struct VectorFieldPlannerParameters
   double jointLimitTolerance;
   double constraintCheckResolution;
   std::chrono::duration<double> timeout;
+  double goalTolerance;
+  double angleDistanceRatio;
 };
 
 struct CRRTPlannerParameters

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -22,7 +22,7 @@ set(sources
   dart/ConfigurationToEndEffectorPose.cpp
   dart/ConfigurationToTSR.cpp
   dart/ConfigurationToEndEffectorOffsetPlanner.cpp
-  # dart/ConfigurationToEndEffectorPosePlanner.cpp
+  dart/ConfigurationToEndEffectorPosePlanner.cpp
   dart/ConfigurationToTSRPlanner.cpp
   dart/ConfigurationToConfiguration_to_ConfigurationToConfiguration.cpp
   dart/ConfigurationToConfiguration_to_ConfigurationToConfigurations.cpp

--- a/src/planner/dart/ConfigurationToEndEffectorPosePlanner.cpp
+++ b/src/planner/dart/ConfigurationToEndEffectorPosePlanner.cpp
@@ -1,0 +1,21 @@
+#include "aikido/planner/dart/ConfigurationToEndEffectorPosePlanner.hpp"
+
+namespace aikido {
+namespace planner {
+namespace dart {
+
+//==============================================================================
+ConfigurationToEndEffectorPosePlanner::ConfigurationToEndEffectorPosePlanner(
+    statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+    ::dart::dynamics::MetaSkeletonPtr metaSkeleton)
+  : dart::SingleProblemPlanner<
+      ConfigurationToEndEffectorPosePlanner,
+      ConfigurationToEndEffectorPose>(
+      std::move(stateSpace), std::move(metaSkeleton))
+{
+  // Do nothing
+}
+
+} // namespace dart
+} // namespace planner
+} // namespace aikido

--- a/src/planner/vectorfield/CMakeLists.txt
+++ b/src/planner/vectorfield/CMakeLists.txt
@@ -3,6 +3,7 @@ set(sources
   VectorField.cpp
   VectorFieldUtil.cpp
   VectorFieldConfigurationToEndEffectorOffsetPlanner.cpp
+  VectorFieldConfigurationToEndEffectorPosePlanner.cpp
   detail/VectorFieldIntegrator.cpp
   detail/VectorFieldPlannerExceptions.cpp
   BodyNodePoseVectorField.cpp

--- a/src/planner/vectorfield/MoveEndEffectorPoseVectorField.cpp
+++ b/src/planner/vectorfield/MoveEndEffectorPoseVectorField.cpp
@@ -61,8 +61,7 @@ MoveEndEffectorPoseVectorField::MoveEndEffectorPoseVectorField(
 
   mDesiredTwist.normalize();
 
-  mLastPoseError = std::make_shared<double>(computeGeodesicDistance(
-      mStartPose, mGoalPose, mConversionRatioFromRadianToMeter));
+  mLastPoseError = std::make_shared<double>(std::numeric_limits<double>::max());
 }
 
 //==============================================================================
@@ -70,9 +69,7 @@ bool MoveEndEffectorPoseVectorField::evaluateCartesianVelocity(
     const Eigen::Isometry3d& /* pose */,
     Eigen::Vector6d& cartesianVelocity) const
 {
-  // Speed up large movements
-  double scale = std::max(*mLastPoseError, 1.0);
-  cartesianVelocity = scale * mDesiredTwist;
+  cartesianVelocity = mDesiredTwist;
   return true;
 }
 
@@ -119,7 +116,8 @@ MoveEndEffectorPoseVectorField::evaluateCartesianStatus(
   }
 
   // End if error increases
-  if (poseError > (*mLastPoseError))
+  if (poseError >= (*mLastPoseError)
+      || FuzzyZero(poseError - *(mLastPoseError)))
   {
     return VectorFieldPlannerStatus::TERMINATE;
   }

--- a/src/planner/vectorfield/MoveEndEffectorPoseVectorField.cpp
+++ b/src/planner/vectorfield/MoveEndEffectorPoseVectorField.cpp
@@ -15,31 +15,45 @@ namespace vectorfield {
 
 //==============================================================================
 MoveEndEffectorPoseVectorField::MoveEndEffectorPoseVectorField(
-    aikido::statespace::dart::MetaSkeletonStateSpacePtr stateSpace,
-    dart::dynamics::MetaSkeletonPtr metaskeleton,
-    dart::dynamics::BodyNodePtr bn,
+    aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+    ::dart::dynamics::MetaSkeletonPtr metaskeleton,
+    ::dart::dynamics::ConstBodyNodePtr bn,
     const Eigen::Isometry3d& goalPose,
-    double poseErrorTolerance,
+    double goalTolerance,
     double r,
+    double positionTolerance,
+    double angularTolerance,
     double maxStepSize,
     double jointLimitPadding)
   : BodyNodePoseVectorField(
       stateSpace, metaskeleton, bn, maxStepSize, jointLimitPadding)
   , mGoalPose(goalPose)
-  , mPoseErrorTolerance(poseErrorTolerance)
+  , mGoalTolerance(goalTolerance)
   , mConversionRatioFromRadiusToMeter(r)
+  , mPositionTolerance(positionTolerance)
+  , mAngularTolerance(angularTolerance)
+  , mStartPose(bn->getTransform())
 {
-  if (mPoseErrorTolerance < 0)
-    throw std::invalid_argument("Pose error tolerance is negative");
+  if (mGoalTolerance < 0)
+    throw std::invalid_argument("Goal tolerance is negative");
+  if (mPositionTolerance < 0)
+    throw std::invalid_argument("Position tolerance is negative");
+  if (mAngularTolerance < 0)
+    throw std::invalid_argument("Angular tolerance is negative");
+
+  mDesiredTwist = computeGeodesicTwist(mStartPose, mGoalPose);
+  mNormalizedTwist = computeGeodesicTwist(mStartPose, mGoalPose);
+  mNormalizedTwist.head<3>().normalize();
+  mNormalizedTwist.tail<3>().normalize();
 }
 
 //==============================================================================
 bool MoveEndEffectorPoseVectorField::evaluateCartesianVelocity(
-    const Eigen::Isometry3d& pose, Eigen::Vector6d& cartesianVelocity) const
+    const Eigen::Isometry3d& /* pose */,
+    Eigen::Vector6d& cartesianVelocity) const
 {
   using aikido::planner::vectorfield::computeGeodesicTwist;
-  Eigen::Vector6d desiredTwist = computeGeodesicTwist(pose, mGoalPose);
-  cartesianVelocity = desiredTwist;
+  cartesianVelocity = mDesiredTwist;
   return true;
 }
 
@@ -48,13 +62,43 @@ VectorFieldPlannerStatus
 MoveEndEffectorPoseVectorField::evaluateCartesianStatus(
     const Eigen::Isometry3d& pose) const
 {
+  // Check arrival at goal
   double poseError = computeGeodesicDistance(
       pose, mGoalPose, mConversionRatioFromRadiusToMeter);
 
-  if (poseError < mPoseErrorTolerance)
+  if (poseError < mGoalTolerance)
   {
     return VectorFieldPlannerStatus::CACHE_AND_TERMINATE;
   }
+
+  // Check for deviation from the desired trajectory.
+  const Eigen::Vector6d startTwist = computeGeodesicTwist(mStartPose, pose);
+  const Eigen::Vector3d direction = mNormalizedTwist.tail<3>();
+  const Eigen::Vector3d position = startTwist.tail<3>();
+  double movedDistance = position.transpose() * direction;
+  double positionDeviation = (position - movedDistance * direction).norm();
+
+  const Eigen::Vector3d angle = startTwist.head<3>();
+  const Eigen::Vector3d rotation = mNormalizedTwist.head<3>();
+  double movedAngle = angle.transpose() * rotation;
+  double orientationError = (angle - movedAngle * rotation).norm();
+
+  if (fabs(orientationError) > mAngularTolerance)
+  {
+    dtwarn << "Deviated from orientation constraint: ("
+           << fabs(orientationError) << " > " << mAngularTolerance << ")"
+           << std::endl;
+    return VectorFieldPlannerStatus::TERMINATE;
+  }
+
+  if (positionDeviation > mPositionTolerance)
+  {
+    dtwarn << "Deviated from straight-line constraint: "
+           << fabs(positionDeviation) << " > " << mPositionTolerance << ")"
+           << std::endl;
+    return VectorFieldPlannerStatus::TERMINATE;
+  }
+
   return VectorFieldPlannerStatus::CONTINUE;
 }
 

--- a/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorPosePlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldConfigurationToEndEffectorPosePlanner.cpp
@@ -1,0 +1,69 @@
+#include "aikido/planner/vectorfield/VectorFieldConfigurationToEndEffectorPosePlanner.hpp"
+
+#include "aikido/planner/vectorfield/VectorFieldPlanner.hpp"
+
+namespace aikido {
+namespace planner {
+namespace vectorfield {
+
+//==============================================================================
+VectorFieldConfigurationToEndEffectorPosePlanner::
+    VectorFieldConfigurationToEndEffectorPosePlanner(
+        statespace::dart::ConstMetaSkeletonStateSpacePtr stateSpace,
+        ::dart::dynamics::MetaSkeletonPtr metaSkeleton,
+        double goalTolerance,
+        double anglePoseRatio,
+        double positionTolerance,
+        double angularTolerance,
+        double initialStepSize,
+        double jointLimitTolerance,
+        double constraintCheckResolution,
+        std::chrono::duration<double> timelimit)
+  : ConfigurationToEndEffectorPosePlanner(
+      std::move(stateSpace), std::move(metaSkeleton))
+  , mGoalTolerance(goalTolerance)
+  , mAnglePoseRatio(anglePoseRatio)
+  , mPositionTolerance(positionTolerance)
+  , mAngularTolerance(angularTolerance)
+  , mInitialStepSize(initialStepSize)
+  , mJointLimitTolerance(jointLimitTolerance)
+  , mConstraintCheckResolution(constraintCheckResolution)
+  , mTimelimit(timelimit)
+{
+  // Do nothing here.
+}
+
+//==============================================================================
+trajectory::TrajectoryPtr
+VectorFieldConfigurationToEndEffectorPosePlanner::plan(
+    const SolvableProblem& problem, Result* result)
+{
+  // TODO (egordon): Check equality between state space of this planner and
+  // given problem.
+
+  using aikido::planner::vectorfield::planToEndEffectorPose;
+
+  // Just call the core VFP function.
+  // NOTE: This both locks the metaskeleton while planning and restores its
+  // state after planning.
+  return planToEndEffectorPose(
+      getMetaSkeletonStateSpace(),
+      *problem.getStartState(),
+      mMetaSkeleton,
+      problem.getEndEffectorBodyNode(),
+      problem.getConstraint(),
+      problem.getGoalPose(),
+      mGoalTolerance,
+      mAnglePoseRatio,
+      mPositionTolerance,
+      mAngularTolerance,
+      mInitialStepSize,
+      mJointLimitTolerance,
+      mConstraintCheckResolution,
+      mTimelimit,
+      result);
+}
+
+} // namespace vectorfield
+} // namespace planner
+} // namespace aikido

--- a/src/planner/vectorfield/VectorFieldPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldPlanner.cpp
@@ -98,7 +98,7 @@ aikido::trajectory::UniqueInterpolatedPtr followVectorField(
     // no enough waypoints cached to make a trajectory output.
     if (result)
     {
-      result->setMessage("No segment cached.");
+      result->setMessage("No segment cached. Timeout?");
     }
     return nullptr;
   }

--- a/src/planner/vectorfield/VectorFieldPlanner.cpp
+++ b/src/planner/vectorfield/VectorFieldPlanner.cpp
@@ -153,11 +153,8 @@ aikido::trajectory::UniqueInterpolatedPtr planToEndEffectorOffset(
   {
     throw std::runtime_error("MetaSkeleton doesn't have any body nodes.");
   }
-  auto robot = metaskeleton->getBodyNode(0)->getSkeleton();
-  std::lock_guard<std::mutex> lock(robot->getMutex());
-  // TODO(JS): The above code should be replaced by
-  // std::lock_guard<std::mutex> lock(metaskeleton->getLockableReference())
-  // once https://github.com/dartsim/dart/pull/1011 is released.
+  auto mutex = metaskeleton->getLockableReference();
+  std::lock_guard<::dart::common::LockableReference> lock(*mutex);
 
   // TODO: Check compatibility between MetaSkeleton and MetaSkeletonStateSpace
 
@@ -198,19 +195,30 @@ aikido::trajectory::UniqueInterpolatedPtr planToEndEffectorOffset(
 
 //==============================================================================
 aikido::trajectory::UniqueInterpolatedPtr planToEndEffectorPose(
-    const aikido::statespace::dart::MetaSkeletonStateSpacePtr& stateSpace,
+    const aikido::statespace::dart::ConstMetaSkeletonStateSpacePtr& stateSpace,
+    const statespace::dart::MetaSkeletonStateSpace::State& startState,
     dart::dynamics::MetaSkeletonPtr metaskeleton,
-    const dart::dynamics::BodyNodePtr& bn,
-    const aikido::constraint::TestablePtr& constraint,
+    const dart::dynamics::ConstBodyNodePtr& bn,
+    const aikido::constraint::ConstTestablePtr& constraint,
     const Eigen::Isometry3d& goalPose,
-    double poseErrorTolerance,
+    double goalTolerance,
     double conversionRatioInGeodesicDistance,
+    double positionTolerance,
+    double angularTolerance,
     double initialStepSize,
     double jointLimitTolerance,
     double constraintCheckResolution,
     std::chrono::duration<double> timelimit,
     planner::Planner::Result* result)
 {
+  // ensure that no two planners run at the same time
+  if (metaskeleton->getNumBodyNodes() == 0)
+  {
+    throw std::runtime_error("MetaSkeleton doesn't have any body nodes.");
+  }
+  auto mutex = metaskeleton->getLockableReference();
+  std::lock_guard<::dart::common::LockableReference> lock(*mutex);
+
   // TODO: Check compatibility between MetaSkeleton and MetaSkeletonStateSpace
 
   // Save the current state of the space
@@ -218,28 +226,29 @@ aikido::trajectory::UniqueInterpolatedPtr planToEndEffectorPose(
       metaskeleton, MetaSkeletonStateSaver::Options::POSITIONS);
   DART_UNUSED(saver);
 
+  stateSpace->setState(metaskeleton.get(), &startState);
+
   auto vectorfield
       = dart::common::make_aligned_shared<MoveEndEffectorPoseVectorField>(
           stateSpace,
           metaskeleton,
           bn,
           goalPose,
-          poseErrorTolerance,
+          goalTolerance,
           conversionRatioInGeodesicDistance,
+          positionTolerance,
+          angularTolerance,
           initialStepSize,
           jointLimitTolerance);
 
   auto compoundConstraint
-      = std::make_shared<aikido::constraint::TestableIntersection>(stateSpace);
+      = std::make_shared<constraint::TestableIntersection>(stateSpace);
   compoundConstraint->addConstraint(constraint);
   compoundConstraint->addConstraint(
       constraint::dart::createTestableBounds(stateSpace));
-
-  auto startState
-      = stateSpace->getScopedStateFromMetaSkeleton(metaskeleton.get());
   return followVectorField(
       *vectorfield,
-      *startState,
+      startState,
       *compoundConstraint,
       timelimit,
       initialStepSize,

--- a/src/robot/Robot.cpp
+++ b/src/robot/Robot.cpp
@@ -623,7 +623,7 @@ trajectory::TrajectoryPtr Robot::planToOffset(
 }
 
 //=============================================================================
-trajectory::TrajectoryPtr Robot::planToTwist(
+trajectory::TrajectoryPtr Robot::planToPoseOffset(
     const std::string bodyNodeName,
     const Eigen::Vector3d& offset,
     const Eigen::Vector3d& rotation,
@@ -717,7 +717,7 @@ trajectory::TrajectoryPtr Robot::planToTwist(
 }
 
 //=============================================================================
-trajectory::TrajectoryPtr Robot::planToTwist(
+trajectory::TrajectoryPtr Robot::planToPoseOffset(
     const std::string bodyNodeName,
     const Eigen::Vector3d& offset,
     const Eigen::Vector3d& rotation,
@@ -726,7 +726,7 @@ trajectory::TrajectoryPtr Robot::planToTwist(
     const std::shared_ptr<aikido::planner::TrajectoryPostProcessor>
         trajPostProcessor) const
 {
-  return planToTwist(
+  return planToPoseOffset(
       bodyNodeName,
       offset,
       rotation,

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -18,3 +18,6 @@ target_link_libraries(test_SplineProblem "${PROJECT_NAME}_common")
 
 aikido_add_test(test_string test_string.cpp)
 target_link_libraries(test_string "${PROJECT_NAME}_common")
+
+aikido_add_test(test_common_util test_util.cpp)
+target_link_libraries(test_common_util "${PROJECT_NAME}_common")

--- a/tests/common/test_util.cpp
+++ b/tests/common/test_util.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+
+#include <aikido/common/util.hpp>
+
+using namespace aikido;
+using aikido::common::FuzzyZero;
+using aikido::common::make_exceptional_future;
+using aikido::common::make_ready_future;
+
+//==============================================================================
+TEST(Util, Futures)
+{
+  std::future<int> exceptionalFuture = make_exceptional_future<int>("Testing");
+  EXPECT_THROW(exceptionalFuture.get(), std::runtime_error);
+
+  std::future<int> readyFuture = make_ready_future(5);
+  EXPECT_EQ(readyFuture.get(), 5);
+}
+
+//==============================================================================
+TEST(Util, FuzzyZero)
+{
+  EXPECT_EQ(FuzzyZero(1E-9), true);
+  EXPECT_EQ(FuzzyZero(1E-7), false);
+}

--- a/tests/planner/vectorfield/test_VectorFieldPlanner.cpp
+++ b/tests/planner/vectorfield/test_VectorFieldPlanner.cpp
@@ -448,7 +448,7 @@ TEST_F(VectorFieldPlannerTest, PlanToEndEffectorPoseAsOffsetTest)
       mStateSpace,
       mSkel,
       distanceTolerance,
-      angularTolerance / positionTolerance,
+      1.0,
       positionTolerance,
       angularTolerance,
       initialStepSize,
@@ -544,7 +544,7 @@ TEST_F(VectorFieldPlannerTest, PlanToEndEffectorPoseTest)
   mSkel->setPositions(goalConfig);
   Eigen::Isometry3d targetPose = mBodynode->getTransform();
 
-  double goalTolerance = 0.01;
+  double goalTolerance = 0.015;
   double initialStepSize = 0.05;
   double r = 1.0;
   double positionTolerance = 0.01;

--- a/tests/planner/vectorfield/test_VectorFieldPlanner.cpp
+++ b/tests/planner/vectorfield/test_VectorFieldPlanner.cpp
@@ -431,6 +431,7 @@ TEST_F(VectorFieldPlannerTest, PlanToEndEffectorPoseAsOffsetTest)
 
   Eigen::Isometry3d goalTrans = Eigen::Isometry3d::Identity();
   goalTrans.translation() = startVec + (signedDistance * direction);
+  goalTrans.linear() = startTrans.linear();
 
   double positionTolerance = 0.01;
   double angularTolerance = 0.15;
@@ -596,4 +597,184 @@ TEST_F(VectorFieldPlannerTest, PlanToEndEffectorPoseTest)
 
   double poseError = computeGeodesicDistance(endTrans, targetPose, r);
   EXPECT_LE(poseError, goalTolerance);
+}
+
+TEST_F(VectorFieldPlannerTest, PlanToEndEffectorPoseAsAngleTest)
+{
+  using aikido::planner::vectorfield::computeGeodesicDistance;
+
+  mSkel->setPositions(mStartConfig);
+  Eigen::Isometry3d startPose = mBodynode->getTransform();
+  Eigen::Isometry3d targetPose = Eigen::Isometry3d::Identity();
+  targetPose.linear() = Eigen::AngleAxisd(0.1, Eigen::Vector3d(0.0, 1.0, 0.0))
+                        * startPose.linear();
+  targetPose.translation() = startPose.translation();
+
+  double goalTolerance = 0.01;
+  double initialStepSize = 0.05;
+  double r = 1.0;
+  double positionTolerance = 0.01;
+  double angularTolerance = 0.15;
+  double jointLimitTolerance = 1e-2;
+  double constraintCheckResolution = 1e-2;
+  std::chrono::duration<double> timelimit(300.);
+
+  auto startState = mStateSpace->createState();
+  mStateSpace->getState(mSkel.get(), startState);
+
+  auto traj1 = aikido::planner::vectorfield::planToEndEffectorPose(
+      mStateSpace,
+      *startState,
+      mSkel,
+      mBodynode,
+      mPassingConstraint,
+      targetPose,
+      goalTolerance,
+      r,
+      positionTolerance,
+      angularTolerance,
+      initialStepSize,
+      jointLimitTolerance,
+      constraintCheckResolution,
+      timelimit);
+
+  EXPECT_FALSE(traj1 == nullptr) << "Trajectory not found";
+
+  if (traj1 == nullptr)
+  {
+    return;
+  }
+
+  // Extract and evalute first waypoint
+  auto firstWayPoint = mStateSpace->createState();
+  traj1->evaluate(0.0, firstWayPoint);
+  Eigen::VectorXd testStart(mNumDof);
+  mStateSpace->convertStateToPositions(firstWayPoint, testStart);
+
+  double errorTolerance = 1e-3;
+  EXPECT_TRUE((testStart - mStartConfig).norm() <= errorTolerance);
+
+  auto endpoint = mStateSpace->createState();
+  traj1->evaluate(traj1->getEndTime(), endpoint);
+  mStateSpace->setState(mSkel.get(), endpoint);
+  Eigen::Isometry3d endTrans = mBodynode->getTransform();
+
+  double poseError = computeGeodesicDistance(endTrans, targetPose, r);
+  EXPECT_LE(poseError, goalTolerance);
+}
+
+TEST_F(VectorFieldPlannerTest, PlanToEndEffectorPoseErrorsTest)
+{
+  using aikido::planner::vectorfield::computeGeodesicDistance;
+
+  Eigen::VectorXd goalConfig = Eigen::VectorXd::Zero(mNumDof);
+  goalConfig << 1.13746, -0.363612, 0.77876, 1.07515, 1.58646, -1.00034,
+      -0.03533;
+  mSkel->setPositions(goalConfig);
+  Eigen::Isometry3d targetPose = mBodynode->getTransform();
+
+  double goalTolerance = 0.01;
+  double initialStepSize = 0.05;
+  double r = 1.0;
+  double positionTolerance = 0.1;
+  double angularTolerance = 0.15;
+  double jointLimitTolerance = 1e-2;
+  double constraintCheckResolution = 1e-2;
+  std::chrono::duration<double> timelimit(300.);
+
+  mSkel->setPositions(mStartConfig);
+  auto startState = mStateSpace->createState();
+  mStateSpace->getState(mSkel.get(), startState);
+
+  // Test constraint violations
+  auto traj = aikido::planner::vectorfield::planToEndEffectorPose(
+      mStateSpace,
+      *startState,
+      mSkel,
+      mBodynode,
+      mPassingConstraint,
+      targetPose,
+      goalTolerance,
+      r,
+      0.0,
+      angularTolerance,
+      initialStepSize,
+      jointLimitTolerance,
+      constraintCheckResolution,
+      timelimit);
+
+  EXPECT_TRUE(traj == nullptr);
+
+  traj = aikido::planner::vectorfield::planToEndEffectorPose(
+      mStateSpace,
+      *startState,
+      mSkel,
+      mBodynode,
+      mPassingConstraint,
+      targetPose,
+      goalTolerance,
+      r,
+      positionTolerance,
+      0.0,
+      initialStepSize,
+      jointLimitTolerance,
+      constraintCheckResolution,
+      timelimit);
+
+  EXPECT_TRUE(traj == nullptr);
+
+  // Test Negative Tolerances
+  EXPECT_THROW(
+      aikido::planner::vectorfield::planToEndEffectorPose(
+          mStateSpace,
+          *startState,
+          mSkel,
+          mBodynode,
+          mPassingConstraint,
+          targetPose,
+          -0.05,
+          r,
+          positionTolerance,
+          angularTolerance,
+          initialStepSize,
+          jointLimitTolerance,
+          constraintCheckResolution,
+          timelimit),
+      std::invalid_argument);
+
+  EXPECT_THROW(
+      aikido::planner::vectorfield::planToEndEffectorPose(
+          mStateSpace,
+          *startState,
+          mSkel,
+          mBodynode,
+          mPassingConstraint,
+          targetPose,
+          goalTolerance,
+          r,
+          -0.05,
+          angularTolerance,
+          initialStepSize,
+          jointLimitTolerance,
+          constraintCheckResolution,
+          timelimit),
+      std::invalid_argument);
+
+  EXPECT_THROW(
+      aikido::planner::vectorfield::planToEndEffectorPose(
+          mStateSpace,
+          *startState,
+          mSkel,
+          mBodynode,
+          mPassingConstraint,
+          targetPose,
+          goalTolerance,
+          r,
+          positionTolerance,
+          -0.05,
+          initialStepSize,
+          jointLimitTolerance,
+          constraintCheckResolution,
+          timelimit),
+      std::invalid_argument);
 }


### PR DESCRIPTION
Instead of creating a whole new ConfigurationToEndEffectorTwist problem and planner (which would be somewhat redundant with ConfigurationToEndEffectorOffset), piggy-back on top of the ConfigurationToEndEffectorPose problem to create a planToPoseOffset function in the Robot class.

In effect, if you add a desired translation and rotation of the end-effector, this will attempt to follow a Vector Field defined by the Jacobian of the configuration space to achieve that translation and rotation. If rotation is 0, Twist and Offset should output identical results.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
