### PR TITLE
Remove bug where Kunz hangs on empty trajectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
   * Cleaned up planning methods in robot/util: [#588](https://github.com/personalrobotics/aikido/pull/588)
   * Added batches to ConcreteRobot's planToTSR: [#607](https://github.com/personalrobotics/aikido/pull/607)
   * Added ConfigurationToEndEffectorPose planner type [#628](https://github.com/personalrobotics/aikido/pull/628)
+  * Have KunzRetimer handle empty trajectories [#629](https://github.com/personalrobotics/aikido/pull/629)
 
 * Build & Testing & ETC
 

--- a/include/aikido/common/util.hpp
+++ b/include/aikido/common/util.hpp
@@ -26,6 +26,13 @@ inline std::future<T> make_ready_future(T obj)
   return promise.get_future();
 }
 
+inline std::future<void> make_ready_future()
+{
+  auto promise = std::promise<void>();
+  promise.set_value();
+  return promise.get_future();
+}
+
 /// Check for a value near-zero
 #ifndef AIKIDO_COMMON_NEARZERO
 #define AIKIDO_COMMON_NEARZERO 1E-8

--- a/include/aikido/robot/util.hpp
+++ b/include/aikido/robot/util.hpp
@@ -33,7 +33,7 @@ const std::vector<double> defaultVFParams{
     0.01,  // initialStepSize
     1e-3,  // jointlimitTolerance
     1e-3,  // constraintCheckResolution
-    5.0,   // timeout (s)
+    1.5,   // timeout (s)
     0.01,  // goalTolerance (twist-only)
     1.0    // angle-to-distance ratio (twist-only)
 };

--- a/include/aikido/robot/util.hpp
+++ b/include/aikido/robot/util.hpp
@@ -33,7 +33,7 @@ const std::vector<double> defaultVFParams{
     0.01,  // initialStepSize
     1e-3,  // jointlimitTolerance
     1e-3,  // constraintCheckResolution
-    1.0,   // timeout (s)
+    5.0,   // timeout (s)
     0.01,  // goalTolerance (twist-only)
     1.0    // angle-to-distance ratio (twist-only)
 };

--- a/src/external/kunz_retimer/Trajectory.cpp
+++ b/src/external/kunz_retimer/Trajectory.cpp
@@ -82,7 +82,17 @@ Trajectory::Trajectory(const Path &path, const VectorXd &maxVelocity, const Vect
 		it->time = 0.0;
 		it++;
 		while(it != trajectory.end()) {
-			it->time = previous->time + (it->pathPos - previous->pathPos) / ((it->pathVel + previous->pathVel) / 2.0);
+			auto avgVel = ((it->pathVel + previous->pathVel) / 2.0);
+			auto posDiff = (it->pathPos - previous->pathPos);
+			// Check for stationary trajectory
+			if(posDiff == 0.0 && avgVel == 0.0) {
+				it->time = previous->time;
+			} else if(avgVel == 0.0) {
+				cout << "Error while calculating timing: 0 velocity" << endl;
+			}
+			else {
+				it->time = previous->time +  posDiff / avgVel;
+			}
 			previous = it;
 			it++;
 		}

--- a/src/robot/Robot.cpp
+++ b/src/robot/Robot.cpp
@@ -224,7 +224,7 @@ std::future<void> Robot::executeTrajectory(
 
   // Check for empty (but valid) trajectory
   // No need to execute, succeed silently
-  if (trajectory && trajectory->getDuration() == 0.0)
+  if (trajectory && aikido::common::FuzzyZero(trajectory->getDuration()))
   {
     return common::make_ready_future();
   }

--- a/src/robot/Robot.cpp
+++ b/src/robot/Robot.cpp
@@ -222,6 +222,13 @@ std::future<void> Robot::executeTrajectory(
         "executeTrajectory: Active executor not a TrajectoryExecutor");
   }
 
+  // Check for empty (but valid) trajectory
+  // No need to execute, succeed silently
+  if (trajectory && trajectory->getDuration() == 0.0)
+  {
+    return common::make_ready_future();
+  }
+
   return trajectoryExecutor->execute(trajectory);
 }
 


### PR DESCRIPTION
Previously, in the case of an empty trajectory (which is possible for an Offset planner with 0 offset or a configuration planner with goal == start), the resulting trajectory was length 0.

In this case, any postprocessor should return a valid (but empty) trajectory.

However, Kunz's Trajectory class initially timed the trajectory using the velocity without checking for 0 velocity. If there is 0 velocity but non-0 position, the trajectory is invalid (this should never happen). But if there is 0 velocity AND 0 change in position, the trajectory is valid but empty, and Kunz shouldn't perform the division (which results in a NaN endTime, which in turn leads to a *VERY LARGE* sequence of waypoints when naively constructed with aikido::common::StepSequence, which in turn causes the program to loop nearly infinitely).

In addition, the Robot class has been modified to gracefully handle valid and empty trajectories (namely: not executing them).

***

**Before creating a pull request**

- [ N/A ] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
