### PR TITLE
Add control and control_ros dependencies to ros robot

### DIFF
--- a/src/robot/ros/CMakeLists.txt
+++ b/src/robot/ros/CMakeLists.txt
@@ -30,6 +30,8 @@ target_link_libraries("${PROJECT_NAME}_robot_ros"
   PUBLIC
   "${PROJECT_NAME}_robot"
   "${PROJECT_NAME}_common"
+  "${PROJECT_NAME}_control"
+  "${PROJECT_NAME}_control_ros"
   "${PROJECT_NAME}_io"
   "${PROJECT_NAME}_planner"
   "${PROJECT_NAME}_planner_ompl"
@@ -50,9 +52,11 @@ target_compile_definitions("${PROJECT_NAME}_robot_ros"
 
 add_component(${PROJECT_NAME} robot_ros)
 add_component_targets(${PROJECT_NAME} robot_ros "${PROJECT_NAME}_robot_ros")
-add_component_dependencies(${PROJECT_NAME} robot_ros 
+add_component_dependencies(${PROJECT_NAME} robot_ros
   robot
   common
+  control
+  control_ros
   io
   planner
   planner_ompl


### PR DESCRIPTION
After the controller switching support was added, packages that created a `RosRobot` had linker errors during `catkin build` which is fixed by these changes to `CMakeLists.txt`

The changes were tested by building a [simple example](https://github.com/vbhatt-cs/aikido_tutorials/tree/master/src/aikido_tutorials) that instantiated a `RosRobot`.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change